### PR TITLE
chore: bump approx-chol to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Modified LSMR is now the sole iterative solver, replacing CG and GMRES.
 - **BREAKING:** `Solver::new` accepts `Option<impl Into<Vec<f64>>>` for weights; `WithinError` is `#[non_exhaustive]`.
 - Free `solve()` / `solve_batch()` accept `impl Into<PreconditionerInput>` (same shapes as `Solver::new`).
 - `Solver` and `Preconditioner` implement `Debug`.
+- `approx-chol` bumped `0.1` → `0.2` (now published on crates.io); the new upstream sampler may produce slightly different fill edges in the Schur complement.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx-chol"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01f4d29e486845115cf5e8bec8af1e2aabc2fbddd3f40931e5375c2d6315b47"
+checksum = "f8fc1b78930a040edb9d77183530c9ebe65cffb929469f044f5bba8dd4fbb8f7"
 dependencies = [
  "num-traits",
  "rand 0.10.0",
@@ -1844,7 +1844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/within/Cargo.toml
+++ b/crates/within/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["mathematics", "science", "algorithms"]
 
 [dependencies]
 schwarz-precond = { version = "0.1.0", path = "../schwarz-precond", features = ["serde"] }
-approx-chol = { version = "0.1.0", features = ["serde"] }
+approx-chol = { version = "0.2.0", features = ["serde"] }
 serde = { version = "1", features = ["derive", "rc"] }
 postcard = { version = "1", features = ["use-std"] }
 ndarray = "0.16"

--- a/crates/within/src/block_elim/elimination.rs
+++ b/crates/within/src/block_elim/elimination.rs
@@ -56,8 +56,6 @@ pub(crate) struct Star<'a> {
     col_indices: &'a [u32],
     /// Edge weights to each neighbor.
     weights: &'a [f64],
-    /// `D_elim[k]` (needed by `clique_tree_sample`).
-    diag: f64,
 }
 
 impl Star<'_> {
@@ -87,7 +85,7 @@ impl SampledCliqueEmitter {
         }
         let seed = self.seed.wrapping_add(star.index as u64);
         if self.split <= 1 {
-            clique_tree_sample(scratch, star.diag, seed, edges);
+            clique_tree_sample(scratch, seed, edges);
         } else {
             clique_tree_sample_multi(scratch, self.split, seed, edges);
         }
@@ -107,7 +105,6 @@ pub(crate) struct Elimination<'a> {
     pub(crate) n_keep: usize,
     pub(crate) n_elim: usize,
     pub(crate) inv_diag_elim: Vec<f64>,
-    pub(crate) diag_elim: &'a [f64],
     pub(crate) diag_keep: &'a [f64],
     pub(crate) keep_to_elim: &'a CsrBlock,
     pub(crate) elim_to_keep: &'a CsrBlock,
@@ -156,7 +153,6 @@ impl<'a> Elimination<'a> {
             n_keep,
             n_elim,
             inv_diag_elim,
-            diag_elim,
             diag_keep,
             keep_to_elim,
             elim_to_keep,
@@ -171,7 +167,6 @@ impl<'a> Elimination<'a> {
             index: k,
             col_indices: &self.elim_to_keep.indices[start..end],
             weights: &self.elim_to_keep.data[start..end],
-            diag: self.diag_elim[k],
         }
     }
 


### PR DESCRIPTION
## Summary
- Bumps `approx-chol` from `0.1.0` → `0.2.0` (now published on crates.io).
- The 0.2 release drops the `diag` parameter from `clique_tree_sample`, so the leftover `Star::diag` field and unused `Elimination::diag_elim` borrow are removed from `crates/within/src/block_elim/elimination.rs`.
- `Cargo.lock` also picks up a transitive shift (`tempfile`'s `getrandom 0.4.2` → `0.3.4`) from the new `rand 0.10` dep tree pulled in by `approx-chol 0.2.0`.

No public API change. The new upstream sampler may yield slightly different fill edges in the Schur complement, but the wire format and `Preconditioner` contract are unchanged.

## Test plan
- [ ] `cargo test --workspace`
- [ ] `pixi run test`
- [ ] `cargo bench -p within -- --quick` (sanity check that fill-edge changes don't regress fixest smoke benches)