### PR TITLE
feat: add iterative refinement to close normal-equation/demeaning  accuracy gap

### DIFF
--- a/crates/schwarz-precond/src/solve/cg.rs
+++ b/crates/schwarz-precond/src/solve/cg.rs
@@ -85,12 +85,13 @@ pub fn cg_solve_preconditioned<A: Operator + ?Sized, M: Operator + ?Sized>(
         }
         let alpha = rz / pap;
 
+        let mut r_norm_sq = 0.0;
         for ((xi, &pi), (ri, &api)) in x.iter_mut().zip(&p).zip(r.iter_mut().zip(&ap)) {
             *xi += alpha * pi;
             *ri -= alpha * api;
+            r_norm_sq += *ri * *ri;
         }
-
-        r_norm = vec_norm(&r);
+        r_norm = r_norm_sq.sqrt();
         if r_norm / b_norm <= tol {
             return Ok(CgResult {
                 x,

--- a/crates/schwarz-precond/src/solve/cg.rs
+++ b/crates/schwarz-precond/src/solve/cg.rs
@@ -105,7 +105,7 @@ pub fn cg_solve_preconditioned<A: Operator + ?Sized, M: Operator + ?Sized>(
         if rz_new.abs() < f64::EPSILON * rz_init.abs().max(f64::MIN_POSITIVE) {
             return Ok(CgResult {
                 x,
-                converged: false,
+                converged: r_norm / b_norm <= tol,
                 iterations: itn,
                 residual_norm: r_norm,
             });

--- a/crates/within-py/src/lib.rs
+++ b/crates/within-py/src/lib.rs
@@ -224,17 +224,20 @@ pub struct PyCG {
     pub maxiter: usize,
     #[pyo3(get)]
     pub operator: PyOperatorRepr,
+    #[pyo3(get)]
+    pub max_refinements: usize,
 }
 
 #[pymethods]
 impl PyCG {
     #[new]
-    #[pyo3(signature = (tol=1e-8, maxiter=1000, operator=PyOperatorRepr::Implicit))]
-    fn new(tol: f64, maxiter: usize, operator: PyOperatorRepr) -> Self {
+    #[pyo3(signature = (tol=1e-8, maxiter=1000, operator=PyOperatorRepr::Implicit, max_refinements=2))]
+    fn new(tol: f64, maxiter: usize, operator: PyOperatorRepr, max_refinements: usize) -> Self {
         Self {
             tol,
             maxiter,
             operator,
+            max_refinements,
         }
     }
 }
@@ -250,18 +253,27 @@ pub struct PyGMRES {
     pub restart: usize,
     #[pyo3(get)]
     pub operator: PyOperatorRepr,
+    #[pyo3(get)]
+    pub max_refinements: usize,
 }
 
 #[pymethods]
 impl PyGMRES {
     #[new]
-    #[pyo3(signature = (tol=1e-8, maxiter=1000, restart=30, operator=PyOperatorRepr::Implicit))]
-    fn new(tol: f64, maxiter: usize, restart: usize, operator: PyOperatorRepr) -> Self {
+    #[pyo3(signature = (tol=1e-8, maxiter=1000, restart=30, operator=PyOperatorRepr::Implicit, max_refinements=2))]
+    fn new(
+        tol: f64,
+        maxiter: usize,
+        restart: usize,
+        operator: PyOperatorRepr,
+        max_refinements: usize,
+    ) -> Self {
         Self {
             tol,
             maxiter,
             restart,
             operator,
+            max_refinements,
         }
     }
 }
@@ -442,6 +454,7 @@ fn extract_solver_params(config: &Bound<'_, PyAny>) -> PyResult<SolverParams> {
             operator: cg.operator.to_native(),
             tol: cg.tol,
             maxiter: cg.maxiter,
+            max_refinements: cg.max_refinements,
         });
     }
 
@@ -454,6 +467,7 @@ fn extract_solver_params(config: &Bound<'_, PyAny>) -> PyResult<SolverParams> {
             operator: gmres.operator.to_native(),
             tol: gmres.tol,
             maxiter: gmres.maxiter,
+            max_refinements: gmres.max_refinements,
         });
     }
 

--- a/crates/within/benches/fixest.rs
+++ b/crates/within/benches/fixest.rs
@@ -154,6 +154,7 @@ fn run_cg_one_level(design: &WeightedDesign<FactorMajorStore>, y: &[f64], ac2: b
         operator: OperatorRepr::Implicit,
         tol: TOL,
         maxiter: MAXITER,
+        ..Default::default()
     };
     let precond = Preconditioner::Additive(cfg);
     let label = if ac2 { "CG(1L,AC2)" } else { "CG(1L,AC)" };
@@ -174,6 +175,7 @@ fn run_gmres_multiplicative_one_level(
         operator,
         tol: TOL,
         maxiter: MAXITER,
+        ..Default::default()
     };
     let precond = Preconditioner::Multiplicative(cfg);
     let label = if ac2 {

--- a/crates/within/benches/store_backend.rs
+++ b/crates/within/benches/store_backend.rs
@@ -52,6 +52,7 @@ fn generate_problem(n_obs: usize, n_lev: &[usize], seed: u64) -> Problem {
         operator: OperatorRepr::Implicit,
         tol: TOL,
         maxiter: MAXITER,
+        ..Default::default()
     };
     let preconditioner = Some(Preconditioner::Additive(LocalSolverConfig::solver_default()));
 

--- a/crates/within/examples/preconditioned_solve.rs
+++ b/crates/within/examples/preconditioned_solve.rs
@@ -50,6 +50,7 @@ fn main() {
         operator: OperatorRepr::Implicit,
         tol: 1e-8,
         maxiter: 1000,
+        ..Default::default()
     };
     let gmres_precond = Preconditioner::Multiplicative(LocalSolverConfig::solver_default());
     let gmres_result = solve(

--- a/crates/within/src/config.rs
+++ b/crates/within/src/config.rs
@@ -139,6 +139,17 @@ pub struct SolverParams {
     pub operator: OperatorRepr,
     pub tol: f64,
     pub maxiter: usize,
+    /// Maximum number of iterative refinement steps after the initial Krylov solve.
+    ///
+    /// Iterative refinement recomputes the normal-equation residual from observation
+    /// space (`D^T W (y - D x)`) and solves for a correction. This closes the gap
+    /// between normal-equation residual accuracy and observation-space demeaning
+    /// quality that arises when the Gramian condition number is large.
+    ///
+    /// Each refinement step costs two cheap matvecs (D and D^T W) plus one Krylov
+    /// solve with a small RHS. The check alone (without the solve) is nearly free.
+    /// Typically 0–1 actual correction solves are needed.
+    pub max_refinements: usize,
 }
 
 impl Default for SolverParams {
@@ -148,6 +159,7 @@ impl Default for SolverParams {
             operator: OperatorRepr::Implicit,
             tol: 1e-8,
             maxiter: 1000,
+            max_refinements: 2,
         }
     }
 }

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -114,56 +114,18 @@ impl<S: ObservationStore> Solver<S> {
         let t_solve_start = Instant::now();
         let time_setup = t_solve_start.duration_since(t_setup_start).as_secs_f64();
 
-        // Dispatch initial Krylov solve
+        // Initial Krylov solve + iterative refinement
         let solve = self.krylov_solve(&rhs)?;
-        let mut x = solve.x;
-        let mut total_iterations = solve.iterations;
-        let mut converged = solve.converged;
-
-        // Iterative refinement: recompute the normal-equation residual from
-        // observation space (D^T W (y - D x)) and solve for a correction.
-        // This closes the gap between normal-equation residual accuracy and
-        // observation-space demeaning quality caused by large κ(G).
-        let mut demeaned = vec![0.0; self.design.n_rows];
-        let mut rhs_corr = vec![0.0; self.design.n_dofs];
-        for _ in 0..self.max_refinements {
-            // Observation-space residual: demeaned = y - D·x
-            self.design.matvec_d(&x, &mut demeaned);
-            for (d, &yi) in demeaned.iter_mut().zip(y.iter()) {
-                *d = yi - *d;
-            }
-
-            // Correction RHS: D^T W (y - Dx) = b - Gx
-            self.design.rmatvec_wdt(&demeaned, &mut rhs_corr);
-
-            if vec_norm(&rhs_corr) <= abs_tol {
-                break; // Residual already meets tolerance
-            }
-
-            // Solve for correction and accumulate
-            let corr = self.krylov_solve(&rhs_corr)?;
-            for (xi, &di) in x.iter_mut().zip(corr.x.iter()) {
-                *xi += di;
-            }
-            total_iterations += corr.iterations;
-            converged = corr.converged;
-        }
+        let refined = self.iterative_refinement(y, abs_tol, solve)?;
 
         let time_solve = t_solve_start.elapsed().as_secs_f64();
-
-        // Final demeaned: y - D*x
-        self.design.matvec_d(&x, &mut demeaned);
-        for (d, &yi) in demeaned.iter_mut().zip(y.iter()) {
-            *d = yi - *d;
-        }
-
-        let final_residual = self.compute_residual(&x, &rhs, rhs_norm);
+        let final_residual = self.compute_residual(&refined.x, &rhs, rhs_norm);
 
         Ok(SolveResult {
-            x,
-            demeaned,
-            converged,
-            iterations: total_iterations,
+            x: refined.x,
+            demeaned: refined.demeaned,
+            converged: refined.converged,
+            iterations: refined.iterations,
             final_residual,
             time_total: t_start.elapsed().as_secs_f64(),
             time_setup,
@@ -226,19 +188,85 @@ impl<S: ObservationStore> Solver<S> {
 
     // --- Internal ---
 
+    /// Iterative refinement: recompute the normal-equation residual from
+    /// observation space (`D^T W (y - D x)`) and solve for a correction.
+    ///
+    /// This closes the gap between normal-equation residual accuracy and
+    /// observation-space demeaning quality that arises when κ(G) is large.
+    /// The correction tolerance is scaled to the original problem so that each
+    /// refinement step does only the minimum work needed.
+    fn iterative_refinement(
+        &self,
+        y: &[f64],
+        abs_tol: f64,
+        initial: KrylovSolve,
+    ) -> WithinResult<RefinedSolve> {
+        let mut x = initial.x;
+        let mut iterations = initial.iterations;
+        let mut converged = initial.converged;
+
+        let mut demeaned = vec![0.0; self.design.n_rows];
+        let mut rhs_corr = vec![0.0; self.design.n_dofs];
+
+        for _ in 0..self.max_refinements {
+            // Observation-space residual: demeaned = y - D·x
+            self.design.matvec_d(&x, &mut demeaned);
+            for (d, &yi) in demeaned.iter_mut().zip(y.iter()) {
+                *d = yi - *d;
+            }
+
+            // Correction RHS in normal-equation space: D^T W (y - Dx)
+            self.design.rmatvec_wdt(&demeaned, &mut rhs_corr);
+
+            let corr_norm = vec_norm(&rhs_corr);
+            if corr_norm <= abs_tol {
+                break;
+            }
+
+            // Tolerance scaled to original problem: only reduce the correction
+            // enough to bring the total residual below abs_tol.
+            let corr_tol = (abs_tol / corr_norm).min(1.0);
+            let corr = self.krylov_solve_with_tol(&rhs_corr, corr_tol)?;
+            for (xi, &di) in x.iter_mut().zip(corr.x.iter()) {
+                *xi += di;
+            }
+            iterations += corr.iterations;
+            converged = corr.converged;
+        }
+
+        // Final demeaned: y - D*x
+        self.design.matvec_d(&x, &mut demeaned);
+        for (d, &yi) in demeaned.iter_mut().zip(y.iter()) {
+            *d = yi - *d;
+        }
+
+        Ok(RefinedSolve {
+            x,
+            demeaned,
+            converged,
+            iterations,
+        })
+    }
+
     fn krylov_solve(&self, rhs: &[f64]) -> WithinResult<KrylovSolve> {
+        self.krylov_solve_with_tol(rhs, self.tol)
+    }
+
+    fn krylov_solve_with_tol(&self, rhs: &[f64], tol: f64) -> WithinResult<KrylovSolve> {
         match (&self.gramian, &self.preconditioner) {
-            (Some(gramian), Some(precond)) => self.dispatch_krylov(gramian, Some(precond), rhs),
+            (Some(gramian), Some(precond)) => {
+                self.dispatch_krylov(gramian, Some(precond), rhs, tol)
+            }
             (Some(gramian), None) => {
-                self.dispatch_krylov::<_, FePreconditioner>(gramian, None, rhs)
+                self.dispatch_krylov::<_, FePreconditioner>(gramian, None, rhs, tol)
             }
             (None, Some(precond)) => {
                 let op = GramianOperator::new(&self.design);
-                self.dispatch_krylov(&op, Some(precond), rhs)
+                self.dispatch_krylov(&op, Some(precond), rhs, tol)
             }
             (None, None) => {
                 let op = GramianOperator::new(&self.design);
-                self.dispatch_krylov::<_, FePreconditioner>(&op, None, rhs)
+                self.dispatch_krylov::<_, FePreconditioner>(&op, None, rhs, tol)
             }
         }
     }
@@ -248,10 +276,11 @@ impl<S: ObservationStore> Solver<S> {
         op: &A,
         preconditioner: Option<&M>,
         rhs: &[f64],
+        tol: f64,
     ) -> WithinResult<KrylovSolve> {
         match self.krylov {
             KrylovMethod::Cg => {
-                let r = pcg(op, rhs, preconditioner, self.tol, self.maxiter)?;
+                let r = pcg(op, rhs, preconditioner, tol, self.maxiter)?;
                 Ok(KrylovSolve {
                     x: r.x,
                     converged: r.converged,
@@ -259,7 +288,7 @@ impl<S: ObservationStore> Solver<S> {
                 })
             }
             KrylovMethod::Gmres { restart } => {
-                let r = pgmres(op, rhs, preconditioner, self.tol, self.maxiter, restart)?;
+                let r = pgmres(op, rhs, preconditioner, tol, self.maxiter, restart)?;
                 Ok(KrylovSolve {
                     x: r.x,
                     converged: r.converged,
@@ -287,6 +316,13 @@ impl<S: ObservationStore> Solver<S> {
 
 struct KrylovSolve {
     x: Vec<f64>,
+    converged: bool,
+    iterations: usize,
+}
+
+struct RefinedSolve {
+    x: Vec<f64>,
+    demeaned: Vec<f64>,
     converged: bool,
     iterations: usize,
 }

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -32,6 +32,7 @@ pub struct Solver<S: ObservationStore> {
     krylov: KrylovMethod,
     tol: f64,
     maxiter: usize,
+    max_refinements: usize,
 }
 
 impl<S: ObservationStore> Solver<S> {
@@ -72,6 +73,7 @@ impl<S: ObservationStore> Solver<S> {
             krylov: params.krylov,
             tol: params.tol,
             maxiter: params.maxiter,
+            max_refinements: params.max_refinements,
         })
     }
 
@@ -94,6 +96,7 @@ impl<S: ObservationStore> Solver<S> {
             krylov: params.krylov,
             tol: params.tol,
             maxiter: params.maxiter,
+            max_refinements: params.max_refinements,
         })
     }
 
@@ -106,30 +109,61 @@ impl<S: ObservationStore> Solver<S> {
         let mut rhs = vec![0.0; self.design.n_dofs];
         self.design.rmatvec_wdt(y, &mut rhs);
         let rhs_norm = vec_norm(&rhs).max(1e-15);
+        let abs_tol = self.tol * rhs_norm;
 
         let t_solve_start = Instant::now();
         let time_setup = t_solve_start.duration_since(t_setup_start).as_secs_f64();
 
-        // Dispatch Krylov solve
+        // Dispatch initial Krylov solve
         let solve = self.krylov_solve(&rhs)?;
+        let mut x = solve.x;
+        let mut total_iterations = solve.iterations;
+        let mut converged = solve.converged;
+
+        // Iterative refinement: recompute the normal-equation residual from
+        // observation space (D^T W (y - D x)) and solve for a correction.
+        // This closes the gap between normal-equation residual accuracy and
+        // observation-space demeaning quality caused by large κ(G).
+        let mut demeaned = vec![0.0; self.design.n_rows];
+        let mut rhs_corr = vec![0.0; self.design.n_dofs];
+        for _ in 0..self.max_refinements {
+            // Observation-space residual: demeaned = y - D·x
+            self.design.matvec_d(&x, &mut demeaned);
+            for (d, &yi) in demeaned.iter_mut().zip(y.iter()) {
+                *d = yi - *d;
+            }
+
+            // Correction RHS: D^T W (y - Dx) = b - Gx
+            self.design.rmatvec_wdt(&demeaned, &mut rhs_corr);
+
+            if vec_norm(&rhs_corr) <= abs_tol {
+                break; // Residual already meets tolerance
+            }
+
+            // Solve for correction and accumulate
+            let corr = self.krylov_solve(&rhs_corr)?;
+            for (xi, &di) in x.iter_mut().zip(corr.x.iter()) {
+                *xi += di;
+            }
+            total_iterations += corr.iterations;
+            converged = corr.converged;
+        }
 
         let time_solve = t_solve_start.elapsed().as_secs_f64();
 
-        // Compute relative residual in normal-equation space
-        let final_residual = self.compute_residual(&solve.x, &rhs, rhs_norm);
-
-        // Compute demeaned: y - D*x
-        let mut demeaned = vec![0.0; self.design.n_rows];
-        self.design.matvec_d(&solve.x, &mut demeaned);
+        // Final demeaned: y - D*x
+        self.design.matvec_d(&x, &mut demeaned);
         for (d, &yi) in demeaned.iter_mut().zip(y.iter()) {
             *d = yi - *d;
         }
 
+        let final_residual = self.compute_residual(&x, &rhs, rhs_norm);
+
         Ok(SolveResult {
-            x: solve.x,
+            x,
             demeaned,
-            converged: solve.converged,
-            iterations: solve.iterations,
+            converged,
+            iterations: total_iterations,
             final_residual,
             time_total: t_start.elapsed().as_secs_f64(),
             time_setup,

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -119,7 +119,14 @@ impl<S: ObservationStore> Solver<S> {
         let refined = self.iterative_refinement(y, abs_tol, solve)?;
 
         let time_solve = t_solve_start.elapsed().as_secs_f64();
-        let final_residual = self.compute_residual(&refined.x, &rhs, rhs_norm);
+
+        // Compute residual via observation space: ||D^T W (y - Dx)|| / ||rhs||.
+        // This is cheaper than a Gramian matvec and avoids the DOF-space
+        // cancellation that motivated iterative refinement.
+        let mut residual_dof = vec![0.0; self.design.n_dofs];
+        self.design
+            .rmatvec_wdt(&refined.demeaned, &mut residual_dof);
+        let final_residual = vec_norm(&residual_dof) / rhs_norm;
 
         Ok(SolveResult {
             x: refined.x,
@@ -296,21 +303,6 @@ impl<S: ObservationStore> Solver<S> {
                 })
             }
         }
-    }
-
-    fn compute_residual(&self, x: &[f64], rhs: &[f64], rhs_norm: f64) -> f64 {
-        let mut scratch = vec![0.0; self.design.n_dofs];
-        match &self.gramian {
-            Some(g) => g.apply(x, &mut scratch),
-            None => {
-                let op = GramianOperator::new(&self.design);
-                op.apply(x, &mut scratch);
-            }
-        }
-        for i in 0..rhs.len() {
-            scratch[i] -= rhs[i];
-        }
-        vec_norm(&scratch) / rhs_norm
     }
 }
 

--- a/crates/within/tests/iterative_refinement.rs
+++ b/crates/within/tests/iterative_refinement.rs
@@ -301,3 +301,48 @@ fn test_refinement_batch_applies() {
         assert!((a - b).abs() < 1e-12, "batch/single x mismatch: {a} vs {b}");
     }
 }
+
+#[test]
+fn test_refinement_correction_tolerance_scaling() {
+    // Batch solve with a structured
+    // RHS (y = signal + noise, converges easily) alongside unstructured RHS columns
+    // (pure noise, harder to demean). Without scaled correction tolerance, the
+    // refinement solve overshoots by applying tol=1e-8 *relative to the small
+    // correction RHS*, wasting iterations. With scaling, the correction only needs
+    // to bring the total residual below the original tolerance.
+    let (design, y_structured) = make_chain_design(200, 42);
+    let n_obs = y_structured.len();
+
+    // Generate unstructured columns (pure random noise — harder for CG)
+    let mut rng = SmallRng::seed_from_u64(123);
+    let x0: Vec<f64> = (0..n_obs).map(|_| rng.random::<f64>() - 0.5).collect();
+    let x1: Vec<f64> = (0..n_obs).map(|_| rng.random::<f64>() - 0.5).collect();
+
+    let precond = Preconditioner::Additive(LocalSolverConfig::solver_default());
+    let params = params_with_refinement(KrylovMethod::Cg, 2);
+    let solver = Solver::from_design(design, &params, Some(&precond)).expect("build solver");
+
+    let batch = solver
+        .solve_batch(&[&y_structured, &x0, &x1])
+        .expect("batch solve");
+
+    // All columns must converge
+    for (i, &c) in batch.converged().iter().enumerate() {
+        assert!(c, "column {i} did not converge");
+    }
+
+    // All residuals must be within tolerance
+    for (i, &r) in batch.final_residual().iter().enumerate() {
+        assert!(r < 1e-6, "column {i} residual too large: {r:.2e}");
+    }
+
+    // Refinement should not waste iterations: the correction solve for harder
+    // columns should add only a few iterations, not double the count.
+    let base_iters = batch.iterations()[0];
+    for (i, &iters) in batch.iterations().iter().enumerate().skip(1) {
+        assert!(
+            iters <= base_iters * 2,
+            "column {i} took {iters} iters (base={base_iters}), correction tolerance may not be scaled"
+        );
+    }
+}

--- a/crates/within/tests/iterative_refinement.rs
+++ b/crates/within/tests/iterative_refinement.rs
@@ -1,0 +1,303 @@
+//! Tests for iterative refinement in the solver.
+//!
+//! Iterative refinement recomputes the normal-equation residual from observation
+//! space and solves for a correction, closing the gap between normal-equation
+//! residual accuracy and observation-space demeaning quality.
+
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+
+use within::{
+    FactorMajorStore, FixedEffectsDesign, KrylovMethod, LocalSolverConfig, ObservationStore,
+    ObservationWeights, Preconditioner, Solver, SolverParams, WeightedDesign,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build a chain-like 2-FE design where factor 1 has `n_chain` levels connected
+/// sequentially through factor 2. This creates a poorly connected graph with
+/// high condition number — exactly the setting where iterative refinement helps.
+///
+/// Structure: observation i connects factor1_level=i to factor2_level=i,
+/// and also factor1_level=i to factor2_level=i+1, forming a chain.
+fn make_chain_design(n_chain: usize, seed: u64) -> (FixedEffectsDesign, Vec<f64>) {
+    let mut rng = SmallRng::seed_from_u64(seed);
+
+    let n_levels_1 = n_chain;
+    let n_levels_2 = n_chain + 1;
+
+    // Each level of factor 1 has exactly 2 observations connecting to
+    // adjacent levels of factor 2, plus some extra observations for density.
+    let mut f1 = Vec::new();
+    let mut f2 = Vec::new();
+
+    // Chain edges: level i of f1 connects to levels i and i+1 of f2
+    for i in 0..n_chain {
+        // Two observations per chain link (minimum for connectivity)
+        f1.push(i as u32);
+        f2.push(i as u32);
+        f1.push(i as u32);
+        f2.push((i + 1) as u32);
+    }
+
+    // Add a few extra observations per level to avoid singular systems
+    for _ in 0..n_chain {
+        let l1 = rng.random_range(0..n_levels_1 as u32);
+        let l2 = rng.random_range(0..n_levels_2 as u32);
+        f1.push(l1);
+        f2.push(l2);
+    }
+
+    let n_obs = f1.len();
+    let y: Vec<f64> = (0..n_obs).map(|_| rng.random::<f64>()).collect();
+
+    let store =
+        FactorMajorStore::new(vec![f1, f2], ObservationWeights::Unit, n_obs).expect("valid store");
+    let design = FixedEffectsDesign::from_store(store).expect("valid design");
+
+    (design, y)
+}
+
+/// Compute max absolute weighted group mean of demeaned values.
+/// This is the observation-space quality metric: if demeaning is perfect,
+/// the mean of demeaned values within every level of every factor is zero.
+fn max_abs_group_mean(design: &FixedEffectsDesign, demeaned: &[f64]) -> f64 {
+    let mut worst = 0.0f64;
+    for q in 0..design.factors.len() {
+        let n_levels = design.factors[q].n_levels;
+        let mut sums = vec![0.0f64; n_levels];
+        let mut counts = vec![0u32; n_levels];
+        for (i, &d) in demeaned.iter().enumerate().take(design.n_rows) {
+            let level = design.store.level(i, q) as usize;
+            sums[level] += d;
+            counts[level] += 1;
+        }
+        for (s, &c) in sums.iter().zip(counts.iter()) {
+            if c > 0 {
+                worst = worst.max((s / c as f64).abs());
+            }
+        }
+    }
+    worst
+}
+
+fn params_with_refinement(krylov: KrylovMethod, max_refinements: usize) -> SolverParams {
+    SolverParams {
+        krylov,
+        tol: 1e-8,
+        maxiter: 2000,
+        max_refinements,
+        ..Default::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CG tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_refinement_cg_improves_demeaning_quality() {
+    // Chain design with n=200 creates κ(G) ~ O(n²), causing a significant gap
+    // between normal-equation residual and demeaning quality.
+    let (design, y) = make_chain_design(200, 42);
+    let precond = Preconditioner::Additive(LocalSolverConfig::solver_default());
+
+    // Without refinement
+    let params_no_refine = params_with_refinement(KrylovMethod::Cg, 0);
+    let solver_no =
+        Solver::from_design(design, &params_no_refine, Some(&precond)).expect("build solver");
+    // Need a fresh design for the second solver (design was moved)
+    let (design2, _) = make_chain_design(200, 42);
+    let result_no = solver_no.solve(&y).expect("solve without refinement");
+
+    // With refinement
+    let params_refine = params_with_refinement(KrylovMethod::Cg, 2);
+    let solver_yes =
+        Solver::from_design(design2, &params_refine, Some(&precond)).expect("build solver");
+    let result_yes = solver_yes.solve(&y).expect("solve with refinement");
+
+    assert!(result_no.converged, "initial solve should converge");
+    assert!(result_yes.converged, "refined solve should converge");
+
+    let (design3, _) = make_chain_design(200, 42);
+    let demean_no = max_abs_group_mean(&design3, &result_no.demeaned);
+    let demean_yes = max_abs_group_mean(&design3, &result_yes.demeaned);
+
+    // Refinement should improve demeaning quality
+    assert!(
+        demean_yes <= demean_no,
+        "refinement should not worsen demeaning: {demean_yes:.2e} > {demean_no:.2e}"
+    );
+
+    // The refined residual should be at least as good
+    assert!(
+        result_yes.final_residual <= result_no.final_residual + 1e-15,
+        "refinement should not worsen residual: {} > {}",
+        result_yes.final_residual,
+        result_no.final_residual
+    );
+}
+
+#[test]
+fn test_refinement_cg_zero_means_old_behavior() {
+    // max_refinements=0 should produce identical results to the old code path.
+    let (design, y) = make_chain_design(50, 99);
+    let precond = Preconditioner::Additive(LocalSolverConfig::solver_default());
+    let params = params_with_refinement(KrylovMethod::Cg, 0);
+    let solver = Solver::from_design(design, &params, Some(&precond)).expect("build solver");
+    let result = solver.solve(&y).expect("solve");
+
+    assert!(result.converged);
+    assert!(result.final_residual < 1e-6);
+}
+
+#[test]
+fn test_refinement_cg_well_conditioned_no_extra_iters() {
+    // On a well-conditioned problem, the refinement check should find the
+    // residual already small enough and not trigger any correction solves.
+    let store = FactorMajorStore::new(
+        vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]],
+        ObservationWeights::Unit,
+        5,
+    )
+    .expect("valid store");
+    let design = WeightedDesign::from_store(store).expect("design");
+    let y = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+
+    let precond = Preconditioner::Additive(LocalSolverConfig::solver_default());
+
+    // With refinement
+    let params_refine = params_with_refinement(KrylovMethod::Cg, 2);
+    let solver = Solver::from_design(design, &params_refine, Some(&precond)).expect("build solver");
+    let result = solver.solve(&y).expect("solve");
+
+    // Should converge with very few iterations (small problem)
+    assert!(result.converged);
+    assert!(
+        result.iterations <= 10,
+        "too many iterations on small problem: {}",
+        result.iterations
+    );
+}
+
+// ---------------------------------------------------------------------------
+// GMRES tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_refinement_gmres_improves_demeaning_quality() {
+    let (design, y) = make_chain_design(200, 77);
+    let precond = Preconditioner::Multiplicative(LocalSolverConfig::solver_default());
+
+    // Without refinement
+    let params_no_refine = params_with_refinement(KrylovMethod::Gmres { restart: 30 }, 0);
+    let solver_no =
+        Solver::from_design(design, &params_no_refine, Some(&precond)).expect("build solver");
+    let (design2, _) = make_chain_design(200, 77);
+    let result_no = solver_no.solve(&y).expect("solve without refinement");
+
+    // With refinement
+    let params_refine = params_with_refinement(KrylovMethod::Gmres { restart: 30 }, 2);
+    let solver_yes =
+        Solver::from_design(design2, &params_refine, Some(&precond)).expect("build solver");
+    let result_yes = solver_yes.solve(&y).expect("solve with refinement");
+
+    assert!(result_no.converged, "initial GMRES solve should converge");
+    assert!(result_yes.converged, "refined GMRES solve should converge");
+
+    let (design3, _) = make_chain_design(200, 77);
+    let demean_no = max_abs_group_mean(&design3, &result_no.demeaned);
+    let demean_yes = max_abs_group_mean(&design3, &result_yes.demeaned);
+
+    assert!(
+        demean_yes <= demean_no,
+        "refinement should not worsen GMRES demeaning: {demean_yes:.2e} > {demean_no:.2e}"
+    );
+}
+
+#[test]
+fn test_refinement_gmres_well_conditioned() {
+    let store = FactorMajorStore::new(
+        vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]],
+        ObservationWeights::Unit,
+        5,
+    )
+    .expect("valid store");
+    let design = WeightedDesign::from_store(store).expect("design");
+    let y = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+
+    let precond = Preconditioner::Multiplicative(LocalSolverConfig::solver_default());
+    let params = params_with_refinement(KrylovMethod::Gmres { restart: 30 }, 2);
+    let solver = Solver::from_design(design, &params, Some(&precond)).expect("build solver");
+    let result = solver.solve(&y).expect("solve");
+
+    assert!(result.converged);
+    assert!(result.final_residual < 1e-6);
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_refinement_zero_rhs() {
+    let store = FactorMajorStore::new(
+        vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]],
+        ObservationWeights::Unit,
+        5,
+    )
+    .expect("valid store");
+    let design = WeightedDesign::from_store(store).expect("design");
+    let y = vec![0.0; 5];
+
+    let params = params_with_refinement(KrylovMethod::Cg, 2);
+    let solver = Solver::from_design(design, &params, None).expect("build solver");
+    let result = solver.solve(&y).expect("solve");
+
+    assert!(result.converged);
+    assert_eq!(result.iterations, 0);
+    assert!(result.x.iter().all(|&v| v == 0.0));
+}
+
+#[test]
+fn test_refinement_unpreconditioned() {
+    // Refinement should work without a preconditioner too.
+    let (design, y) = make_chain_design(50, 123);
+    let params = params_with_refinement(KrylovMethod::Cg, 2);
+    let solver = Solver::from_design(design, &params, None).expect("build solver");
+    let result = solver.solve(&y).expect("solve");
+
+    assert!(result.converged);
+    assert!(result.final_residual < 1e-6);
+}
+
+#[test]
+fn test_refinement_batch_applies() {
+    // Refinement should apply to each RHS in a batch solve.
+    let (design, _) = make_chain_design(50, 456);
+    let precond = Preconditioner::Additive(LocalSolverConfig::solver_default());
+    let params = params_with_refinement(KrylovMethod::Cg, 2);
+    let solver = Solver::from_design(design, &params, Some(&precond)).expect("build solver");
+
+    let mut rng = SmallRng::seed_from_u64(789);
+    let n_obs = solver.n_obs();
+    let y1: Vec<f64> = (0..n_obs).map(|_| rng.random::<f64>()).collect();
+    let y2: Vec<f64> = (0..n_obs).map(|_| rng.random::<f64>()).collect();
+
+    let single1 = solver.solve(&y1).expect("solve y1");
+    let single2 = solver.solve(&y2).expect("solve y2");
+    let batch = solver.solve_batch(&[&y1, &y2]).expect("batch solve");
+
+    assert_eq!(batch.n_rhs(), 2);
+    assert!(batch.converged().iter().all(|&c| c));
+
+    // Batch results should match single solves
+    for (a, b) in batch.x(0).iter().zip(single1.x.iter()) {
+        assert!((a - b).abs() < 1e-12, "batch/single x mismatch: {a} vs {b}");
+    }
+    for (a, b) in batch.x(1).iter().zip(single2.x.iter()) {
+        assert!((a - b).abs() < 1e-12, "batch/single x mismatch: {a} vs {b}");
+    }
+}

--- a/crates/within/tests/orchestrate_high_level.rs
+++ b/crates/within/tests/orchestrate_high_level.rs
@@ -48,6 +48,7 @@ fn test_high_level_solve_preconditioned() {
         operator: OperatorRepr::Implicit,
         tol: 1e-8,
         maxiter: 1000,
+        ..Default::default()
     };
     let precond = Preconditioner::Additive(LocalSolverConfig::solver_default());
     let result =

--- a/crates/within/tests/orchestrate_solve.rs
+++ b/crates/within/tests/orchestrate_solve.rs
@@ -17,6 +17,7 @@ fn test_cg_unpreconditioned() {
         operator: OperatorRepr::Implicit,
         tol: 1e-8,
         maxiter: 1000,
+        ..Default::default()
     };
     let solver = Solver::from_design(design, &params, None).expect("build solver");
     let result = solver.solve(&y).expect("solve");
@@ -33,6 +34,7 @@ fn test_cg_preconditioned() {
         operator: OperatorRepr::Implicit,
         tol: 1e-8,
         maxiter: 1000,
+        ..Default::default()
     };
     let precond = Preconditioner::Additive(LocalSolverConfig::default());
     let solver = Solver::from_design(design, &params, Some(&precond)).expect("build solver");
@@ -50,6 +52,7 @@ fn test_least_squares_cg() {
         operator: OperatorRepr::Implicit,
         tol: 1e-8,
         maxiter: 1000,
+        ..Default::default()
     };
     let solver = Solver::from_design(design, &params, None).expect("build solver");
     let result = solver.solve(&y).expect("solve");
@@ -71,6 +74,7 @@ fn test_least_squares_weighted_cg_preconditioned() {
         operator: OperatorRepr::Implicit,
         tol: 1e-8,
         maxiter: 1000,
+        ..Default::default()
     };
     let precond = Preconditioner::Additive(LocalSolverConfig::solver_default());
     let solver = Solver::from_design(design, &params, Some(&precond)).expect("build solver");
@@ -254,6 +258,7 @@ fn test_gmres_multiplicative_implicit() {
         operator: OperatorRepr::Implicit,
         tol: 1e-8,
         maxiter: 1000,
+        ..Default::default()
     };
     let precond = Preconditioner::Multiplicative(LocalSolverConfig::default());
     let solver = Solver::from_design(design, &params, Some(&precond)).expect("build solver");
@@ -272,6 +277,7 @@ fn test_gmres_multiplicative_explicit() {
         operator: OperatorRepr::Explicit,
         tol: 1e-8,
         maxiter: 1000,
+        ..Default::default()
     };
     let precond = Preconditioner::Multiplicative(LocalSolverConfig::default());
     let solver = Solver::from_design(design, &params, Some(&precond)).expect("build solver");

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -79,6 +79,7 @@ fn test_solver_explicit_gramian() {
         operator: OperatorRepr::Explicit,
         tol: 1e-8,
         maxiter: 1000,
+        ..Default::default()
     };
     let precond = additive_precond();
 
@@ -187,6 +188,7 @@ fn test_solver_multiplicative_preconditioner() {
         operator: OperatorRepr::Explicit,
         tol: 1e-8,
         maxiter: 1000,
+        ..Default::default()
     };
     let precond = Preconditioner::Multiplicative(LocalSolverConfig::solver_default());
 
@@ -206,6 +208,7 @@ fn test_multiplicative_preconditioner_nrows_ncols() {
         operator: OperatorRepr::Explicit,
         tol: 1e-8,
         maxiter: 1000,
+        ..Default::default()
     };
     let precond = Preconditioner::Multiplicative(LocalSolverConfig::solver_default());
 
@@ -260,6 +263,7 @@ fn test_multiplicative_vs_additive_same_solution() {
         operator: OperatorRepr::Implicit,
         tol: 1e-10,
         maxiter: 2000,
+        ..Default::default()
     };
     let precond_add = Preconditioner::Additive(LocalSolverConfig::solver_default());
     let result_add = solve(categories.view(), &y, None, &params_add, Some(&precond_add))
@@ -270,6 +274,7 @@ fn test_multiplicative_vs_additive_same_solution() {
         operator: OperatorRepr::Explicit,
         tol: 1e-10,
         maxiter: 2000,
+        ..Default::default()
     };
     let precond_mult = Preconditioner::Multiplicative(LocalSolverConfig::solver_default());
     let result_mult = solve(
@@ -303,6 +308,7 @@ fn test_multiplicative_serde_roundtrip() {
         operator: OperatorRepr::Explicit,
         tol: 1e-8,
         maxiter: 1000,
+        ..Default::default()
     };
     let precond = Preconditioner::Multiplicative(LocalSolverConfig::solver_default());
 
@@ -334,6 +340,7 @@ fn test_solver_multiplicative_implicit_fused() {
         operator: OperatorRepr::Implicit,
         tol: 1e-8,
         maxiter: 1000,
+        ..Default::default()
     };
     let precond = Preconditioner::Multiplicative(LocalSolverConfig::solver_default());
 

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -19,11 +19,13 @@ class CG:
     tol: float
     maxiter: int
     operator: OperatorRepr
+    max_refinements: int
     def __init__(
         self,
         tol: float = 1e-8,
         maxiter: int = 1000,
         operator: OperatorRepr = OperatorRepr.Implicit,
+        max_refinements: int = 2,
     ) -> None: ...
 
 class GMRES:
@@ -33,12 +35,14 @@ class GMRES:
     maxiter: int
     restart: int
     operator: OperatorRepr
+    max_refinements: int
     def __init__(
         self,
         tol: float = 1e-8,
         maxiter: int = 1000,
         restart: int = 30,
         operator: OperatorRepr = OperatorRepr.Implicit,
+        max_refinements: int = 2,
     ) -> None: ...
 
 class SolveResult:


### PR DESCRIPTION


  After the initial Krylov solve, recompute the residual from
  observation
  space (D^T W (y - Dx)) and solve for a correction. This squares the
  effective tolerance, closing the 1/√λ_min amplification gap between
  normal-equation residual and observation-space demeaning quality on
  ill-conditioned problems.

  - Add max_refinements to SolverParams (default: 2)
  - Refinement loop in Solver::solve() with early exit when residual meets tol
  - Expose max_refinements on Python CG/GMRES classes
  - 8 new tests covering CG, GMRES, edge cases, and batch solves