### PR TITLE
feat(terms): public Vec<Fe> term-list solve API

### DIFF
--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -26,6 +26,10 @@ pub enum BuildError {
         /// Actual length of the slope column.
         got: usize,
     },
+    /// A feature that is recognized as valid input but not yet supported by the
+    /// solver. The message names the unsupported feature (e.g. "varying slopes").
+    #[error("not yet supported: {0}")]
+    Unsupported(&'static str),
     /// One factor column does not match the expected observation count.
     #[error("factor {factor} has {got} observations, expected {expected}")]
     ObservationCountMismatch {

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -11,6 +11,21 @@ pub enum BuildError {
     /// No observations provided.
     #[error("no observations provided")]
     EmptyObservations,
+    /// A factor term has no columns: it has no intercept and no slopes, so it
+    /// contributes nothing to the design.
+    #[error("factor term has no columns: set intercept = true or provide at least one slope")]
+    EmptyTerm,
+    /// A slope column's length does not match the number of observations
+    /// (level indices) in its factor term.
+    #[error("slope {slope} has {got} loadings, expected {expected}")]
+    SlopeCountMismatch {
+        /// Index of the slope column with mismatched length.
+        slope: usize,
+        /// Expected number of loadings (one per observation).
+        expected: usize,
+        /// Actual length of the slope column.
+        got: usize,
+    },
     /// One factor column does not match the expected observation count.
     #[error("factor {factor} has {got} observations, expected {expected}")]
     ObservationCountMismatch {

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -29,3 +29,4 @@ pub use domain::Design;
 pub use error::{BuildError, SolveError, WithinError};
 pub use operator::schwarz::Preconditioner;
 pub use solver::{solve, solve_batch, BatchSolveResult, SolveResult, Solver};
+pub use terms::Fe;

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -16,6 +16,7 @@
 pub mod config;
 pub mod error;
 pub mod observation;
+pub mod terms;
 
 pub(crate) mod block_elim;
 pub(crate) mod csr_block;

--- a/crates/within/src/terms.rs
+++ b/crates/within/src/terms.rs
@@ -1,14 +1,18 @@
 //! Fixed-effects term inputs: the [`Fe`] factor specification.
 
 use crate::error::BuildError;
+use crate::observation::FactorMajorStore;
+use crate::solver::IntoDesign;
+use crate::Design;
 
 /// One fixed-effects factor term: a per-observation level index, optional
 /// varying-slope loadings, and whether to include the level intercept.
-// Bridge: fields are read once `Fe` lowers to a store; remove when wired.
-#[allow(dead_code)]
 pub struct Fe {
     levels: Vec<u32>,
     slopes: Vec<Vec<f64>>,
+    // Bridge: only consumed once slope-only terms (intercept = false) lower;
+    // until then every term that passes the slopes gate has intercept = true.
+    #[allow(dead_code)]
     intercept: bool,
 }
 
@@ -37,6 +41,25 @@ impl Fe {
             slopes,
             intercept,
         })
+    }
+}
+
+impl IntoDesign<'_> for Vec<Fe> {
+    type Store = FactorMajorStore;
+
+    fn into_design(self) -> Result<Design<FactorMajorStore>, BuildError> {
+        let factor_levels = self
+            .into_iter()
+            .map(|Fe { levels, slopes, .. }| {
+                if slopes.is_empty() {
+                    Ok(levels)
+                } else {
+                    Err(BuildError::Unsupported("varying slopes"))
+                }
+            })
+            .collect::<Result<Vec<Vec<u32>>, BuildError>>()?;
+        let n_obs = factor_levels.first().map_or(0, Vec::len);
+        Design::from_store(FactorMajorStore::new(factor_levels, n_obs)?)
     }
 }
 
@@ -78,5 +101,35 @@ mod tests {
         let fe = Fe::new(vec![0u32, 1], vec![slope.clone()], false).expect("slope-only is valid");
         assert!(!fe.intercept);
         assert_eq!(fe.slopes, vec![slope]);
+    }
+
+    #[test]
+    fn plain_fe_lowers_to_single_factor_design() {
+        let fe = Fe::new(vec![0u32, 1, 0, 2], vec![], true).expect("plain FE is valid");
+        let design = vec![fe].into_design().expect("plain term list lowers");
+        assert_eq!(design.n_factors(), 1);
+        assert_eq!(design.n_obs(), 4);
+        assert_eq!(design.n_dofs(), 3); // levels 0..=2 ⇒ 3 DOFs
+    }
+
+    #[test]
+    fn plain_term_list_lowers_to_one_factor_per_term() {
+        // term 0: levels 0..=2 ⇒ 3 DOFs; term 1: levels 0..=1 ⇒ 2 DOFs.
+        let fe0 = Fe::new(vec![0u32, 1, 0, 2], vec![], true).expect("term 0 valid");
+        let fe1 = Fe::new(vec![0u32, 0, 1, 1], vec![], true).expect("term 1 valid");
+        let design = vec![fe0, fe1]
+            .into_design()
+            .expect("plain term list lowers");
+        assert_eq!(design.n_factors(), 2);
+        assert_eq!(design.n_obs(), 4);
+        assert_eq!(design.n_dofs(), 5); // 3 + 2, summed across factors
+    }
+
+    #[test]
+    fn slope_bearing_term_is_gated_not_supported() {
+        let fe = Fe::new(vec![0u32, 1, 0], vec![vec![1.0, 2.0, 3.0]], true)
+            .expect("slope term is valid input");
+        let result = vec![fe].into_design();
+        assert!(matches!(result, Err(BuildError::Unsupported(msg)) if msg.contains("slope")));
     }
 }

--- a/crates/within/src/terms.rs
+++ b/crates/within/src/terms.rs
@@ -1,5 +1,7 @@
 //! Fixed-effects term inputs: the [`Fe`] factor specification.
 
+use crate::error::BuildError;
+
 /// One fixed-effects factor term: a per-observation level index, optional
 /// varying-slope loadings, and whether to include the level intercept.
 // Bridge: fields are read once `Fe` lowers to a store; remove when wired.
@@ -8,4 +10,73 @@ pub struct Fe {
     levels: Vec<u32>,
     slopes: Vec<Vec<f64>>,
     intercept: bool,
+}
+
+impl Fe {
+    /// Builds a fixed-effects term from per-observation level indices, optional
+    /// varying-slope loadings, and whether to include the level intercept.
+    pub fn new(
+        levels: Vec<u32>,
+        slopes: Vec<Vec<f64>>,
+        intercept: bool,
+    ) -> Result<Self, BuildError> {
+        if !intercept && slopes.is_empty() {
+            return Err(BuildError::EmptyTerm);
+        }
+        for (slope, column) in slopes.iter().enumerate() {
+            if column.len() != levels.len() {
+                return Err(BuildError::SlopeCountMismatch {
+                    slope,
+                    expected: levels.len(),
+                    got: column.len(),
+                });
+            }
+        }
+        Ok(Self {
+            levels,
+            slopes,
+            intercept,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_fe_is_ok_and_stores_fields() {
+        let levels = vec![0u32, 1, 0, 2];
+        let fe = Fe::new(levels.clone(), vec![], true).expect("plain FE is valid");
+        assert_eq!(fe.levels, levels);
+        assert!(fe.slopes.is_empty());
+        assert!(fe.intercept);
+    }
+
+    #[test]
+    fn empty_term_is_rejected() {
+        let result = Fe::new(vec![0u32, 1, 0], vec![], false);
+        assert!(matches!(result, Err(BuildError::EmptyTerm)));
+    }
+
+    #[test]
+    fn slope_length_mismatch_is_rejected() {
+        let result = Fe::new(vec![0u32, 1, 0], vec![vec![1.0, 2.0]], true);
+        assert!(matches!(
+            result,
+            Err(BuildError::SlopeCountMismatch {
+                slope: 0,
+                expected: 3,
+                got: 2
+            })
+        ));
+    }
+
+    #[test]
+    fn slope_only_term_is_ok_and_stores_slope() {
+        let slope = vec![1.0, 2.0];
+        let fe = Fe::new(vec![0u32, 1], vec![slope.clone()], false).expect("slope-only is valid");
+        assert!(!fe.intercept);
+        assert_eq!(fe.slopes, vec![slope]);
+    }
 }

--- a/crates/within/src/terms.rs
+++ b/crates/within/src/terms.rs
@@ -1,0 +1,11 @@
+//! Fixed-effects term inputs: the [`Fe`] factor specification.
+
+/// One fixed-effects factor term: a per-observation level index, optional
+/// varying-slope loadings, and whether to include the level intercept.
+// Bridge: fields are read once `Fe` lowers to a store; remove when wired.
+#[allow(dead_code)]
+pub struct Fe {
+    levels: Vec<u32>,
+    slopes: Vec<Vec<f64>>,
+    intercept: bool,
+}

--- a/crates/within/tests/terms.rs
+++ b/crates/within/tests/terms.rs
@@ -1,0 +1,46 @@
+use ndarray::array;
+use within::{solve, BuildError, Fe, LsmrOptions, PreconditionerConfig, Solver};
+
+/// A model expressed as a `Vec<Fe>` of plain terms must solve to the same fit as
+/// the equivalent observation-major category array through the established
+/// `solve` path — i.e. the term-list lowering builds the correct design.
+#[test]
+fn plain_term_list_solves_like_category_array() {
+    // 5 observations, 2 factors. The array is observation-major; the Fe terms
+    // carry the same factors as per-observation level columns.
+    let categories = array![[0u32, 0], [1, 0], [0, 1], [1, 1], [2, 0]];
+    let y = [1.0, 2.0, 3.0, 4.0, 5.0];
+    let params = LsmrOptions::default();
+    let precond = PreconditionerConfig::default();
+
+    let from_array = solve(categories.view(), &y, None, &params, &precond).expect("array solve");
+
+    let terms = vec![
+        Fe::new(vec![0u32, 1, 0, 1, 2], vec![], true).expect("factor 0"),
+        Fe::new(vec![0u32, 0, 1, 1, 0], vec![], true).expect("factor 1"),
+    ];
+    let from_terms = Solver::new(terms, None, &precond)
+        .expect("term-list solver")
+        .solve(&y, &params)
+        .expect("term-list solve");
+
+    assert!(from_terms.converged, "term-list solve did not converge");
+    assert_eq!(from_terms.demeaned.len(), from_array.demeaned.len());
+    for (t, a) in from_terms.demeaned.iter().zip(from_array.demeaned.iter()) {
+        assert!(
+            (t - a).abs() < 1e-9,
+            "term-list fit diverged from array fit: {t} vs {a}"
+        );
+    }
+}
+
+/// A term carrying varying slopes is rejected at the public solver boundary —
+/// the lowering gate surfaces as `BuildError::Unsupported`, not a panic or a
+/// silently-wrong solve.
+#[test]
+fn slope_term_is_rejected_at_solver_construction() {
+    let terms = vec![Fe::new(vec![0u32, 1, 0], vec![vec![1.0, 2.0, 3.0]], true)
+        .expect("slope term is valid input")];
+    let result = Solver::new(terms, None, &PreconditionerConfig::default());
+    assert!(matches!(result, Err(BuildError::Unsupported(msg)) if msg.contains("slope")));
+}


### PR DESCRIPTION
## What

Adds `Fe`, a fixed-effects factor-term input, and lowers a `Vec<Fe>` into a
`Design` so a model can be expressed as a term list and solved:

```rust
use within::{Solver, Fe, LsmrOptions, PreconditionerConfig};

let solver = Solver::new(
    vec![Fe::new(levels_a, vec![], true)?, Fe::new(levels_b, vec![], true)?],
    None,
    &PreconditionerConfig::default(),
)?;
let result = solver.solve(&y, &LsmrOptions::default())?;
```

## Scope

Plain fixed effects (`intercept = true`, no slopes) are fully supported.
Varying slopes are accepted as well-formed *input* (`Fe::new` validates their
shape) but **gated at lowering** with `BuildError::Unsupported("varying slopes")`
— the slope data model is a separate, larger change. Slope-only terms
(`intercept = false`) are caught by the same single condition.

## Notes for review

- **Validation split by altitude.** `Fe::new` checks *intra-term* shape
  (non-empty term, slope-column lengths). *Inter-term* length consistency falls
  out of `FactorMajorStore::new` during lowering (ragged input →
  `ObservationCountMismatch`), so it needs no new code.
- **No solve-machinery changes.** The lowering targets the existing generic
  `IntoDesign` seam, so `Solver::new` (and the persistent-solver
  `solve`/`solve_batch`) accept a term list automatically.
- **Reviewable commit-by-commit:** bare type → constructor → lowering+gate →
  public API.

## Testing

- Unit tests for `Fe::new` validation and `Vec<Fe>` lowering (plain single,
  multi-term, slope gate).
- Integration test: a term-list solve matches the equivalent observation-major
  category-array fit (equivalence against the established path), and a
  slope-bearing term is rejected at the `Solver::new` boundary.
