### PR TITLE
errors: consolidate vocabulary to per-crate BuildError / SolveError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,19 @@ Modified LSMR is now the sole iterative solver, replacing CG and GMRES.
   weighted `apply` / `apply_adjoint` no longer allocate. The weighted
   `apply` fuses the `W^{1/2}` multiply into the last gather pass, so
   there is no trailing scale loop.
-- `build_preconditioner` now returns `WithinError::WeightCountMismatch`
+- `build_preconditioner` now returns `BuildError::WeightCountMismatch`
   for wrong-length weights instead of panicking on out-of-bounds access
   inside `CrossTab` assembly.
+- **BREAKING:** Error vocabulary collapsed to per-crate `BuildError` /
+  `SolveError`. `schwarz_precond` absorbs three sub-enums into one
+  `BuildError`. `within::WithinError` splits into `BuildError`, a
+  `SolveError` re-export, and a thin union for `solve()` / `solve_batch()`.
+  `WithinResult` removed. `LocalSolveError::ApproxCholSolveFailed` renamed
+  to `BackendFailed`; `LocalSolveError` is now `#[non_exhaustive]`.
+  `WithinError::{Build, Solve}` are transparent — `Display` and
+  `Error::source` forward to the inner error, so the union no longer
+  appears in the error chain. Internally migrated to `thiserror` (new
+  dependency on `schwarz-precond` and `within`). Closes #30.
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,6 +1664,7 @@ dependencies = [
  "faer",
  "rayon",
  "serde",
+ "thiserror 2.0.18",
  "thread_local",
 ]
 
@@ -2324,6 +2325,7 @@ dependencies = [
  "rayon",
  "schwarz-precond",
  "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/schwarz-precond/Cargo.toml
+++ b/crates/schwarz-precond/Cargo.toml
@@ -16,4 +16,5 @@ serde = ["dep:serde"]
 rayon = "1.10"
 faer = "0.24.0"
 serde = { version = "1", features = ["derive"], optional = true }
+thiserror = "2"
 thread_local = "1.1"

--- a/crates/schwarz-precond/src/domain.rs
+++ b/crates/schwarz-precond/src/domain.rs
@@ -48,7 +48,7 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::error::SubdomainCoreBuildError;
+use crate::error::BuildError;
 
 /// Partition-of-unity weights for a subdomain.
 ///
@@ -137,7 +137,7 @@ impl SubdomainCore {
     pub fn with_partition_weights(
         global_indices: Vec<u32>,
         partition_weights: PartitionWeights,
-    ) -> Result<Self, SubdomainCoreBuildError> {
+    ) -> Result<Self, BuildError> {
         let mut core = Self::uniform(global_indices);
         core.set_partition_weights(partition_weights)?;
         Ok(core)
@@ -167,11 +167,11 @@ impl SubdomainCore {
     pub fn set_partition_weights(
         &mut self,
         partition_weights: PartitionWeights,
-    ) -> Result<(), SubdomainCoreBuildError> {
+    ) -> Result<(), BuildError> {
         let index_count = self.global_indices.len();
         let weight_count = partition_weights.len();
         if weight_count != index_count {
-            return Err(SubdomainCoreBuildError::PartitionWeightLengthMismatch {
+            return Err(BuildError::PartitionWeightLengthMismatch {
                 index_count,
                 weight_count,
             });

--- a/crates/schwarz-precond/src/error.rs
+++ b/crates/schwarz-precond/src/error.rs
@@ -1,53 +1,41 @@
 //! Error types for the `schwarz-precond` crate.
 //!
-//! Errors are layered to match the build → solve lifecycle:
+//! Errors are partitioned by lifecycle phase:
 //!
-//! - **Build errors** ([`SubdomainCoreBuildError`], [`SubdomainEntryBuildError`],
-//!   [`PreconditionerBuildError`]) — caught during construction, before any
-//!   solve begins.
-//! - **Solve errors** ([`SolveError`]) — runtime failures during a solve,
-//!   including operator/preconditioner application (e.g. a local solver
-//!   diverges) and iterative-solver input validation.
+//! - **Build** ([`BuildError`]) — caught during construction, before any
+//!   solve begins. Covers partition-weight validation, subdomain DOF/scratch
+//!   contracts, and preconditioner-wide index checks.
+//! - **Solve** ([`SolveError`]) — runtime failures during a solve, including
+//!   operator/preconditioner application (e.g. a local solver diverges) and
+//!   iterative-solver input validation.
 //!
-//! Each level chains to its source via [`Error::source`].
+//! [`LocalSolveError`] is the narrow trait contract returned by
+//! [`LocalSolver::solve_local`](crate::LocalSolver::solve_local). The Schwarz
+//! executor lifts it into [`SolveError::LocalSolveFailed`] at the one apply
+//! site that knows the subdomain index, so there is no `From` chain between
+//! the two.
 
-use std::error::Error;
-use std::fmt::{Display, Formatter};
+use thiserror::Error;
 
 use crate::local_solve::{LocalSolver, SubdomainEntry};
 
-/// Construction-time validation errors for a [`crate::SubdomainCore`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SubdomainCoreBuildError {
+/// Construction-time validation errors for the Schwarz building blocks.
+///
+/// Consolidates failures from subdomain core/entry construction and
+/// preconditioner-wide index checks into a single flat enum.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum BuildError {
     /// Partition-of-unity weight vector length does not match index count.
+    #[error("partition weight count ({weight_count}) does not match index count ({index_count})")]
     PartitionWeightLengthMismatch {
         /// Number of global indices in the subdomain core.
         index_count: usize,
         /// Number of partition weights in the subdomain core.
         weight_count: usize,
     },
-}
-
-impl Display for SubdomainCoreBuildError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::PartitionWeightLengthMismatch {
-                index_count,
-                weight_count,
-            } => write!(
-                f,
-                "partition weight count ({weight_count}) does not match index count ({index_count})",
-            ),
-        }
-    }
-}
-
-impl Error for SubdomainCoreBuildError {}
-
-/// Construction-time validation errors for a [`crate::SubdomainEntry`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SubdomainEntryBuildError {
     /// Local solver `n_local` does not match the subdomain index count.
+    #[error("index count ({index_count}) does not match solver n_local ({solver_n_local})")]
     LocalDofCountMismatch {
         /// Number of global indices in the subdomain core.
         index_count: usize,
@@ -55,41 +43,17 @@ pub enum SubdomainEntryBuildError {
         solver_n_local: usize,
     },
     /// Local solver scratch size is too small for the subdomain gather/scatter buffers.
+    #[error("scratch size ({scratch_size}) is smaller than required minimum ({required_min})")]
     ScratchSizeTooSmall {
         /// Scratch size reported by the local solver.
         scratch_size: usize,
         /// Minimum scratch size required by the subdomain core.
         required_min: usize,
     },
-}
-
-impl Display for SubdomainEntryBuildError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::LocalDofCountMismatch {
-                index_count,
-                solver_n_local,
-            } => write!(
-                f,
-                "index count ({index_count}) does not match solver n_local ({solver_n_local})",
-            ),
-            Self::ScratchSizeTooSmall {
-                scratch_size,
-                required_min,
-            } => write!(
-                f,
-                "scratch size ({scratch_size}) is smaller than required minimum ({required_min})",
-            ),
-        }
-    }
-}
-
-impl Error for SubdomainEntryBuildError {}
-
-/// Construction-time validation errors for Schwarz preconditioners.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PreconditionerBuildError {
     /// A subdomain references a global DOF outside `[0, n_dofs)`.
+    #[error(
+        "subdomain {subdomain}: global index at local position {local_index} is out of bounds ({global_index} >= {n_dofs})"
+    )]
     GlobalIndexOutOfBounds {
         /// Index of the failing subdomain entry in the provided list.
         subdomain: usize,
@@ -102,29 +66,18 @@ pub enum PreconditionerBuildError {
     },
 }
 
-impl Display for PreconditionerBuildError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::GlobalIndexOutOfBounds {
-                subdomain,
-                local_index,
-                global_index,
-                n_dofs,
-            } => write!(
-                f,
-                "subdomain {subdomain}: global index at local position {local_index} is out of bounds ({global_index} >= {n_dofs})",
-            ),
-        }
-    }
-}
-
-impl Error for PreconditionerBuildError {}
-
 /// Runtime error emitted by a local subdomain solver during a solve call.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Returned by [`LocalSolver::solve_local`](crate::LocalSolver::solve_local).
+/// Backend-agnostic by design: backends report a `context` site and a
+/// free-form `message` rather than enumerating their internal error modes
+/// through this generic crate.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum LocalSolveError {
-    /// Approximate Cholesky back-substitution failed.
-    ApproxCholSolveFailed {
+    /// The backend implementation reported a failure during a local solve.
+    #[error("{context}: {message}")]
+    BackendFailed {
         /// Context string identifying where the failure occurred.
         context: &'static str,
         /// Backend error text.
@@ -132,38 +85,30 @@ pub enum LocalSolveError {
     },
 }
 
-impl Display for LocalSolveError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ApproxCholSolveFailed { context, message } => {
-                write!(f, "{context}: {message}")
-            }
-        }
-    }
-}
-
-impl Error for LocalSolveError {}
-
 /// Runtime failure while executing a solve.
 ///
 /// Covers both operator/preconditioner application failures (e.g. a local
 /// solver diverges) and iterative-solver input validation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum SolveError {
     /// A local subdomain solve failed during a preconditioner apply.
+    #[error("subdomain {subdomain} local solve failed: {source}")]
     LocalSolveFailed {
         /// Index of the failing subdomain entry in the preconditioner.
         subdomain: usize,
         /// Local solver error.
+        #[source]
         source: LocalSolveError,
     },
     /// Internal synchronization failed (e.g. poisoned mutex) during an apply.
+    #[error("synchronization failure at {context}")]
     Synchronization {
         /// Context string identifying the lock/synchronization site.
         context: &'static str,
     },
     /// Solver input was invalid before any iteration was attempted.
+    #[error("invalid solver input at {context}: {message}")]
     InvalidInput {
         /// Context string identifying the validation site.
         context: &'static str,
@@ -172,40 +117,14 @@ pub enum SolveError {
     },
 }
 
-impl Display for SolveError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::LocalSolveFailed { subdomain, source } => {
-                write!(f, "subdomain {subdomain} local solve failed: {source}")
-            }
-            Self::Synchronization { context } => {
-                write!(f, "synchronization failure at {context}")
-            }
-            Self::InvalidInput { context, message } => {
-                write!(f, "invalid solver input at {context}: {message}")
-            }
-        }
-    }
-}
-
-impl Error for SolveError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::LocalSolveFailed { source, .. } => Some(source),
-            Self::Synchronization { .. } => None,
-            Self::InvalidInput { .. } => None,
-        }
-    }
-}
-
 pub(crate) fn validate_entries<S: LocalSolver>(
     entries: &[SubdomainEntry<S>],
     n_dofs: usize,
-) -> Result<(), PreconditionerBuildError> {
+) -> Result<(), BuildError> {
     for (subdomain, entry) in entries.iter().enumerate() {
         for (local_index, &global_index) in entry.global_indices().iter().enumerate() {
             if (global_index as usize) >= n_dofs {
-                return Err(PreconditionerBuildError::GlobalIndexOutOfBounds {
+                return Err(BuildError::GlobalIndexOutOfBounds {
                     subdomain,
                     local_index,
                     global_index,

--- a/crates/schwarz-precond/src/lib.rs
+++ b/crates/schwarz-precond/src/lib.rs
@@ -123,10 +123,7 @@ mod schwarz;
 mod sparse_matrix;
 
 pub use domain::{PartitionWeights, SubdomainCore};
-pub use error::{
-    LocalSolveError, PreconditionerBuildError, SolveError, SubdomainCoreBuildError,
-    SubdomainEntryBuildError,
-};
+pub use error::{BuildError, LocalSolveError, SolveError};
 pub use local_solve::{LocalSolver, SubdomainEntry};
 pub use lsmr::{lsmr, mlsmr, LsmrResult, LsmrStopReason};
 pub use schwarz::{ReductionStrategy, SchwarzPreconditioner};

--- a/crates/schwarz-precond/src/local_solve.rs
+++ b/crates/schwarz-precond/src/local_solve.rs
@@ -15,7 +15,7 @@
 use std::sync::atomic::AtomicU64;
 
 use crate::domain::SubdomainCore;
-use crate::error::{LocalSolveError, SubdomainEntryBuildError};
+use crate::error::{BuildError, LocalSolveError};
 
 // ---------------------------------------------------------------------------
 // LocalSolver trait
@@ -78,11 +78,11 @@ pub struct SubdomainEntry<S: LocalSolver> {
 
 impl<S: LocalSolver> SubdomainEntry<S> {
     /// Create a validated subdomain entry from a core and a local solver.
-    pub fn try_new(core: SubdomainCore, solver: S) -> Result<Self, SubdomainEntryBuildError> {
+    pub fn try_new(core: SubdomainCore, solver: S) -> Result<Self, BuildError> {
         let index_count = core.n_local();
         let solver_n_local = solver.n_local();
         if solver_n_local != index_count {
-            return Err(SubdomainEntryBuildError::LocalDofCountMismatch {
+            return Err(BuildError::LocalDofCountMismatch {
                 index_count,
                 solver_n_local,
             });
@@ -90,7 +90,7 @@ impl<S: LocalSolver> SubdomainEntry<S> {
 
         let scratch_size = solver.scratch_size();
         if scratch_size < index_count {
-            return Err(SubdomainEntryBuildError::ScratchSizeTooSmall {
+            return Err(BuildError::ScratchSizeTooSmall {
                 scratch_size,
                 required_min: index_count,
             });

--- a/crates/schwarz-precond/src/schwarz/preconditioner.rs
+++ b/crates/schwarz-precond/src/schwarz/preconditioner.rs
@@ -6,7 +6,7 @@
 //! the executor. `apply` is lock-free in steady state (buffers are
 //! borrowed from a pool).
 
-use crate::error::{validate_entries, PreconditionerBuildError, SolveError};
+use crate::error::{validate_entries, BuildError, SolveError};
 use crate::local_solve::{LocalSolver, SubdomainEntry};
 use crate::Operator;
 
@@ -77,10 +77,7 @@ pub struct SchwarzPreconditioner<S: LocalSolver> {
 
 impl<S: LocalSolver> SchwarzPreconditioner<S> {
     /// Construct from pre-built subdomain entries using the default strategy.
-    pub fn new(
-        entries: Vec<SubdomainEntry<S>>,
-        n_dofs: usize,
-    ) -> Result<Self, PreconditionerBuildError> {
+    pub fn new(entries: Vec<SubdomainEntry<S>>, n_dofs: usize) -> Result<Self, BuildError> {
         Self::with_strategy(entries, n_dofs, ReductionStrategy::default())
     }
 
@@ -89,7 +86,7 @@ impl<S: LocalSolver> SchwarzPreconditioner<S> {
         entries: Vec<SubdomainEntry<S>>,
         n_dofs: usize,
         strategy: ReductionStrategy,
-    ) -> Result<Self, PreconditionerBuildError> {
+    ) -> Result<Self, BuildError> {
         validate_entries(&entries, n_dofs)?;
         let max_scratch_size = entries
             .iter()

--- a/crates/schwarz-precond/tests/common/mod.rs
+++ b/crates/schwarz-precond/tests/common/mod.rs
@@ -115,7 +115,7 @@ pub fn make_schwarz_entries(n: usize) -> Vec<SubdomainEntry<UniformDiagLocalSolv
     entries
 }
 
-/// Local solver that always fails with `ApproxCholSolveFailed`.
+/// Local solver that always fails with `BackendFailed`.
 pub struct FailingLocalSolver {
     pub n_local: usize,
     pub scratch_size: usize,
@@ -134,7 +134,7 @@ impl LocalSolver for FailingLocalSolver {
         _sol: &mut [f64],
         _allow_inner_parallelism: bool,
     ) -> Result<(), LocalSolveError> {
-        Err(LocalSolveError::ApproxCholSolveFailed {
+        Err(LocalSolveError::BackendFailed {
             context: "test.failing_local_solver",
             message: format!("deliberate failure for n={}", self.n_local),
         })

--- a/crates/schwarz-precond/tests/schwarz.rs
+++ b/crates/schwarz-precond/tests/schwarz.rs
@@ -390,9 +390,7 @@ fn test_additive_auto_matches_resolved_backend() {
     }
 }
 
-use schwarz_precond::{
-    PreconditionerBuildError, SolveError, SubdomainCoreBuildError, SubdomainEntryBuildError,
-};
+use schwarz_precond::{BuildError, SolveError};
 use std::error::Error;
 
 // ============================================================================
@@ -444,7 +442,7 @@ fn test_additive_schwarz_apply_subdomain_empty_indices() {
 
 #[test]
 fn test_subdomain_entry_build_error_display_local_dof_mismatch() {
-    let err = SubdomainEntryBuildError::LocalDofCountMismatch {
+    let err = BuildError::LocalDofCountMismatch {
         index_count: 5,
         solver_n_local: 3,
     };
@@ -455,7 +453,7 @@ fn test_subdomain_entry_build_error_display_local_dof_mismatch() {
 
 #[test]
 fn test_subdomain_entry_build_error_display_scratch_size_too_small() {
-    let err = SubdomainEntryBuildError::ScratchSizeTooSmall {
+    let err = BuildError::ScratchSizeTooSmall {
         scratch_size: 2,
         required_min: 4,
     };
@@ -466,7 +464,7 @@ fn test_subdomain_entry_build_error_display_scratch_size_too_small() {
 
 #[test]
 fn test_subdomain_core_build_error_display_partition_weight_mismatch() {
-    let err = SubdomainCoreBuildError::PartitionWeightLengthMismatch {
+    let err = BuildError::PartitionWeightLengthMismatch {
         index_count: 3,
         weight_count: 5,
     };
@@ -477,7 +475,7 @@ fn test_subdomain_core_build_error_display_partition_weight_mismatch() {
 
 #[test]
 fn test_preconditioner_build_error_display_global_index_out_of_bounds() {
-    let err = PreconditionerBuildError::GlobalIndexOutOfBounds {
+    let err = BuildError::GlobalIndexOutOfBounds {
         subdomain: 3,
         local_index: 1,
         global_index: 99,
@@ -494,7 +492,7 @@ fn test_preconditioner_build_error_display_global_index_out_of_bounds() {
 
 #[test]
 fn test_local_solve_error_display() {
-    let err = LocalSolveError::ApproxCholSolveFailed {
+    let err = LocalSolveError::BackendFailed {
         context: "backsolve",
         message: "singular matrix".to_string(),
     };
@@ -505,7 +503,7 @@ fn test_local_solve_error_display() {
 
 #[test]
 fn test_solve_error_display_local_solve_failed() {
-    let local_err = LocalSolveError::ApproxCholSolveFailed {
+    let local_err = LocalSolveError::BackendFailed {
         context: "test",
         message: "fail".to_string(),
     };
@@ -536,7 +534,7 @@ fn test_solve_error_display_synchronization() {
 
 #[test]
 fn test_solve_error_source() {
-    let local_err = LocalSolveError::ApproxCholSolveFailed {
+    let local_err = LocalSolveError::BackendFailed {
         context: "test",
         message: "err".to_string(),
     };
@@ -578,7 +576,7 @@ fn test_validate_local_dof_count_mismatch() {
     let core = SubdomainCore::uniform(vec![0, 1]); // 2 indices
     let result = SubdomainEntry::try_new(core, solver);
     match result {
-        Err(SubdomainEntryBuildError::LocalDofCountMismatch { .. }) => {}
+        Err(BuildError::LocalDofCountMismatch { .. }) => {}
         Ok(_) => panic!("expected LocalDofCountMismatch, got Ok"),
         Err(other) => panic!("expected LocalDofCountMismatch, got: {:?}", other),
     }
@@ -591,8 +589,9 @@ fn test_validate_global_index_out_of_bounds() {
     let entry = make_entry(core, solver);
     let result = SchwarzPreconditioner::new(vec![entry], 5);
     match result {
-        Err(PreconditionerBuildError::GlobalIndexOutOfBounds { .. }) => {}
+        Err(BuildError::GlobalIndexOutOfBounds { .. }) => {}
         Ok(_) => panic!("expected GlobalIndexOutOfBounds, got Ok"),
+        Err(other) => panic!("expected GlobalIndexOutOfBounds, got: {:?}", other),
     }
 }
 
@@ -603,8 +602,9 @@ fn test_validate_partition_weight_length_mismatch() {
         PartitionWeights::NonUniform(vec![1.0, 0.5, 0.3]),
     );
     match result {
-        Err(SubdomainCoreBuildError::PartitionWeightLengthMismatch { .. }) => {}
+        Err(BuildError::PartitionWeightLengthMismatch { .. }) => {}
         Ok(_) => panic!("expected PartitionWeightLengthMismatch, got Ok"),
+        Err(other) => panic!("expected PartitionWeightLengthMismatch, got: {:?}", other),
     }
 }
 

--- a/crates/within/Cargo.toml
+++ b/crates/within/Cargo.toml
@@ -18,6 +18,7 @@ ndarray = "0.16"
 portable-atomic = { version = "1", features = ["float"] }
 rayon = "1.10"
 faer = "0.24.0"
+thiserror = "2"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -76,7 +76,7 @@ impl std::fmt::Debug for Subdomain {
 // ===========================================================================
 
 use crate::observation::{FactorMeta, Store};
-use crate::{WithinError, WithinResult};
+use crate::BuildError;
 
 /// Fixed-effects design, generic over observation storage.
 ///
@@ -119,9 +119,9 @@ impl<S: Store + std::fmt::Debug> std::fmt::Debug for Design<S> {
 impl<S: Store> Design<S> {
     /// Construct from a store, inferring the number of levels per factor
     /// from the maximum observed level in each column (`max + 1`).
-    pub fn from_store(store: S) -> WithinResult<Self> {
+    pub fn from_store(store: S) -> Result<Self, BuildError> {
         if store.n_obs() == 0 {
-            return Err(WithinError::EmptyObservations);
+            return Err(BuildError::EmptyObservations);
         }
 
         let mut factors = Vec::with_capacity(store.n_factors());

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -1,31 +1,33 @@
 //! Error types for the `within` crate.
 //!
-//! Errors fall into three categories:
+//! Errors are partitioned by lifecycle phase:
 //!
-//! | Category | Variants | When it happens |
-//! |---|---|---|
-//! | **Validation** | [`WithinError::EmptyObservations`], [`ObservationCountMismatch`](WithinError::ObservationCountMismatch), [`WeightCountMismatch`](WithinError::WeightCountMismatch) | Bad input detected before any computation begins. |
-//! | **Build** | [`SingularDiagonal`](WithinError::SingularDiagonal), [`LocalSolverBuild`](WithinError::LocalSolverBuild), [`PreconditionerBuild`](WithinError::PreconditionerBuild) | Construction of operators or preconditioners fails due to degenerate data (e.g., a factor with zero observations at some level). |
-//! | **Runtime** | [`WithinError::IterativeSolve`] | The iterative solver diverges or exceeds the iteration limit. Wraps [`schwarz_precond::SolveError`]. |
+//! - **Build** ([`BuildError`]) — input validation and operator/preconditioner
+//!   construction failures.
+//! - **Solve** ([`SolveError`]) — runtime failures during the iterative solve.
+//!   Re-exported from [`schwarz_precond`] because this crate adds no new
+//!   solve-time failure modes.
+//! - **Union** ([`WithinError`]) — a thin convenience union used by
+//!   [`crate::solve`] and [`crate::solve_batch`] so callers see a single
+//!   error type at the top-level API boundary.
 //!
-//! All public APIs in this crate return [`WithinResult<T>`], which is
-//! `Result<T, WithinError>`. The build and runtime variants implement
-//! [`Error::source`] to chain the underlying `schwarz_precond` error.
+//! Per-phase functions return [`Result<T, BuildError>`] or
+//! [`Result<T, SolveError>`] directly. Only the top-level convenience
+//! wrappers return [`WithinError`].
 
-use std::error::Error;
-use std::fmt::{Display, Formatter};
+use thiserror::Error;
 
-use schwarz_precond::{PreconditionerBuildError, SolveError};
-
-/// Result alias used by fallible public APIs in this crate.
-pub type WithinResult<T> = Result<T, WithinError>;
+pub use schwarz_precond::SolveError;
 
 /// Errors produced while validating inputs or building solver components.
-#[derive(Debug)]
-pub enum WithinError {
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum BuildError {
     /// No observations provided.
+    #[error("no observations provided")]
     EmptyObservations,
     /// One factor column does not match the expected observation count.
+    #[error("factor {factor} has {got} observations, expected {expected}")]
     ObservationCountMismatch {
         /// Index of the factor with mismatched length.
         factor: usize,
@@ -35,6 +37,7 @@ pub enum WithinError {
         got: usize,
     },
     /// Weight vector does not match the number of observations.
+    #[error("weights has length {got}, expected {expected}")]
     WeightCountMismatch {
         /// Expected number of weights.
         expected: usize,
@@ -42,6 +45,7 @@ pub enum WithinError {
         got: usize,
     },
     /// A zero diagonal was encountered during block elimination.
+    #[error("zero diagonal in {block} block at index {index}")]
     SingularDiagonal {
         /// Which block contained the zero diagonal ("keep" or "elim").
         block: &'static str,
@@ -49,56 +53,30 @@ pub enum WithinError {
         index: usize,
     },
     /// Local solver construction failed.
+    #[error("local solver build failed: {0}")]
     LocalSolverBuild(String),
-    /// Preconditioner structural validation failed.
-    PreconditionerBuild(PreconditionerBuildError),
-    /// Iterative solver runtime error.
-    IterativeSolve(SolveError),
+    /// Schwarz preconditioner structural validation failed.
+    ///
+    /// Lifted from [`schwarz_precond::BuildError`] explicitly at call sites
+    /// via `.map_err(BuildError::Preconditioner)`; no `From` conversion is
+    /// provided so the cross-crate boundary stays visible.
+    #[error("preconditioner build failed: {0}")]
+    Preconditioner(#[source] schwarz_precond::BuildError),
 }
 
-impl Display for WithinError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::EmptyObservations => write!(f, "no observations provided"),
-            Self::ObservationCountMismatch {
-                factor,
-                expected,
-                got,
-            } => write!(
-                f,
-                "factor {factor} has {got} observations, expected {expected}",
-            ),
-            Self::WeightCountMismatch { expected, got } => {
-                write!(f, "weights has length {got}, expected {expected}")
-            }
-            Self::SingularDiagonal { block, index } => {
-                write!(f, "zero diagonal in {block} block at index {index}")
-            }
-            Self::LocalSolverBuild(msg) => write!(f, "local solver build failed: {msg}"),
-            Self::PreconditionerBuild(err) => write!(f, "{err}"),
-            Self::IterativeSolve(err) => write!(f, "{err}"),
-        }
-    }
-}
-
-impl Error for WithinError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::PreconditionerBuild(err) => Some(err),
-            Self::IterativeSolve(err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
-impl From<PreconditionerBuildError> for WithinError {
-    fn from(value: PreconditionerBuildError) -> Self {
-        Self::PreconditionerBuild(value)
-    }
-}
-
-impl From<SolveError> for WithinError {
-    fn from(value: SolveError) -> Self {
-        Self::IterativeSolve(value)
-    }
+/// Top-level error type returned by [`crate::solve`] and [`crate::solve_batch`].
+///
+/// Lifts the per-phase [`BuildError`] / [`SolveError`] pair into a single
+/// union at the convenience-wrapper boundary. Per-phase APIs do not return
+/// this type. The wrapping variants are transparent: [`Display`] and
+/// [`Error::source`] both forward to the inner error, so the union does not
+/// appear in the error chain.
+#[derive(Debug, Error)]
+pub enum WithinError {
+    /// Build-time failure: validation or operator/preconditioner construction.
+    #[error(transparent)]
+    Build(#[from] BuildError),
+    /// Solve-time failure: iterative solver runtime error.
+    #[error(transparent)]
+    Solve(#[from] SolveError),
 }

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -106,7 +106,7 @@
 //! ├── solver              Persistent Solver<S> with preconditioner reuse
 //! ├── orchestrate         Public API: solve(), solve_batch()
 //! ├── config              SolverParams, Preconditioner, LocalSolverConfig
-//! └── error               WithinError, WithinResult<T>
+//! └── error               BuildError, SolveError, WithinError
 //! ```
 //!
 //! # Crate dependency tree
@@ -183,7 +183,7 @@ pub use config::{
     ApproxCholConfig, ApproxSchurConfig, LocalSolverConfig, Preconditioner, ReductionStrategy,
     SolverParams, DEFAULT_DENSE_SCHUR_THRESHOLD,
 };
-pub use error::{WithinError, WithinResult};
+pub use error::{BuildError, SolveError, WithinError};
 pub use orchestrate::SolveResult;
 
 // ---------------------------------------------------------------------------

--- a/crates/within/src/observation.rs
+++ b/crates/within/src/observation.rs
@@ -44,7 +44,7 @@
 
 use ndarray::ArrayView2;
 
-use crate::error::{WithinError, WithinResult};
+use crate::error::BuildError;
 
 // ---------------------------------------------------------------------------
 // FactorMeta — per-factor metadata (no observation data)
@@ -107,10 +107,10 @@ pub struct FactorMajorStore {
 
 impl FactorMajorStore {
     /// Create a new factor-major store, validating that all columns have length `n_obs`.
-    pub fn new(factor_levels: Vec<Vec<u32>>, n_obs: usize) -> WithinResult<Self> {
+    pub fn new(factor_levels: Vec<Vec<u32>>, n_obs: usize) -> Result<Self, BuildError> {
         for (factor, col) in factor_levels.iter().enumerate() {
             if col.len() != n_obs {
-                return Err(WithinError::ObservationCountMismatch {
+                return Err(BuildError::ObservationCountMismatch {
                     factor,
                     expected: n_obs,
                     got: col.len(),
@@ -173,7 +173,7 @@ pub struct ArrayStore<'a> {
 
 impl<'a> ArrayStore<'a> {
     /// Create a zero-copy store from a borrowed 2-D category array.
-    pub fn new(categories: ArrayView2<'a, u32>) -> WithinResult<Self> {
+    pub fn new(categories: ArrayView2<'a, u32>) -> Result<Self, BuildError> {
         Ok(Self { categories })
     }
 }
@@ -217,10 +217,10 @@ impl Store for ArrayStore<'_> {
 ///
 /// `None` is always valid (interpreted as unit weights). `Some(w)` requires
 /// `w.len() == n_obs`.
-pub(crate) fn validate_weights(weights: Option<&[f64]>, n_obs: usize) -> WithinResult<()> {
+pub(crate) fn validate_weights(weights: Option<&[f64]>, n_obs: usize) -> Result<(), BuildError> {
     if let Some(w) = weights {
         if w.len() != n_obs {
-            return Err(WithinError::WeightCountMismatch {
+            return Err(BuildError::WeightCountMismatch {
                 expected: n_obs,
                 got: w.len(),
             });

--- a/crates/within/src/operator.rs
+++ b/crates/within/src/operator.rs
@@ -288,7 +288,7 @@ impl<'a, S: Store> DesignOperator<'a, S> {
     ///
     /// Panics when `weights.is_some()` and `weights.unwrap().len()` does not
     /// equal `design.n_rows`. The `Solver` entry points perform fallible
-    /// validation against `WithinError::WeightCountMismatch` before
+    /// validation against `BuildError::WeightCountMismatch` before
     /// construction, so callers that go through `Solver::from_design` or
     /// `solve()` never trigger this panic.
     pub fn new(design: &'a Design<S>, weights: Option<&[f64]>) -> Self {

--- a/crates/within/src/operator/local_solver.rs
+++ b/crates/within/src/operator/local_solver.rs
@@ -165,7 +165,7 @@ impl ReducedFactor {
             Self::Approx(f) => {
                 debug_assert_eq!(f.n(), x.len());
                 f.solve_in_place(x)
-                    .map_err(|e| LocalSolveError::ApproxCholSolveFailed {
+                    .map_err(|e| LocalSolveError::BackendFailed {
                         context: "within.local.block_elim.reduced_approx",
                         message: e.to_string(),
                     })?;

--- a/crates/within/src/operator/preconditioner.rs
+++ b/crates/within/src/operator/preconditioner.rs
@@ -20,7 +20,7 @@ use crate::config::Preconditioner;
 use crate::domain::Design;
 use crate::observation::{validate_weights, Store};
 use crate::operator::schwarz::{build_additive_with_strategy, FeSchwarz};
-use crate::WithinResult;
+use crate::BuildError;
 
 /// A pre-built preconditioner ready for use in LSMR solves.
 ///
@@ -99,7 +99,7 @@ pub fn build_preconditioner<S: Store>(
     design: &Design<S>,
     weights: Option<&[f64]>,
     config: &Preconditioner,
-) -> WithinResult<FePreconditioner> {
+) -> Result<FePreconditioner, BuildError> {
     use crate::domain::build_local_domains;
 
     validate_weights(weights, design.n_rows)?;

--- a/crates/within/src/operator/schur_complement.rs
+++ b/crates/within/src/operator/schur_complement.rs
@@ -56,7 +56,7 @@ use schwarz_precond::SparseMatrix;
 use super::csr_block::CsrBlock;
 use super::gramian::CrossTab;
 use crate::config::ApproxSchurConfig;
-use crate::{WithinError, WithinResult};
+use crate::BuildError;
 
 /// Undirected fill edge: `(lo_col, hi_col, weight)` with `lo_col < hi_col`.
 type Edge = (u32, u32, f64);
@@ -167,7 +167,7 @@ struct Elimination<'a> {
 
 impl<'a> Elimination<'a> {
     /// Select which block to eliminate and precompute inverse-diagonals.
-    fn new(cross_tab: &'a CrossTab) -> WithinResult<Self> {
+    fn new(cross_tab: &'a CrossTab) -> Result<Self, BuildError> {
         let n_q = cross_tab.n_q();
         let n_r = cross_tab.n_r();
         // Eliminate the larger block to minimize the reduced system size.
@@ -184,7 +184,7 @@ impl<'a> Elimination<'a> {
             if d > 0.0 {
                 inv_diag_elim.push(1.0 / d);
             } else {
-                return Err(WithinError::SingularDiagonal {
+                return Err(BuildError::SingularDiagonal {
                     block: if eliminate_q { "q (elim)" } else { "r (elim)" },
                     index: i,
                 });
@@ -627,7 +627,7 @@ pub(crate) struct AnchoredDenseSchurResult {
 
 /// Strategy for computing the Schur complement of a [`CrossTab`].
 pub(crate) trait SchurComplement {
-    fn compute(&self, cross_tab: &CrossTab) -> WithinResult<SchurResult>;
+    fn compute(&self, cross_tab: &CrossTab) -> Result<SchurResult, BuildError>;
 }
 
 /// Exact Schur complement via block elimination.
@@ -650,7 +650,7 @@ impl SchurComplement for ExactSchurComplement {
     /// For the bipartite SDDM `[D_q, -C; -C^T, D_r]`, eliminates the larger
     /// block (exact since it's diagonal) to get a reduced Laplacian on the
     /// smaller block.
-    fn compute(&self, cross_tab: &CrossTab) -> WithinResult<SchurResult> {
+    fn compute(&self, cross_tab: &CrossTab) -> Result<SchurResult, BuildError> {
         let elim = Elimination::new(cross_tab)?;
         let laplacian = SchurLaplacian::from_elimination(&elim);
         Ok(SchurResult {
@@ -666,7 +666,10 @@ impl ExactSchurComplement {
     /// Used by the tiny-system fast path to avoid sparse Schur assembly and
     /// sparse ApproxChol builder overhead.
     #[cfg(test)]
-    pub(crate) fn compute_dense(&self, cross_tab: &CrossTab) -> WithinResult<DenseSchurResult> {
+    pub(crate) fn compute_dense(
+        &self,
+        cross_tab: &CrossTab,
+    ) -> Result<DenseSchurResult, BuildError> {
         let elim = Elimination::new(cross_tab)?;
         let matrix = SchurLaplacian::dense_from_elimination(&elim);
         Ok(DenseSchurResult {
@@ -683,7 +686,7 @@ impl ExactSchurComplement {
     pub(crate) fn compute_dense_anchored(
         &self,
         cross_tab: &CrossTab,
-    ) -> WithinResult<AnchoredDenseSchurResult> {
+    ) -> Result<AnchoredDenseSchurResult, BuildError> {
         let elim = Elimination::new(cross_tab)?;
         let anchored_minor = SchurLaplacian::anchored_minor_from_elimination(&elim);
         Ok(AnchoredDenseSchurResult {
@@ -699,7 +702,7 @@ impl SchurComplement for ApproxSchurComplement {
     ///
     /// Each eliminated vertex produces at most deg-1 fill edges via the
     /// GKS 2023 Algorithm 5 clique-tree approximation.
-    fn compute(&self, cross_tab: &CrossTab) -> WithinResult<SchurResult> {
+    fn compute(&self, cross_tab: &CrossTab) -> Result<SchurResult, BuildError> {
         let elim = Elimination::new(cross_tab)?;
         let emitter = SampledCliqueEmitter::new(&self.config);
         let edges = elim.par_emit(&emitter);

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -38,7 +38,7 @@ use super::schur_complement::{
 };
 use crate::config::{ApproxCholConfig, ApproxSchurConfig, LocalSolverConfig};
 use crate::domain::Subdomain;
-use crate::{WithinError, WithinResult};
+use crate::BuildError;
 
 /// Concrete additive Schwarz type used in the parent crate.
 #[derive(Clone, Serialize, Deserialize)]
@@ -103,17 +103,18 @@ pub(crate) fn build_additive_with_strategy(
     n_dofs: usize,
     config: &LocalSolverConfig,
     strategy: schwarz_precond::ReductionStrategy,
-) -> WithinResult<FeSchwarz> {
+) -> Result<FeSchwarz, BuildError> {
     let entries = build_entries_from_pairs(domains, config)?;
-    Ok(FeSchwarz::new(SchwarzPreconditioner::with_strategy(
-        entries, n_dofs, strategy,
-    )?))
+    Ok(FeSchwarz::new(
+        SchwarzPreconditioner::with_strategy(entries, n_dofs, strategy)
+            .map_err(BuildError::Preconditioner)?,
+    ))
 }
 
 fn build_entries_from_pairs(
     domain_pairs: Vec<(Subdomain, CrossTab)>,
     config: &LocalSolverConfig,
-) -> WithinResult<Vec<SubdomainEntry<BlockElimSolver>>> {
+) -> Result<Vec<SubdomainEntry<BlockElimSolver>>, BuildError> {
     domain_pairs
         .into_par_iter()
         .map(|(domain, cross_tab)| build_entry(domain, cross_tab, config))
@@ -129,7 +130,7 @@ pub(crate) fn build_entry(
     domain: Subdomain,
     cross_tab: CrossTab,
     config: &LocalSolverConfig,
-) -> WithinResult<SubdomainEntry<BlockElimSolver>> {
+) -> Result<SubdomainEntry<BlockElimSolver>, BuildError> {
     let schur_config = ReducedSchurConfig {
         approx_chol: config.approx_chol,
         approx_schur: config.approx_schur,
@@ -142,8 +143,7 @@ pub(crate) fn build_entry(
         reduced.factor,
         reduced.elimination.eliminate_q,
     );
-    SubdomainEntry::try_new(domain.core, solver)
-        .map_err(|e| WithinError::LocalSolverBuild(format!("invalid subdomain entry: {e}")))
+    SubdomainEntry::try_new(domain.core, solver).map_err(BuildError::Preconditioner)
 }
 
 pub(crate) struct ReducedSchurBuild {
@@ -158,7 +158,7 @@ fn dense_fast_path_enabled(n_keep: usize, threshold: usize) -> bool {
 fn compute_schur(
     cross_tab: &CrossTab,
     approx_schur: Option<ApproxSchurConfig>,
-) -> WithinResult<SchurResult> {
+) -> Result<SchurResult, BuildError> {
     match approx_schur {
         None => ExactSchurComplement.compute(cross_tab),
         Some(cfg) => ApproxSchurComplement::new(cfg).compute(cross_tab),
@@ -168,7 +168,7 @@ fn compute_schur(
 fn build_sparse_reduced_factor(
     matrix: &schwarz_precond::SparseMatrix,
     approx_chol: ApproxCholConfig,
-) -> WithinResult<ReducedFactor> {
+) -> Result<ReducedFactor, BuildError> {
     let schur_builder = Builder::new(approx_chol.to_approx_chol());
     let csr = CsrRef::new(
         matrix.indptr(),
@@ -176,12 +176,12 @@ fn build_sparse_reduced_factor(
         matrix.data(),
         matrix.n() as u32,
     )
-    .map_err(|e| WithinError::LocalSolverBuild(format!("invalid Schur complement CSR: {e}")))?;
+    .map_err(|e| BuildError::LocalSolverBuild(format!("invalid Schur complement CSR: {e}")))?;
     schur_builder
         .build(csr)
         .map(ReducedFactor::approx)
         .map_err(|e| {
-            WithinError::LocalSolverBuild(format!("failed Schur complement factorization: {e}"))
+            BuildError::LocalSolverBuild(format!("failed Schur complement factorization: {e}"))
         })
 }
 
@@ -195,7 +195,7 @@ pub(crate) struct ReducedSchurConfig {
 pub(crate) fn build_reduced_schur_factor(
     cross_tab: &CrossTab,
     config: &ReducedSchurConfig,
-) -> WithinResult<ReducedSchurBuild> {
+) -> Result<ReducedSchurBuild, BuildError> {
     let n_keep = cross_tab.n_q().min(cross_tab.n_r());
     let prefer_dense = dense_fast_path_enabled(n_keep, config.dense_threshold);
 

--- a/crates/within/src/operator/tests.rs
+++ b/crates/within/src/operator/tests.rs
@@ -308,7 +308,7 @@ mod schur_complement_tests {
 
         let result = ExactSchurComplement.compute(&cross_tab);
         match result {
-            Err(crate::WithinError::SingularDiagonal { index: 2, .. }) => {}
+            Err(crate::BuildError::SingularDiagonal { index: 2, .. }) => {}
             Err(e) => panic!("expected SingularDiagonal at index 2, got: {e}"),
             Ok(_) => panic!("expected SingularDiagonal error, got Ok"),
         }

--- a/crates/within/src/orchestrate.rs
+++ b/crates/within/src/orchestrate.rs
@@ -29,7 +29,7 @@ use std::time::Instant;
 use ndarray::ArrayView2;
 
 use crate::config::{Preconditioner, SolverParams};
-use crate::WithinResult;
+use crate::WithinError;
 
 /// Common solve output for all orchestration entry points.
 #[derive(Debug, Clone)]
@@ -154,7 +154,7 @@ pub fn solve(
     weights: Option<&[f64]>,
     params: &SolverParams,
     preconditioner: Option<&Preconditioner>,
-) -> WithinResult<SolveResult> {
+) -> Result<SolveResult, WithinError> {
     let t_start = Instant::now();
     let solver = crate::solver::Solver::new(categories, weights, params, preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
@@ -175,7 +175,7 @@ pub fn solve_batch(
     weights: Option<&[f64]>,
     params: &SolverParams,
     preconditioner: Option<&Preconditioner>,
-) -> WithinResult<BatchSolveResult> {
+) -> Result<BatchSolveResult, WithinError> {
     let t_start = Instant::now();
     let solver = crate::solver::Solver::new(categories, weights, params, preconditioner)?;
     let mut result = solver.solve_batch(ys)?;

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -45,7 +45,7 @@ use crate::domain::Design;
 use crate::observation::{validate_weights, ArrayStore, Store};
 use crate::operator::preconditioner::{build_preconditioner, FePreconditioner};
 use crate::orchestrate::{BatchSolveResult, SolveResult};
-use crate::WithinResult;
+use crate::{BuildError, SolveError};
 
 fn norm(v: &[f64]) -> f64 {
     v.iter().map(|x| x * x).sum::<f64>().sqrt()
@@ -76,7 +76,7 @@ impl<S: Store> Solver<S> {
         weights: Option<Vec<f64>>,
         params: &SolverParams,
         preconditioner: Option<&Preconditioner>,
-    ) -> WithinResult<Self> {
+    ) -> Result<Self, BuildError> {
         validate_weights(weights.as_deref(), design.n_rows)?;
         let built_precond = match preconditioner {
             Some(config) => Some(build_preconditioner(&design, weights.as_deref(), config)?),
@@ -99,7 +99,7 @@ impl<S: Store> Solver<S> {
         weights: Option<Vec<f64>>,
         params: &SolverParams,
         preconditioner: FePreconditioner,
-    ) -> WithinResult<Self> {
+    ) -> Result<Self, BuildError> {
         validate_weights(weights.as_deref(), design.n_rows)?;
         Ok(Self {
             design,
@@ -112,7 +112,7 @@ impl<S: Store> Solver<S> {
     }
 
     /// Solve for a single RHS vector.
-    pub fn solve(&self, y: &[f64]) -> WithinResult<SolveResult> {
+    pub fn solve(&self, y: &[f64]) -> Result<SolveResult, SolveError> {
         let t_start = Instant::now();
         let t_setup_start = Instant::now();
 
@@ -162,11 +162,11 @@ impl<S: Store> Solver<S> {
     }
 
     /// Solve for multiple RHS vectors in parallel.
-    pub fn solve_batch(&self, ys: &[&[f64]]) -> WithinResult<BatchSolveResult> {
+    pub fn solve_batch(&self, ys: &[&[f64]]) -> Result<BatchSolveResult, SolveError> {
         let t_start = Instant::now();
         let n_rhs = ys.len();
 
-        let results: Vec<WithinResult<SolveResult>> =
+        let results: Vec<Result<SolveResult, SolveError>> =
             ys.par_iter().map(|y| self.solve(y)).collect();
 
         let mut x = Vec::with_capacity(self.design.n_dofs * n_rhs);
@@ -221,7 +221,7 @@ impl<'a> Solver<ArrayStore<'a>> {
         weights: Option<&[f64]>,
         params: &SolverParams,
         preconditioner: Option<&Preconditioner>,
-    ) -> WithinResult<Self> {
+    ) -> Result<Self, BuildError> {
         let store = ArrayStore::new(categories)?;
         let design = Design::from_store(store)?;
         let weights = weights.map(|w| w.to_vec());
@@ -234,7 +234,7 @@ impl<'a> Solver<ArrayStore<'a>> {
         weights: Option<&[f64]>,
         params: &SolverParams,
         preconditioner: FePreconditioner,
-    ) -> WithinResult<Self> {
+    ) -> Result<Self, BuildError> {
         let store = ArrayStore::new(categories)?;
         let design = Design::from_store(store)?;
         let weights = weights.map(|w| w.to_vec());

--- a/crates/within/tests/common/orchestrate_helpers.rs
+++ b/crates/within/tests/common/orchestrate_helpers.rs
@@ -8,7 +8,9 @@ pub fn make_test_design() -> Design<FactorMajorStore> {
     make_design(vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]).expect("valid test design")
 }
 
-pub fn make_design(categories: Vec<Vec<u32>>) -> within::WithinResult<Design<FactorMajorStore>> {
+pub fn make_design(
+    categories: Vec<Vec<u32>>,
+) -> Result<Design<FactorMajorStore>, within::BuildError> {
     let n_rows = categories.first().map_or(0, Vec::len);
     let store = FactorMajorStore::new(categories, n_rows)?;
     Design::from_store(store)

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -1,9 +1,9 @@
 use std::error::Error;
 
 use ndarray::Array2;
-use schwarz_precond::{PreconditionerBuildError, SolveError};
+use schwarz_precond::SolveError;
 use within::observation::FactorMajorStore;
-use within::{solve, Design, Preconditioner, Solver, SolverParams, WithinError};
+use within::{solve, BuildError, Design, Preconditioner, Solver, SolverParams, WithinError};
 
 #[test]
 fn test_empty_observations_error() {
@@ -12,7 +12,7 @@ fn test_empty_observations_error() {
     let result = Design::from_store(store);
     assert!(result.is_err());
     match result.unwrap_err() {
-        WithinError::EmptyObservations => {}
+        BuildError::EmptyObservations => {}
         other => panic!("Expected EmptyObservations, got: {:?}", other),
     }
 }
@@ -23,7 +23,7 @@ fn test_observation_count_mismatch_error() {
     let result = FactorMajorStore::new(vec![vec![0, 1, 2], vec![0, 1]], 3);
     assert!(result.is_err());
     match result.unwrap_err() {
-        WithinError::ObservationCountMismatch { .. } => {}
+        BuildError::ObservationCountMismatch { .. } => {}
         other => panic!("Expected ObservationCountMismatch, got: {:?}", other),
     }
 }
@@ -39,7 +39,7 @@ fn test_weight_count_mismatch_error() {
         .err()
         .expect("expected WeightCountMismatch error, got Ok");
     match err {
-        WithinError::WeightCountMismatch { .. } => {}
+        BuildError::WeightCountMismatch { .. } => {}
         other => panic!("Expected WeightCountMismatch, got: {:?}", other),
     }
 }
@@ -52,21 +52,28 @@ fn test_empty_categories_via_solve() {
     let precond = Preconditioner::default();
     let result = solve(cats.view(), &y, None, &params, Some(&precond));
     assert!(result.is_err());
+    match result.unwrap_err() {
+        WithinError::Build(BuildError::EmptyObservations) => {}
+        other => panic!(
+            "Expected Build(EmptyObservations) via solve(), got: {:?}",
+            other
+        ),
+    }
 }
 
 // ---------------------------------------------------------------------------
-// Display tests for all WithinError variants
+// Display tests for BuildError variants
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_within_error_display_empty_observations() {
-    let e = WithinError::EmptyObservations;
+fn test_build_error_display_empty_observations() {
+    let e = BuildError::EmptyObservations;
     assert_eq!(e.to_string(), "no observations provided");
 }
 
 #[test]
-fn test_within_error_display_observation_count_mismatch() {
-    let e = WithinError::ObservationCountMismatch {
+fn test_build_error_display_observation_count_mismatch() {
+    let e = BuildError::ObservationCountMismatch {
         factor: 1,
         expected: 10,
         got: 5,
@@ -78,8 +85,8 @@ fn test_within_error_display_observation_count_mismatch() {
 }
 
 #[test]
-fn test_within_error_display_weight_count_mismatch() {
-    let e = WithinError::WeightCountMismatch {
+fn test_build_error_display_weight_count_mismatch() {
+    let e = BuildError::WeightCountMismatch {
         expected: 10,
         got: 5,
     };
@@ -89,8 +96,8 @@ fn test_within_error_display_weight_count_mismatch() {
 }
 
 #[test]
-fn test_within_error_display_singular_diagonal() {
-    let e = WithinError::SingularDiagonal {
+fn test_build_error_display_singular_diagonal() {
+    let e = BuildError::SingularDiagonal {
         block: "test_block",
         index: 42,
     };
@@ -100,29 +107,39 @@ fn test_within_error_display_singular_diagonal() {
 }
 
 #[test]
-fn test_within_error_display_local_solver_build() {
-    let e = WithinError::LocalSolverBuild("factorization failed".to_string());
+fn test_build_error_display_local_solver_build() {
+    let e = BuildError::LocalSolverBuild("factorization failed".to_string());
     assert!(e.to_string().contains("factorization failed"));
 }
 
 #[test]
-fn test_within_error_display_preconditioner_build() {
-    let inner = PreconditionerBuildError::GlobalIndexOutOfBounds {
+fn test_build_error_display_preconditioner() {
+    let inner = schwarz_precond::BuildError::GlobalIndexOutOfBounds {
         subdomain: 0,
         local_index: 1,
         global_index: 5,
         n_dofs: 3,
     };
-    let e = WithinError::PreconditionerBuild(inner);
+    let e = BuildError::Preconditioner(inner);
     let s = e.to_string();
     assert!(s.contains("5"));
     assert!(s.contains("3"));
 }
 
+// ---------------------------------------------------------------------------
+// Display tests for WithinError union
+// ---------------------------------------------------------------------------
+
 #[test]
-fn test_within_error_display_iterative_solve() {
+fn test_within_error_display_build() {
+    let e = WithinError::Build(BuildError::EmptyObservations);
+    assert_eq!(e.to_string(), "no observations provided");
+}
+
+#[test]
+fn test_within_error_display_solve() {
     let inner = SolveError::Synchronization { context: "test" };
-    let e = WithinError::IterativeSolve(inner);
+    let e = WithinError::Solve(inner);
     assert!(e.to_string().contains("test"));
 }
 
@@ -131,23 +148,23 @@ fn test_within_error_display_iterative_solve() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_within_error_source_none_variants() {
-    let variants: Vec<WithinError> = vec![
-        WithinError::EmptyObservations,
-        WithinError::ObservationCountMismatch {
+fn test_build_error_source_leaf_variants_have_no_source() {
+    let variants: Vec<BuildError> = vec![
+        BuildError::EmptyObservations,
+        BuildError::ObservationCountMismatch {
             factor: 0,
             expected: 1,
             got: 2,
         },
-        WithinError::WeightCountMismatch {
+        BuildError::WeightCountMismatch {
             expected: 1,
             got: 2,
         },
-        WithinError::SingularDiagonal {
+        BuildError::SingularDiagonal {
             block: "b",
             index: 0,
         },
-        WithinError::LocalSolverBuild("x".to_string()),
+        BuildError::LocalSolverBuild("x".to_string()),
     ];
     for e in &variants {
         assert!(e.source().is_none(), "expected None source for {:?}", e);
@@ -155,40 +172,56 @@ fn test_within_error_source_none_variants() {
 }
 
 #[test]
-fn test_within_error_source_preconditioner_build() {
-    let inner = PreconditionerBuildError::GlobalIndexOutOfBounds {
+fn test_build_error_source_preconditioner_chains() {
+    let inner = schwarz_precond::BuildError::GlobalIndexOutOfBounds {
         subdomain: 0,
         local_index: 1,
         global_index: 5,
         n_dofs: 3,
     };
-    let e = WithinError::PreconditionerBuild(inner);
+    let e = BuildError::Preconditioner(inner);
     assert!(e.source().is_some());
 }
 
 #[test]
-fn test_within_error_source_iterative_solve() {
-    let inner = SolveError::Synchronization { context: "test" };
-    let e = WithinError::IterativeSolve(inner);
-    assert!(e.source().is_some());
+fn test_within_error_build_leaf_variant_has_no_source() {
+    // WithinError::Build is transparent, so source() forwards to the inner
+    // BuildError's source. A leaf variant has no underlying source.
+    let e = WithinError::Build(BuildError::EmptyObservations);
+    assert!(e.source().is_none());
 }
 
-// ---------------------------------------------------------------------------
-// From conversions
-// ---------------------------------------------------------------------------
-
 #[test]
-fn test_within_error_from_preconditioner_build_error() {
-    let inner = PreconditionerBuildError::GlobalIndexOutOfBounds {
+fn test_within_error_build_preconditioner_chains_through_transparent_wrapper() {
+    // Transparent: WithinError -> (BuildError::Preconditioner via #[source]) -> schwarz_precond::BuildError
+    let inner = schwarz_precond::BuildError::GlobalIndexOutOfBounds {
         subdomain: 0,
-        local_index: 0,
-        global_index: 100,
-        n_dofs: 50,
+        local_index: 1,
+        global_index: 5,
+        n_dofs: 3,
     };
+    let e = WithinError::Build(BuildError::Preconditioner(inner));
+    assert!(e.source().is_some());
+}
+
+#[test]
+fn test_within_error_solve_leaf_variant_has_no_source() {
+    let inner = SolveError::Synchronization { context: "test" };
+    let e = WithinError::Solve(inner);
+    assert!(e.source().is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Convenience-wrapper From conversions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_within_error_from_build_error() {
+    let inner = BuildError::EmptyObservations;
     let e: WithinError = inner.into();
     match e {
-        WithinError::PreconditionerBuild(_) => {}
-        other => panic!("expected PreconditionerBuild, got: {:?}", other),
+        WithinError::Build(BuildError::EmptyObservations) => {}
+        other => panic!("expected Build(EmptyObservations), got: {:?}", other),
     }
 }
 
@@ -197,7 +230,7 @@ fn test_within_error_from_solve_error() {
     let inner = SolveError::Synchronization { context: "test" };
     let e: WithinError = inner.into();
     match e {
-        WithinError::IterativeSolve(_) => {}
-        other => panic!("expected IterativeSolve, got: {:?}", other),
+        WithinError::Solve(_) => {}
+        other => panic!("expected Solve, got: {:?}", other),
     }
 }


### PR DESCRIPTION
## Summary

Closes #30. Collapses six error enums chained through hand-written `From` impls into a per-crate `BuildError` / `SolveError` pair plus a thin `WithinError` union at the convenience-wrapper boundary.

- **schwarz-precond**: absorb `SubdomainCoreBuildError`, `SubdomainEntryBuildError`, `PreconditionerBuildError` into one flat `BuildError`. Rename `LocalSolveError::ApproxCholSolveFailed` → `BackendFailed` so the type is backend-agnostic (`#[non_exhaustive]` added).
- **within**: split `WithinError` into `BuildError`, a re-export of `schwarz_precond::SolveError`, and a thin union retained only for `solve()` / `solve_batch()`. Per-phase APIs now return `BuildError` or `SolveError` directly. `WithinResult` alias removed.
- **Cross-crate boundary**: no `From<schwarz_precond::BuildError> for within::BuildError` — call sites use explicit `.map_err(BuildError::Preconditioner)`. Display surfaces the boundary with a `"preconditioner build failed: "` prefix; `source()` still chains.
- **`WithinError::{Build, Solve}`** are transparent — neither appears in the error chain; `Display` and `Error::source` forward to the inner error.
- **thiserror migration**: replaced hand-rolled `Display` / `Error` / `From` impls with `#[derive(thiserror::Error)]`. New dep on `thiserror = "2"` in both crates.

Net: 25 files, +263 / −320 lines. Six error types reduced to four; three layered `From` chains reduced to two `From` impls scoped to the one convenience boundary.

## Test plan

- [x] `cargo test --workspace` — full Rust suite passes (all 18 test binaries).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo doc --no-deps --workspace` — only pre-existing unrelated warnings.
- [x] `pixi run develop && pixi run test` — 97 Python tests pass; PyO3 boundary unchanged (`value_err(e: impl Display)` works transparently).
- [x] Manual spot-check via Python: `ValueError: weights has length 2, expected 3` message preserved.