### PR TITLE
schwarz-precond: drop LocalSolveInvoker generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ Modified LSMR is now the sole iterative solver, replacing CG and GMRES.
   `schwarz_precond::SolveError` are now `#[non_exhaustive]`. External
   `match` sites need a wildcard arm. `SolveError` gains an
   `InvalidInput { context, message }` variant.
+- **BREAKING:** `LocalSolver::solve_local` now takes an
+  `allow_inner_parallelism: bool` policy hint. Implementations with no
+  nested-parallel region can ignore it (`_allow_inner_parallelism`).
+  `SchwarzPreconditioner` no longer carries the `I: LocalSolveInvoker`
+  type parameter; the `LocalSolveInvoker` trait, `DefaultLocalSolveInvoker`,
+  and `with_strategy_and_invoker` constructor are removed.
 - LSMR vector kernels parallelized via Rayon.
 
 ### Removed

--- a/crates/schwarz-precond/examples/additive_schwarz.rs
+++ b/crates/schwarz-precond/examples/additive_schwarz.rs
@@ -55,7 +55,12 @@ impl LocalSolver for DiagLocalSolver {
     fn scratch_size(&self) -> usize {
         self.n_local
     }
-    fn solve_local(&self, rhs: &mut [f64], sol: &mut [f64]) -> Result<(), LocalSolveError> {
+    fn solve_local(
+        &self,
+        rhs: &mut [f64],
+        sol: &mut [f64],
+        _allow_inner_parallelism: bool,
+    ) -> Result<(), LocalSolveError> {
         for i in 0..self.n_local {
             sol[i] = rhs[i] / self.diag_val;
         }

--- a/crates/schwarz-precond/examples/custom_local_solver.rs
+++ b/crates/schwarz-precond/examples/custom_local_solver.rs
@@ -147,7 +147,12 @@ impl LocalSolver for DenseCholeskyLocalSolver {
     fn scratch_size(&self) -> usize {
         self.n_local
     }
-    fn solve_local(&self, rhs: &mut [f64], sol: &mut [f64]) -> Result<(), LocalSolveError> {
+    fn solve_local(
+        &self,
+        rhs: &mut [f64],
+        sol: &mut [f64],
+        _allow_inner_parallelism: bool,
+    ) -> Result<(), LocalSolveError> {
         self.solve(rhs, sol);
         Ok(())
     }

--- a/crates/schwarz-precond/src/lib.rs
+++ b/crates/schwarz-precond/src/lib.rs
@@ -43,7 +43,7 @@
 //! ```text
 //! schwarz-precond
 //! ├── domain          SubdomainCore, PartitionWeights
-//! ├── local_solve     LocalSolver trait, LocalSolveInvoker, SubdomainEntry
+//! ├── local_solve     LocalSolver trait, SubdomainEntry
 //! ├── schwarz         Additive Schwarz preconditioner (parallel local solves)
 //! ├── lsmr            Modified LSMR for rectangular least-squares
 //! ├── sparse_matrix   SparseMatrix (internal CSR representation)
@@ -52,7 +52,7 @@
 //!
 //! # Trait relationships
 //!
-//! The crate is built around three core traits that compose to form the
+//! The crate is built around two core traits that compose to form the
 //! preconditioner:
 //!
 //! - **[`Operator`]** — A linear map `R^n -> R^n` with `apply` and
@@ -64,12 +64,10 @@
 //!   right-hand side, produce the local solution. Implementations range
 //!   from exact Cholesky to approximate incomplete factorizations.
 //!   The solver declares its DOF count and scratch buffer requirements,
-//!   which are validated at construction time.
-//!
-//! - **[`LocalSolveInvoker`]** — An execution-policy adapter that wraps
-//!   a `LocalSolver` call. The default ([`DefaultLocalSolveInvoker`])
-//!   delegates directly; specialized invokers can add instrumentation or
-//!   nested-parallelism control without polluting the solver trait itself.
+//!   which are validated at construction time. The `solve_local` method
+//!   receives an `allow_inner_parallelism` hint so implementations with
+//!   worthwhile nested-parallel regions can opt in without a separate
+//!   policy trait.
 //!
 //! These compose inside [`SubdomainEntry`], which bundles a
 //! [`SubdomainCore`] (restriction indices + partition-of-unity weights)
@@ -138,7 +136,7 @@ pub use error::{
     ApplyError, LocalSolveError, PreconditionerBuildError, SolveError, SubdomainCoreBuildError,
     SubdomainEntryBuildError,
 };
-pub use local_solve::{DefaultLocalSolveInvoker, LocalSolveInvoker, LocalSolver, SubdomainEntry};
+pub use local_solve::{LocalSolver, SubdomainEntry};
 pub use lsmr::{lsmr, mlsmr, LsmrResult, LsmrStopReason};
 pub use schwarz::{AdditiveSchwarzDiagnostics, ReductionStrategy, SchwarzPreconditioner};
 pub use sparse_matrix::SparseMatrix;

--- a/crates/schwarz-precond/src/local_solve.rs
+++ b/crates/schwarz-precond/src/local_solve.rs
@@ -11,9 +11,6 @@
 //!   `Rᵢ` and `D̃ᵢ`) with a `LocalSolver` (which implements `Aᵢ⁻¹`),
 //!   giving a single object that can compute the full per-subdomain
 //!   contribution `Rᵢᵀ D̃ᵢ Aᵢ⁻¹ D̃ᵢ Rᵢ r` via [`SubdomainEntry::apply_weighted_into_with_scratch`].
-//!
-//! [`LocalSolveInvoker`] is a policy trait that controls *how* the local
-//! solve is dispatched (e.g. with or without nested parallelism).
 
 use std::sync::atomic::AtomicU64;
 
@@ -41,46 +38,23 @@ pub trait LocalSolver: Send + Sync {
     ///
     /// Both `rhs` and `sol` have length >= `scratch_size()`.
     /// The solver may read/write up to `scratch_size()` elements.
-    fn solve_local(&self, rhs: &mut [f64], sol: &mut [f64]) -> Result<(), LocalSolveError>;
+    ///
+    /// `allow_inner_parallelism` is an execution-policy hint: implementations
+    /// with worthwhile inner parallel regions may consult it to decide whether
+    /// to engage nested Rayon. Implementations that have no nested-parallel
+    /// region can ignore the hint.
+    fn solve_local(
+        &self,
+        rhs: &mut [f64],
+        sol: &mut [f64],
+        allow_inner_parallelism: bool,
+    ) -> Result<(), LocalSolveError>;
 
     /// Estimated amount of local work that can benefit from nested Rayon.
     ///
     /// Return zero when the solver has no nested-parallel region worth enabling.
     fn inner_parallelism_work_estimate(&self) -> usize {
         0
-    }
-}
-
-/// Strategy for invoking a local solver under a specific execution policy.
-///
-/// The default invoker simply calls [`LocalSolver::solve_local`] and ignores
-/// the policy hint. Specialized integrations can override this without
-/// polluting the core [`LocalSolver`] trait.
-pub trait LocalSolveInvoker<S: LocalSolver>: Clone + Default + Send + Sync {
-    /// Invoke `solver` for one local solve.
-    fn solve_local(
-        &self,
-        solver: &S,
-        rhs: &mut [f64],
-        sol: &mut [f64],
-        allow_inner_parallelism: bool,
-    ) -> Result<(), LocalSolveError>;
-}
-
-/// Default local-solve invoker: ignores the policy hint.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct DefaultLocalSolveInvoker;
-
-impl<S: LocalSolver> LocalSolveInvoker<S> for DefaultLocalSolveInvoker {
-    fn solve_local(
-        &self,
-        solver: &S,
-        rhs: &mut [f64],
-        sol: &mut [f64],
-        allow_inner_parallelism: bool,
-    ) -> Result<(), LocalSolveError> {
-        let _ = allow_inner_parallelism;
-        solver.solve_local(rhs, sol)
     }
 }
 
@@ -168,24 +142,6 @@ impl<S: LocalSolver> SubdomainEntry<S> {
         out: &mut [f64],
         r_scratch: &mut [f64],
         z_scratch: &mut [f64],
-    ) -> Result<(), LocalSolveError> {
-        self.apply_weighted_into_with_scratch_by(
-            r,
-            out,
-            r_scratch,
-            z_scratch,
-            &DefaultLocalSolveInvoker,
-            true,
-        )
-    }
-
-    pub(crate) fn apply_weighted_into_with_scratch_by<I: LocalSolveInvoker<S>>(
-        &self,
-        r: &[f64],
-        out: &mut [f64],
-        r_scratch: &mut [f64],
-        z_scratch: &mut [f64],
-        invoker: &I,
         allow_inner_parallelism: bool,
     ) -> Result<(), LocalSolveError> {
         if self.core.is_empty() {
@@ -196,7 +152,8 @@ impl<S: LocalSolver> SubdomainEntry<S> {
         self.core.restrict_weighted(r, r_scratch);
 
         // Local solve (strategy-specific transforms happen inside the solver)
-        invoker.solve_local(&self.solver, r_scratch, z_scratch, allow_inner_parallelism)?;
+        self.solver
+            .solve_local(r_scratch, z_scratch, allow_inner_parallelism)?;
 
         // Weighted scatter directly into output: out += R_i^T @ D_i @ z_local
         self.core.prolongate_weighted_add(z_scratch, out);
@@ -212,24 +169,6 @@ impl<S: LocalSolver> SubdomainEntry<S> {
         out: &[AtomicU64],
         r_scratch: &mut [f64],
         z_scratch: &mut [f64],
-    ) -> Result<(), LocalSolveError> {
-        self.apply_weighted_into_atomic_by(
-            r,
-            out,
-            r_scratch,
-            z_scratch,
-            &DefaultLocalSolveInvoker,
-            true,
-        )
-    }
-
-    pub(crate) fn apply_weighted_into_atomic_by<I: LocalSolveInvoker<S>>(
-        &self,
-        r: &[f64],
-        out: &[AtomicU64],
-        r_scratch: &mut [f64],
-        z_scratch: &mut [f64],
-        invoker: &I,
         allow_inner_parallelism: bool,
     ) -> Result<(), LocalSolveError> {
         if self.core.is_empty() {
@@ -240,7 +179,8 @@ impl<S: LocalSolver> SubdomainEntry<S> {
         self.core.restrict_weighted(r, r_scratch);
 
         // Local solve (strategy-specific transforms happen inside the solver)
-        invoker.solve_local(&self.solver, r_scratch, z_scratch, allow_inner_parallelism)?;
+        self.solver
+            .solve_local(r_scratch, z_scratch, allow_inner_parallelism)?;
 
         // Weighted atomic scatter into output: out += R_i^T @ D_i @ z_local
         self.core.prolongate_weighted_add_atomic(z_scratch, out);
@@ -304,7 +244,12 @@ mod tests {
         fn scratch_size(&self) -> usize {
             self.n
         }
-        fn solve_local(&self, rhs: &mut [f64], sol: &mut [f64]) -> Result<(), LocalSolveError> {
+        fn solve_local(
+            &self,
+            rhs: &mut [f64],
+            sol: &mut [f64],
+            _allow_inner_parallelism: bool,
+        ) -> Result<(), LocalSolveError> {
             sol[..self.n].copy_from_slice(&rhs[..self.n]);
             Ok(())
         }
@@ -368,7 +313,7 @@ mod tests {
         let mut z_scratch = vec![0.0; 2];
 
         entry
-            .apply_weighted_into_with_scratch(&r, &mut out, &mut r_scratch, &mut z_scratch)
+            .apply_weighted_into_with_scratch(&r, &mut out, &mut r_scratch, &mut z_scratch, true)
             .expect("identity local solver should not fail");
 
         // Should restrict DOFs [1,2] → [20, 30], identity solve, scatter back

--- a/crates/schwarz-precond/src/schwarz/executor.rs
+++ b/crates/schwarz-precond/src/schwarz/executor.rs
@@ -27,7 +27,7 @@ use rayon::prelude::*;
 use thread_local::ThreadLocal;
 
 use crate::error::ApplyError;
-use crate::local_solve::{LocalSolveInvoker, LocalSolver, SubdomainEntry};
+use crate::local_solve::{LocalSolver, SubdomainEntry};
 
 use super::planning::{ReductionPlan, ResolvedReductionStrategy};
 
@@ -244,26 +244,23 @@ fn take_reduction_buffer(
 // Executor
 // ============================================================================
 
-pub(super) struct AdditiveExecutor<S: LocalSolver, I: LocalSolveInvoker<S>> {
+pub(super) struct AdditiveExecutor<S: LocalSolver> {
     pub(super) subdomains: Arc<Vec<SubdomainEntry<S>>>,
     pub(super) n_dofs: usize,
     pub(super) max_scratch_size: usize,
-    invoker: I,
     buf_pool: BufferPool,
 }
 
-impl<S: LocalSolver, I: LocalSolveInvoker<S>> AdditiveExecutor<S, I> {
+impl<S: LocalSolver> AdditiveExecutor<S> {
     pub(super) fn new(
         entries: Vec<SubdomainEntry<S>>,
         n_dofs: usize,
         max_scratch_size: usize,
-        invoker: I,
     ) -> Self {
         Self {
             subdomains: Arc::new(entries),
             n_dofs,
             max_scratch_size,
-            invoker,
             buf_pool: BufferPool::default(),
         }
     }
@@ -277,7 +274,6 @@ impl<S: LocalSolver, I: LocalSolveInvoker<S>> AdditiveExecutor<S, I> {
             subdomains: Arc::clone(&self.subdomains),
             n_dofs: self.n_dofs,
             max_scratch_size: self.max_scratch_size,
-            invoker: self.invoker.clone(),
             buf_pool: BufferPool::default(),
         }
     }
@@ -314,12 +310,11 @@ impl<S: LocalSolver, I: LocalSolveInvoker<S>> AdditiveExecutor<S, I> {
             || LocalSolveScratch::new(self.max_scratch_size),
             |scratch, (subdomain, entry)| {
                 entry
-                    .apply_weighted_into_atomic_by(
+                    .apply_weighted_into_atomic(
                         r,
                         accum,
                         &mut scratch.r_scratch,
                         &mut scratch.z_scratch,
-                        &self.invoker,
                         allow_inner_parallelism,
                     )
                     .map_err(|source| ApplyError::LocalSolveFailed { subdomain, source })
@@ -355,12 +350,11 @@ impl<S: LocalSolver, I: LocalSolveInvoker<S>> AdditiveExecutor<S, I> {
                 .try_for_each(|(subdomain, entry)| {
                     worker_buffers.with_buffer(|buffers| {
                         entry
-                            .apply_weighted_into_with_scratch_by(
+                            .apply_weighted_into_with_scratch(
                                 r,
                                 &mut buffers.global_accum,
                                 &mut buffers.scratch.r_scratch,
                                 &mut buffers.scratch.z_scratch,
-                                &self.invoker,
                                 allow_inner_parallelism,
                             )
                             .map_err(|source| ApplyError::LocalSolveFailed { subdomain, source })
@@ -373,13 +367,12 @@ impl<S: LocalSolver, I: LocalSolveInvoker<S>> AdditiveExecutor<S, I> {
     }
 }
 
-impl<S: LocalSolver, I: LocalSolveInvoker<S>> Clone for AdditiveExecutor<S, I> {
+impl<S: LocalSolver> Clone for AdditiveExecutor<S> {
     fn clone(&self) -> Self {
         Self {
             subdomains: Arc::clone(&self.subdomains),
             n_dofs: self.n_dofs,
             max_scratch_size: self.max_scratch_size,
-            invoker: self.invoker.clone(),
             buf_pool: self.buf_pool.clone(),
         }
     }

--- a/crates/schwarz-precond/src/schwarz/preconditioner.rs
+++ b/crates/schwarz-precond/src/schwarz/preconditioner.rs
@@ -7,9 +7,7 @@
 //! borrowed from a pool).
 
 use crate::error::{validate_entries, ApplyError, PreconditionerBuildError};
-use crate::local_solve::{
-    DefaultLocalSolveInvoker, LocalSolveInvoker, LocalSolver, SubdomainEntry,
-};
+use crate::local_solve::{LocalSolver, SubdomainEntry};
 use crate::Operator;
 
 use super::executor::AdditiveExecutor;
@@ -25,10 +23,9 @@ use super::planning::{
 /// The reduction strategy resets to `Auto` on deserialize; buffers are
 /// re-allocated fresh.
 #[cfg(feature = "serde")]
-impl<S, I> serde::Serialize for SchwarzPreconditioner<S, I>
+impl<S> serde::Serialize for SchwarzPreconditioner<S>
 where
     S: LocalSolver + serde::Serialize,
-    I: LocalSolveInvoker<S>,
 {
     fn serialize<Ser: serde::Serializer>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error> {
         use serde::ser::SerializeStruct;
@@ -41,10 +38,9 @@ where
 }
 
 #[cfg(feature = "serde")]
-impl<'de, S, I> serde::Deserialize<'de> for SchwarzPreconditioner<S, I>
+impl<'de, S> serde::Deserialize<'de> for SchwarzPreconditioner<S>
 where
     S: LocalSolver + serde::de::DeserializeOwned,
-    I: LocalSolveInvoker<S>,
 {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use serde::Deserialize;
@@ -61,12 +57,7 @@ where
         Ok(SchwarzPreconditioner {
             reduction_strategy: ReductionStrategy::default(),
             scheduler: AdditiveScheduler::from_entries(&h.subdomains, h.n_dofs),
-            executor: AdditiveExecutor::new(
-                h.subdomains,
-                h.n_dofs,
-                h.max_scratch_size,
-                I::default(),
-            ),
+            executor: AdditiveExecutor::new(h.subdomains, h.n_dofs, h.max_scratch_size),
         })
     }
 }
@@ -77,17 +68,16 @@ where
 /// shares the heavy subdomain data. A pool of per-thread buffer sets enables
 /// safe concurrent `apply()` calls on the same instance — each caller grabs
 /// an independent buffer set from the pool for the duration of the call.
-pub struct SchwarzPreconditioner<S: LocalSolver, I: LocalSolveInvoker<S> = DefaultLocalSolveInvoker>
-{
+pub struct SchwarzPreconditioner<S: LocalSolver> {
     /// Strategy for combining per-subdomain results.
     pub(super) reduction_strategy: ReductionStrategy,
     /// Build-time scheduler state for additive apply.
     pub(super) scheduler: AdditiveScheduler,
     /// Static execution state for additive apply.
-    pub(super) executor: AdditiveExecutor<S, I>,
+    pub(super) executor: AdditiveExecutor<S>,
 }
 
-impl<S: LocalSolver> SchwarzPreconditioner<S, DefaultLocalSolveInvoker> {
+impl<S: LocalSolver> SchwarzPreconditioner<S> {
     /// Construct from pre-built subdomain entries using the default strategy.
     pub fn new(
         entries: Vec<SubdomainEntry<S>>,
@@ -102,19 +92,6 @@ impl<S: LocalSolver> SchwarzPreconditioner<S, DefaultLocalSolveInvoker> {
         n_dofs: usize,
         strategy: ReductionStrategy,
     ) -> Result<Self, PreconditionerBuildError> {
-        Self::with_strategy_and_invoker(entries, n_dofs, strategy, DefaultLocalSolveInvoker)
-    }
-}
-
-impl<S: LocalSolver, I: LocalSolveInvoker<S>> SchwarzPreconditioner<S, I> {
-    /// Construct from pre-built subdomain entries with an explicit reduction strategy
-    /// and a caller-provided local-solve invoker.
-    pub fn with_strategy_and_invoker(
-        entries: Vec<SubdomainEntry<S>>,
-        n_dofs: usize,
-        strategy: ReductionStrategy,
-        invoker: I,
-    ) -> Result<Self, PreconditionerBuildError> {
         validate_entries(&entries, n_dofs)?;
         let max_scratch_size = entries
             .iter()
@@ -125,7 +102,7 @@ impl<S: LocalSolver, I: LocalSolveInvoker<S>> SchwarzPreconditioner<S, I> {
         Ok(Self {
             reduction_strategy: strategy,
             scheduler,
-            executor: AdditiveExecutor::new(entries, n_dofs, max_scratch_size, invoker),
+            executor: AdditiveExecutor::new(entries, n_dofs, max_scratch_size),
         })
     }
 
@@ -174,7 +151,7 @@ impl<S: LocalSolver, I: LocalSolveInvoker<S>> SchwarzPreconditioner<S, I> {
     }
 }
 
-impl<S: LocalSolver, I: LocalSolveInvoker<S>> Clone for SchwarzPreconditioner<S, I> {
+impl<S: LocalSolver> Clone for SchwarzPreconditioner<S> {
     /// Clone shares both the subdomain data and the buffer pool via `Arc`.
     /// This is O(1) and the clone is fully interchangeable with the original.
     fn clone(&self) -> Self {
@@ -186,7 +163,7 @@ impl<S: LocalSolver, I: LocalSolveInvoker<S>> Clone for SchwarzPreconditioner<S,
     }
 }
 
-impl<S: LocalSolver, I: LocalSolveInvoker<S>> Operator for SchwarzPreconditioner<S, I> {
+impl<S: LocalSolver> Operator for SchwarzPreconditioner<S> {
     fn nrows(&self) -> usize {
         self.executor.n_dofs
     }

--- a/crates/schwarz-precond/tests/common/mod.rs
+++ b/crates/schwarz-precond/tests/common/mod.rs
@@ -69,7 +69,12 @@ impl LocalSolver for UniformDiagLocalSolver {
     fn scratch_size(&self) -> usize {
         self.n_local
     }
-    fn solve_local(&self, rhs: &mut [f64], sol: &mut [f64]) -> Result<(), LocalSolveError> {
+    fn solve_local(
+        &self,
+        rhs: &mut [f64],
+        sol: &mut [f64],
+        _allow_inner_parallelism: bool,
+    ) -> Result<(), LocalSolveError> {
         for i in 0..self.n_local {
             sol[i] = rhs[i] * self.inv_diag;
         }
@@ -120,7 +125,12 @@ impl LocalSolver for FailingLocalSolver {
     fn scratch_size(&self) -> usize {
         self.scratch_size
     }
-    fn solve_local(&self, _rhs: &mut [f64], _sol: &mut [f64]) -> Result<(), LocalSolveError> {
+    fn solve_local(
+        &self,
+        _rhs: &mut [f64],
+        _sol: &mut [f64],
+        _allow_inner_parallelism: bool,
+    ) -> Result<(), LocalSolveError> {
         Err(LocalSolveError::ApproxCholSolveFailed {
             context: "test.failing_local_solver",
             message: format!("deliberate failure for n={}", self.n_local),

--- a/crates/schwarz-precond/tests/schwarz.rs
+++ b/crates/schwarz-precond/tests/schwarz.rs
@@ -8,8 +8,8 @@ use std::time::{Duration, Instant};
 use rayon::prelude::*;
 use schwarz_precond::domain::PartitionWeights;
 use schwarz_precond::{
-    lsmr, mlsmr, LocalSolveError, LocalSolveInvoker, LocalSolver, Operator, ReductionStrategy,
-    SchwarzPreconditioner, SubdomainCore, SubdomainEntry,
+    lsmr, mlsmr, LocalSolveError, LocalSolver, Operator, ReductionStrategy, SchwarzPreconditioner,
+    SubdomainCore, SubdomainEntry,
 };
 
 use common::{make_schwarz_entries, FailingLocalSolver, TridiagOperator, UniformDiagLocalSolver};
@@ -75,40 +75,29 @@ impl LocalSolver for NestedRayonIdentitySolver {
         self.n
     }
 
-    fn solve_local(&self, rhs: &mut [f64], sol: &mut [f64]) -> Result<(), LocalSolveError> {
-        sol[..self.n].copy_from_slice(&rhs[..self.n]);
-        Ok(())
-    }
-
-    fn inner_parallelism_work_estimate(&self) -> usize {
-        self.n.saturating_mul(32)
-    }
-}
-
-#[derive(Clone, Copy, Default)]
-struct NestedRayonSolveInvoker;
-
-impl LocalSolveInvoker<NestedRayonIdentitySolver> for NestedRayonSolveInvoker {
     fn solve_local(
         &self,
-        solver: &NestedRayonIdentitySolver,
         rhs: &mut [f64],
         sol: &mut [f64],
         allow_inner_parallelism: bool,
     ) -> Result<(), LocalSolveError> {
         if allow_inner_parallelism {
-            sol[..solver.n]
-                .par_chunks_mut(NestedRayonIdentitySolver::CHUNK_SIZE)
+            sol[..self.n]
+                .par_chunks_mut(Self::CHUNK_SIZE)
                 .enumerate()
                 .for_each(|(chunk_idx, chunk)| {
-                    let start = chunk_idx * NestedRayonIdentitySolver::CHUNK_SIZE;
+                    let start = chunk_idx * Self::CHUNK_SIZE;
                     let end = start + chunk.len();
                     chunk.copy_from_slice(&rhs[start..end]);
                 });
         } else {
-            sol[..solver.n].copy_from_slice(&rhs[..solver.n]);
+            sol[..self.n].copy_from_slice(&rhs[..self.n]);
         }
         Ok(())
+    }
+
+    fn inner_parallelism_work_estimate(&self) -> usize {
+        self.n.saturating_mul(32)
     }
 }
 
@@ -133,11 +122,10 @@ fn run_nested_parallel_reduction_regression_case() {
         .build()
         .expect("test rayon pool");
     pool.install(|| {
-        let schwarz = SchwarzPreconditioner::with_strategy_and_invoker(
+        let schwarz = SchwarzPreconditioner::with_strategy(
             make_nested_parallel_entries(n),
             n,
             ReductionStrategy::ParallelReduction,
-            NestedRayonSolveInvoker,
         )
         .expect("valid nested parallel additive preconditioner");
 

--- a/crates/within/src/operator/local_solver.rs
+++ b/crates/within/src/operator/local_solver.rs
@@ -46,29 +46,10 @@ use std::sync::Arc;
 use approx_chol::Factor;
 use faer::{MatRef, Side};
 use rayon::prelude::*;
-use schwarz_precond::{LocalSolveError, LocalSolveInvoker, LocalSolver};
+use schwarz_precond::{LocalSolveError, LocalSolver};
 
 use crate::operator::csr_block::{CsrBlock, PAR_SPMV_THRESHOLD};
 use crate::operator::gramian::CrossTab;
-
-// ===========================================================================
-// FeLocalSolveInvoker — delegates to BlockElimSolver with parallelism control
-// ===========================================================================
-
-#[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct FeLocalSolveInvoker;
-
-impl LocalSolveInvoker<BlockElimSolver> for FeLocalSolveInvoker {
-    fn solve_local(
-        &self,
-        solver: &BlockElimSolver,
-        rhs: &mut [f64],
-        sol: &mut [f64],
-        allow_inner_parallelism: bool,
-    ) -> Result<(), LocalSolveError> {
-        solver.solve_local_with_parallelism(rhs, sol, allow_inner_parallelism)
-    }
-}
 
 // ===========================================================================
 // Transform helpers — sign-flipping, mean subtraction, back-substitution
@@ -356,8 +337,20 @@ impl BlockElimSolver {
     }
 }
 
-impl BlockElimSolver {
-    fn solve_local_with_parallelism(
+impl LocalSolver for BlockElimSolver {
+    fn n_local(&self) -> usize {
+        self.n_local
+    }
+
+    fn scratch_size(&self) -> usize {
+        self.n_local + self.n_reduced
+    }
+
+    fn inner_parallelism_work_estimate(&self) -> usize {
+        self.estimated_inner_parallel_work()
+    }
+
+    fn solve_local(
         &self,
         rhs: &mut [f64],
         sol: &mut [f64],
@@ -446,24 +439,6 @@ impl BlockElimSolver {
         subtract_mean(sol, n);
         negate_block(&mut sol[..n], n_q);
         Ok(())
-    }
-}
-
-impl LocalSolver for BlockElimSolver {
-    fn n_local(&self) -> usize {
-        self.n_local
-    }
-
-    fn scratch_size(&self) -> usize {
-        self.n_local + self.n_reduced
-    }
-
-    fn solve_local(&self, rhs: &mut [f64], sol: &mut [f64]) -> Result<(), LocalSolveError> {
-        self.solve_local_with_parallelism(rhs, sol, true)
-    }
-
-    fn inner_parallelism_work_estimate(&self) -> usize {
-        self.estimated_inner_parallel_work()
     }
 }
 

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -32,7 +32,7 @@ use schwarz_precond::{SchwarzPreconditioner, SubdomainEntry};
 use serde::{Deserialize, Serialize};
 
 use super::gramian::CrossTab;
-use super::local_solver::{BlockElimSolver, FeLocalSolveInvoker, ReducedFactor};
+use super::local_solver::{BlockElimSolver, ReducedFactor};
 use super::schur_complement::{
     ApproxSchurComplement, EliminationInfo, ExactSchurComplement, SchurComplement, SchurResult,
 };
@@ -42,10 +42,10 @@ use crate::{WithinError, WithinResult};
 
 /// Concrete additive Schwarz type used in the parent crate.
 #[derive(Clone, Serialize, Deserialize)]
-pub struct FeSchwarz(SchwarzPreconditioner<BlockElimSolver, FeLocalSolveInvoker>);
+pub struct FeSchwarz(SchwarzPreconditioner<BlockElimSolver>);
 
 impl FeSchwarz {
-    pub(crate) fn new(inner: SchwarzPreconditioner<BlockElimSolver, FeLocalSolveInvoker>) -> Self {
+    pub(crate) fn new(inner: SchwarzPreconditioner<BlockElimSolver>) -> Self {
         Self(inner)
     }
 
@@ -122,14 +122,9 @@ pub(crate) fn build_additive_with_strategy(
     strategy: schwarz_precond::ReductionStrategy,
 ) -> WithinResult<FeSchwarz> {
     let entries = build_entries_from_pairs(domains, config)?;
-    Ok(FeSchwarz::new(
-        SchwarzPreconditioner::with_strategy_and_invoker(
-            entries,
-            n_dofs,
-            strategy,
-            FeLocalSolveInvoker,
-        )?,
-    ))
+    Ok(FeSchwarz::new(SchwarzPreconditioner::with_strategy(
+        entries, n_dofs, strategy,
+    )?))
 }
 
 fn build_entries_from_pairs(

--- a/crates/within/src/operator/tests.rs
+++ b/crates/within/src/operator/tests.rs
@@ -736,7 +736,7 @@ mod schwarz_tests {
         for _ in 0..iters {
             rhs[..n_local].copy_from_slice(&rhs_template);
             solver
-                .solve_local(&mut rhs, &mut sol)
+                .solve_local(&mut rhs, &mut sol, true)
                 .expect("benchmark local solve");
             checksum += sol[0];
         }
@@ -988,7 +988,7 @@ mod block_elim_tests {
         let mut sol = vec![0.0; scratch_sz];
 
         solver
-            .solve_local(&mut rhs, &mut sol)
+            .solve_local(&mut rhs, &mut sol, true)
             .expect("solve_local should succeed");
 
         // Solution must be finite.


### PR DESCRIPTION
Closes #31.

## Summary
- `LocalSolver::solve_local` now takes `allow_inner_parallelism: bool` directly. Solvers with no nested-parallel region ignore the hint (`_allow_inner_parallelism`).
- `SchwarzPreconditioner` and `AdditiveExecutor` lose the `I: LocalSolveInvoker` type parameter. `LocalSolveInvoker`, `DefaultLocalSolveInvoker`, `FeLocalSolveInvoker`, and `with_strategy_and_invoker` are gone.
- `BlockElimSolver::solve_local_with_parallelism` folds into its `LocalSolver::solve_local` impl. `FeSchwarz` is now `SchwarzPreconditioner<BlockElimSolver>`.
- The nested-Rayon `ParallelReduction` regression test overrides `LocalSolver::solve_local` on its own impl (no custom invoker needed).

Net **-107 LOC**.

This is a breaking change to `schwarz-precond`'s public trait surface. CHANGELOG `[Unreleased]` updated.

## Test plan
- [x] `cargo build --workspace --examples --tests`
- [x] `cargo test --workspace` (all crates, including the nested-Rayon deadlock regression `test_parallel_reduction_nested_rayon_does_not_deadlock`)
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo doc -p schwarz-precond --no-deps` (crate has `#![deny(missing_docs)]`)
- [x] `pixi run test` (98 Python tests)