### PR TITLE
Drop AdditiveSchwarzDiagnostics from public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ Modified LSMR is now the sole iterative solver, replacing CG and GMRES.
   `schwarz_precond::schwarz::{additive, multiplicative}` flattened into
   `schwarz_precond::schwarz`; crate-root `SchwarzPreconditioner` re-export
   unchanged.
+- **BREAKING:** `AdditiveSchwarzDiagnostics` removed from Rust and Python
+  public APIs along with `SchwarzPreconditioner::diagnostics`,
+  `FePreconditioner::additive_schwarz_diagnostics`, and the Python
+  `AdditiveSchwarzDiagnostics` class. Scheduling metrics are now private
+  to the `Auto` heuristic (closes #34).
 
 ## [0.1.0] - 2026-03-12
 

--- a/crates/schwarz-precond/src/lib.rs
+++ b/crates/schwarz-precond/src/lib.rs
@@ -138,5 +138,5 @@ pub use error::{
 };
 pub use local_solve::{LocalSolver, SubdomainEntry};
 pub use lsmr::{lsmr, mlsmr, LsmrResult, LsmrStopReason};
-pub use schwarz::{AdditiveSchwarzDiagnostics, ReductionStrategy, SchwarzPreconditioner};
+pub use schwarz::{ReductionStrategy, SchwarzPreconditioner};
 pub use sparse_matrix::SparseMatrix;

--- a/crates/schwarz-precond/src/schwarz.rs
+++ b/crates/schwarz-precond/src/schwarz.rs
@@ -27,5 +27,5 @@ mod executor;
 mod planning;
 mod preconditioner;
 
-pub use planning::{AdditiveSchwarzDiagnostics, ReductionStrategy};
+pub use planning::ReductionStrategy;
 pub use preconditioner::SchwarzPreconditioner;

--- a/crates/schwarz-precond/src/schwarz/planning.rs
+++ b/crates/schwarz-precond/src/schwarz/planning.rs
@@ -1,9 +1,9 @@
-//! Reduction strategy selection and build-time diagnostics.
+//! Reduction strategy selection.
 //!
 //! [`ReductionStrategy`] is the user-facing enum (`Auto`, `AtomicScatter`,
 //! `ParallelReduction`). [`AdditiveScheduler`] resolves `Auto` at apply-time
-//! using build-time metrics ([`AdditiveSchwarzDiagnostics`]) and the current
-//! Rayon thread-pool width.
+//! using build-time scheduling metrics and the current Rayon thread-pool
+//! width.
 //!
 //! The heuristic balances two costs:
 //! - **Atomic scatter**: contention grows with overlap (DOFs shared across
@@ -49,95 +49,9 @@ pub(super) struct ReductionPlan {
     pub(super) allow_inner_parallelism: bool,
 }
 
+/// Build-time scheduling metrics + `Auto` resolution logic.
 #[derive(Debug, Clone, Copy)]
 pub(super) struct AdditiveScheduler {
-    diagnostics: AdditiveSchwarzDiagnostics,
-}
-
-impl AdditiveScheduler {
-    pub(super) fn from_entries<S: LocalSolver>(
-        entries: &[SubdomainEntry<S>],
-        n_dofs: usize,
-    ) -> Self {
-        Self {
-            diagnostics: AdditiveSchwarzDiagnostics::from_entries(entries, n_dofs),
-        }
-    }
-
-    pub(super) fn diagnostics(self) -> AdditiveSchwarzDiagnostics {
-        self.diagnostics
-    }
-
-    pub(super) fn reduction_plan(
-        self,
-        configured: ReductionStrategy,
-        threads: usize,
-    ) -> ReductionPlan {
-        let allow_inner_parallelism = self.allow_inner_parallelism(threads);
-        let strategy = self.resolve_strategy(configured, threads, allow_inner_parallelism);
-        ReductionPlan {
-            strategy,
-            allow_inner_parallelism,
-        }
-    }
-
-    fn allow_inner_parallelism(self, threads: usize) -> bool {
-        if self.diagnostics.max_inner_parallel_work < Self::MIN_INNER_PARALLEL_WORK {
-            return false;
-        }
-
-        self.diagnostics.outer_parallel_capacity() < (threads as f64 * Self::OUTER_CAPACITY_TARGET)
-    }
-
-    fn resolve_strategy(
-        self,
-        configured: ReductionStrategy,
-        threads: usize,
-        allow_inner_parallelism: bool,
-    ) -> ResolvedReductionStrategy {
-        match configured {
-            ReductionStrategy::AtomicScatter => ResolvedReductionStrategy::AtomicScatter,
-            ReductionStrategy::ParallelReduction => ResolvedReductionStrategy::ParallelReduction,
-            ReductionStrategy::Auto => self.pick_auto_strategy(threads, allow_inner_parallelism),
-        }
-    }
-
-    fn pick_auto_strategy(
-        self,
-        threads: usize,
-        allow_inner_parallelism: bool,
-    ) -> ResolvedReductionStrategy {
-        let overlap = self.diagnostics.scatter_overlap();
-        let reduction_to_scatter = self.reduction_sweep_to_scatter(threads);
-
-        if reduction_to_scatter <= Self::AUTO_REDUCTION_SWEEP_FACTOR {
-            return ResolvedReductionStrategy::ParallelReduction;
-        }
-
-        if allow_inner_parallelism
-            && reduction_to_scatter <= Self::AUTO_INNER_REDUCTION_SWEEP_FACTOR
-        {
-            return ResolvedReductionStrategy::ParallelReduction;
-        }
-
-        if overlap >= Self::AUTO_OVERLAP_FOR_REDUCTION {
-            return ResolvedReductionStrategy::ParallelReduction;
-        }
-
-        ResolvedReductionStrategy::AtomicScatter
-    }
-
-    fn reduction_sweep_to_scatter(self, threads: usize) -> f64 {
-        let active_buffers = threads.min(self.diagnostics.n_subdomains).max(1);
-        let reduction_sweep = active_buffers.saturating_mul(self.diagnostics.n_dofs);
-        let scatter_work = self.diagnostics.total_scatter_dofs.max(1);
-        reduction_sweep as f64 / scatter_work as f64
-    }
-}
-
-/// Build-time metrics that describe additive Schwarz scheduling pressure.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct AdditiveSchwarzDiagnostics {
     n_subdomains: usize,
     n_dofs: usize,
     total_inner_parallel_work: usize,
@@ -145,7 +59,13 @@ pub struct AdditiveSchwarzDiagnostics {
     total_scatter_dofs: usize,
 }
 
-impl AdditiveSchwarzDiagnostics {
+impl AdditiveScheduler {
+    const MIN_INNER_PARALLEL_WORK: usize = 200_000;
+    const OUTER_CAPACITY_TARGET: f64 = 0.75;
+    const AUTO_REDUCTION_SWEEP_FACTOR: f64 = 1.1;
+    const AUTO_INNER_REDUCTION_SWEEP_FACTOR: f64 = 6.0;
+    const AUTO_OVERLAP_FOR_REDUCTION: f64 = 4.0;
+
     pub(super) fn from_entries<S: LocalSolver>(
         entries: &[SubdomainEntry<S>],
         n_dofs: usize,
@@ -171,49 +91,80 @@ impl AdditiveSchwarzDiagnostics {
         }
     }
 
-    /// Number of additive Schwarz subdomains.
-    pub fn n_subdomains(&self) -> usize {
-        self.n_subdomains
+    pub(super) fn reduction_plan(
+        self,
+        configured: ReductionStrategy,
+        threads: usize,
+    ) -> ReductionPlan {
+        let allow_inner_parallelism = self.allow_inner_parallelism(threads);
+        let strategy = self.resolve_strategy(configured, threads, allow_inner_parallelism);
+        ReductionPlan {
+            strategy,
+            allow_inner_parallelism,
+        }
     }
 
-    /// Global number of degrees of freedom.
-    pub fn n_dofs(&self) -> usize {
-        self.n_dofs
-    }
-
-    /// Sum of per-subdomain work estimates that can benefit from nested Rayon.
-    pub fn total_inner_parallel_work(&self) -> usize {
-        self.total_inner_parallel_work
-    }
-
-    /// Largest single-subdomain inner-parallel work estimate.
-    pub fn max_inner_parallel_work(&self) -> usize {
-        self.max_inner_parallel_work
-    }
-
-    /// Sum of local scatter entries across all subdomains.
-    pub fn total_scatter_dofs(&self) -> usize {
-        self.total_scatter_dofs
-    }
-
-    /// Estimated outer parallel capacity: roughly how many heavy subdomains exist.
-    pub fn outer_parallel_capacity(&self) -> f64 {
+    fn outer_parallel_capacity(self) -> f64 {
         if self.max_inner_parallel_work == 0 {
             return 0.0;
         }
         self.total_inner_parallel_work as f64 / self.max_inner_parallel_work as f64
     }
 
-    /// Average overlap multiplicity of the additive scatter.
-    pub fn scatter_overlap(&self) -> f64 {
+    fn scatter_overlap(self) -> f64 {
         self.total_scatter_dofs as f64 / self.n_dofs.max(1) as f64
     }
-}
 
-impl AdditiveScheduler {
-    const MIN_INNER_PARALLEL_WORK: usize = 200_000;
-    const OUTER_CAPACITY_TARGET: f64 = 0.75;
-    const AUTO_REDUCTION_SWEEP_FACTOR: f64 = 1.1;
-    const AUTO_INNER_REDUCTION_SWEEP_FACTOR: f64 = 6.0;
-    const AUTO_OVERLAP_FOR_REDUCTION: f64 = 4.0;
+    fn allow_inner_parallelism(self, threads: usize) -> bool {
+        if self.max_inner_parallel_work < Self::MIN_INNER_PARALLEL_WORK {
+            return false;
+        }
+
+        self.outer_parallel_capacity() < (threads as f64 * Self::OUTER_CAPACITY_TARGET)
+    }
+
+    fn resolve_strategy(
+        self,
+        configured: ReductionStrategy,
+        threads: usize,
+        allow_inner_parallelism: bool,
+    ) -> ResolvedReductionStrategy {
+        match configured {
+            ReductionStrategy::AtomicScatter => ResolvedReductionStrategy::AtomicScatter,
+            ReductionStrategy::ParallelReduction => ResolvedReductionStrategy::ParallelReduction,
+            ReductionStrategy::Auto => self.pick_auto_strategy(threads, allow_inner_parallelism),
+        }
+    }
+
+    fn pick_auto_strategy(
+        self,
+        threads: usize,
+        allow_inner_parallelism: bool,
+    ) -> ResolvedReductionStrategy {
+        let overlap = self.scatter_overlap();
+        let reduction_to_scatter = self.reduction_sweep_to_scatter(threads);
+
+        if reduction_to_scatter <= Self::AUTO_REDUCTION_SWEEP_FACTOR {
+            return ResolvedReductionStrategy::ParallelReduction;
+        }
+
+        if allow_inner_parallelism
+            && reduction_to_scatter <= Self::AUTO_INNER_REDUCTION_SWEEP_FACTOR
+        {
+            return ResolvedReductionStrategy::ParallelReduction;
+        }
+
+        if overlap >= Self::AUTO_OVERLAP_FOR_REDUCTION {
+            return ResolvedReductionStrategy::ParallelReduction;
+        }
+
+        ResolvedReductionStrategy::AtomicScatter
+    }
+
+    fn reduction_sweep_to_scatter(self, threads: usize) -> f64 {
+        let active_buffers = threads.min(self.n_subdomains).max(1);
+        let reduction_sweep = active_buffers.saturating_mul(self.n_dofs);
+        let scatter_work = self.total_scatter_dofs.max(1);
+        reduction_sweep as f64 / scatter_work as f64
+    }
 }

--- a/crates/schwarz-precond/src/schwarz/preconditioner.rs
+++ b/crates/schwarz-precond/src/schwarz/preconditioner.rs
@@ -11,9 +11,7 @@ use crate::local_solve::{LocalSolver, SubdomainEntry};
 use crate::Operator;
 
 use super::executor::AdditiveExecutor;
-use super::planning::{
-    AdditiveScheduler, AdditiveSchwarzDiagnostics, ReductionPlan, ReductionStrategy,
-};
+use super::planning::{AdditiveScheduler, ReductionPlan, ReductionStrategy};
 
 // ---------------------------------------------------------------------------
 // Serde
@@ -119,11 +117,6 @@ impl<S: LocalSolver> SchwarzPreconditioner<S> {
     /// Concrete backend selected for the current Rayon thread-pool width.
     pub fn resolved_reduction_strategy(&self) -> ReductionStrategy {
         self.reduction_plan().strategy.as_public()
-    }
-
-    /// Build-time metrics used by the additive scheduler.
-    pub fn diagnostics(&self) -> AdditiveSchwarzDiagnostics {
-        self.scheduler.diagnostics()
     }
 
     /// Return a copy that uses a different reduction strategy.

--- a/crates/within-py/src/lib.rs
+++ b/crates/within-py/src/lib.rs
@@ -156,83 +156,11 @@ impl PyReductionStrategy {
             Self::ParallelReduction => ReductionStrategy::ParallelReduction,
         }
     }
-
-    fn from_native(strategy: ReductionStrategy) -> Self {
-        match strategy {
-            ReductionStrategy::Auto => Self::Auto,
-            ReductionStrategy::AtomicScatter => Self::AtomicScatter,
-            ReductionStrategy::ParallelReduction => Self::ParallelReduction,
-        }
-    }
-}
-
-#[pyclass(frozen)]
-#[pyo3(name = "AdditiveSchwarzDiagnostics")]
-pub struct PyAdditiveSchwarzDiagnostics {
-    #[pyo3(get)]
-    pub reduction_strategy: PyReductionStrategy,
-    #[pyo3(get)]
-    pub resolved_reduction_strategy: PyReductionStrategy,
-    #[pyo3(get)]
-    pub total_inner_parallel_work: usize,
-    #[pyo3(get)]
-    pub max_inner_parallel_work: usize,
-    #[pyo3(get)]
-    pub total_scatter_dofs: usize,
-    #[pyo3(get)]
-    pub outer_parallel_capacity: f64,
-    #[pyo3(get)]
-    pub scatter_overlap: f64,
-}
-
-impl PyAdditiveSchwarzDiagnostics {
-    fn from_native(preconditioner: &FePreconditioner) -> Option<Self> {
-        let diagnostics = preconditioner.additive_schwarz_diagnostics()?;
-        Some(Self {
-            reduction_strategy: PyReductionStrategy::from_native(
-                preconditioner.additive_reduction_strategy()?,
-            ),
-            resolved_reduction_strategy: PyReductionStrategy::from_native(
-                preconditioner.resolved_additive_reduction_strategy()?,
-            ),
-            total_inner_parallel_work: diagnostics.total_inner_parallel_work(),
-            max_inner_parallel_work: diagnostics.max_inner_parallel_work(),
-            total_scatter_dofs: diagnostics.total_scatter_dofs(),
-            outer_parallel_capacity: diagnostics.outer_parallel_capacity(),
-            scatter_overlap: diagnostics.scatter_overlap(),
-        })
-    }
-}
-
-#[pymethods]
-impl PyAdditiveSchwarzDiagnostics {
-    fn __repr__(&self) -> String {
-        format!(
-            concat!(
-                "AdditiveSchwarzDiagnostics(",
-                "reduction_strategy={:?}, ",
-                "resolved_reduction_strategy={:?}, ",
-                "total_inner_parallel_work={}, ",
-                "max_inner_parallel_work={}, ",
-                "total_scatter_dofs={}, ",
-                "outer_parallel_capacity={:.3}, ",
-                "scatter_overlap={:.3})"
-            ),
-            self.reduction_strategy,
-            self.resolved_reduction_strategy,
-            self.total_inner_parallel_work,
-            self.max_inner_parallel_work,
-            self.total_scatter_dofs,
-            self.outer_parallel_capacity,
-            self.scatter_overlap,
-        )
-    }
 }
 
 // ---------------------------------------------------------------------------
 // Local solver config classes (available via `_within` for benchmarks)
 // ---------------------------------------------------------------------------
-
 #[pyclass(frozen)]
 #[pyo3(name = "SchurComplement")]
 pub struct PySchurComplement {
@@ -702,11 +630,6 @@ impl PyFePreconditioner {
         self.inner.subdomain_inner_parallel_work()
     }
 
-    /// Additive Schwarz diagnostics.
-    fn additive_schwarz_diagnostics(&self) -> Option<PyAdditiveSchwarzDiagnostics> {
-        PyAdditiveSchwarzDiagnostics::from_native(&self.inner)
-    }
-
     fn __repr__(&self) -> String {
         format!("FePreconditioner(Additive, n={})", self.inner.nrows())
     }
@@ -878,7 +801,6 @@ fn _within(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyBatchSolveResult>()?;
     m.add_class::<PyLSMR>()?;
     m.add_class::<PyAdditiveSchwarz>()?;
-    m.add_class::<PyAdditiveSchwarzDiagnostics>()?;
     m.add_class::<PyReductionStrategy>()?;
     m.add_class::<PyPreconditioner>()?;
     m.add_class::<PyApproxCholConfig>()?;

--- a/crates/within/src/operator/preconditioner.rs
+++ b/crates/within/src/operator/preconditioner.rs
@@ -13,7 +13,7 @@
 //! handling flows through `try_apply` for graceful reporting of local-solver
 //! failures.
 
-use schwarz_precond::{AdditiveSchwarzDiagnostics, LocalSolver, Operator, ReductionStrategy};
+use schwarz_precond::{LocalSolver, Operator, ReductionStrategy};
 use serde::{Deserialize, Serialize};
 
 use crate::config::Preconditioner;
@@ -63,13 +63,6 @@ impl FePreconditioner {
     pub fn resolved_additive_reduction_strategy(&self) -> Option<ReductionStrategy> {
         match self {
             Self::Additive(p) => Some(p.resolved_reduction_strategy()),
-        }
-    }
-
-    /// Build-time additive Schwarz scheduling diagnostics, if applicable.
-    pub fn additive_schwarz_diagnostics(&self) -> Option<AdditiveSchwarzDiagnostics> {
-        match self {
-            Self::Additive(p) => Some(p.diagnostics()),
         }
     }
 }

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -64,11 +64,6 @@ impl FeSchwarz {
         self.0.resolved_reduction_strategy()
     }
 
-    /// Subdomain diagnostics (sizes, overlap counts).
-    pub fn diagnostics(&self) -> schwarz_precond::AdditiveSchwarzDiagnostics {
-        self.0.diagnostics()
-    }
-
     /// Apply the preconditioner, returning an error on local-solver failure.
     pub fn try_apply(&self, r: &[f64], z: &mut [f64]) -> Result<(), schwarz_precond::ApplyError> {
         self.0.try_apply(r, z)

--- a/crates/within/src/operator/tests.rs
+++ b/crates/within/src/operator/tests.rs
@@ -601,9 +601,15 @@ mod schwarz_tests {
                 reduction.resolved_reduction_strategy(),
                 ReductionStrategy::ParallelReduction
             );
-            assert_eq!(reduction.diagnostics().n_subdomains(), 2);
+            assert_eq!(reduction.subdomains().len(), 2);
+            let max_inner_work = reduction
+                .subdomains()
+                .iter()
+                .map(|entry| entry.solver().inner_parallelism_work_estimate())
+                .max()
+                .unwrap_or(0);
             assert!(
-                reduction.diagnostics().max_inner_parallel_work() > 200_000,
+                max_inner_work > 200_000,
                 "test setup must force nested local-solver parallelism"
             );
 

--- a/python/within/__init__.py
+++ b/python/within/__init__.py
@@ -52,7 +52,6 @@ from within._within import (
     solve,
     solve_batch,
     AdditiveSchwarz,
-    AdditiveSchwarzDiagnostics,
     ReductionStrategy,
 )
 
@@ -66,6 +65,5 @@ __all__ = [
     "solve",
     "solve_batch",
     "AdditiveSchwarz",
-    "AdditiveSchwarzDiagnostics",
     "ReductionStrategy",
 ]

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -36,43 +36,6 @@ class ReductionStrategy(IntEnum):
     AtomicScatter = 1
     ParallelReduction = 2
 
-class AdditiveSchwarzDiagnostics:
-    """Diagnostics for an additive Schwarz preconditioner.
-
-    Provides insight into the parallel structure and work distribution
-    across subdomains. Useful for performance tuning.
-    """
-
-    @property
-    def reduction_strategy(self) -> ReductionStrategy:
-        """The configured reduction strategy (may be ``Auto``)."""
-        ...
-    @property
-    def resolved_reduction_strategy(self) -> ReductionStrategy:
-        """The actual strategy chosen after resolving ``Auto``."""
-        ...
-    @property
-    def total_inner_parallel_work(self) -> int:
-        """Sum of inner parallel work across all subdomains."""
-        ...
-    @property
-    def max_inner_parallel_work(self) -> int:
-        """Maximum inner parallel work in any single subdomain."""
-        ...
-    @property
-    def total_scatter_dofs(self) -> int:
-        """Total number of DOFs scattered across subdomains (with overlap)."""
-        ...
-    @property
-    def outer_parallel_capacity(self) -> float:
-        """Ratio indicating how well the outer loop parallelises (higher is better)."""
-        ...
-    @property
-    def scatter_overlap(self) -> float:
-        """Ratio of scattered DOFs to unique DOFs (1.0 = no overlap)."""
-        ...
-    def __repr__(self) -> str: ...
-
 class LSMR:
     """Modified LSMR solver configuration.
 
@@ -257,10 +220,6 @@ class FePreconditioner:
         ...
     def subdomain_inner_parallel_work(self) -> list[int]:
         """Estimated inner-parallel work per subdomain."""
-        ...
-    def additive_schwarz_diagnostics(self) -> AdditiveSchwarzDiagnostics | None:
-        """Diagnostics for the additive Schwarz scheduling. Returns ``None``
-        if this preconditioner is not the additive variant."""
         ...
     def __repr__(self) -> str: ...
     def __reduce__(self) -> tuple: ...

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -6,7 +6,7 @@ import numpy as np
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-from within import Preconditioner, Solver, solve
+from within import Solver, solve
 from within import AdditiveSchwarz, ReductionStrategy
 
 
@@ -271,22 +271,6 @@ class TestAdvancedPreconditioners:
         )
         if r_atomic.converged and r_parallel.converged:
             np.testing.assert_allclose(r_atomic.x, r_parallel.x, atol=1e-4)
-
-    def test_additive_schwarz_diagnostics_available(self):
-        """FePreconditioner built with additive Schwarz should expose diagnostics."""
-        rng = np.random.default_rng(5)
-        categories = np.asfortranarray(
-            np.column_stack(
-                [rng.integers(0, 10, size=300), rng.integers(0, 10, size=300)]
-            ).astype(np.uint32)
-        )
-        solver = Solver(categories, preconditioner=Preconditioner.Additive)
-        precond = solver.preconditioner()
-        assert precond is not None
-        diag = precond.additive_schwarz_diagnostics()
-        assert diag is not None
-        assert diag.total_inner_parallel_work >= 0
-        assert diag.total_scatter_dofs >= 0
 
 
 class TestBatchProperties:


### PR DESCRIPTION
## Summary

- Removes `AdditiveSchwarzDiagnostics` (Rust struct, `pub use` re-exports, Python class, `additive_schwarz_diagnostics` accessors at every layer).
- Inlines the 5 scheduling metrics directly into `AdditiveScheduler` — they remain private to the `Auto` heuristic.
- Keeps `ReductionStrategy` and the `Preconditioner::Additive(_, ReductionStrategy)` knob unchanged: the wall-clock-vs-memory tradeoff (12x peak memory at scale) is a real user concern.

Closes #34.

## Why

Empirical bake-off across small / medium / huge regimes (see the issue comments) showed:

- `Auto`'s wall-clock decisions are within the ~5% measurement noise floor on every regime in the project's normal operating range.
- `AdditiveSchwarzDiagnostics` had **zero readers** outside the scheduler itself — no test asserted on its fields, no benchmark inspected it, no production caller read it.
- The heuristic's tuning constants are private, so an external caller could not reproduce or override decisions from the diagnostics anyway.

`ReductionStrategy` is kept because memory matters: on a 100K-DOF problem, `ParallelReduction` peaks at ~9.6 MB vs `AtomicScatter`'s ~800 KB (12x). At 1M DOFs that becomes ~96 MB vs ~8 MB. Memory-constrained or server-scenario users need the override.

## Test plan

- [x] `cargo build --workspace --release` clean
- [x] `cargo test --workspace --exclude within-py` all pass (within-py lib-test failure is the expected "PyO3 can't run standalone" issue per CLAUDE.md)
- [x] `pixi run develop` rebuilds the extension cleanly
- [x] `pytest tests/` 97/97 pass
- [x] Within nested-rayon regression test rewritten to use `subdomains().len()` and direct `inner_parallelism_work_estimate()` iteration — same assertions, no `diagnostics()` dependency