### PR TITLE
feat: varying-slopes effect-term design API + plain-factor parity (#58)

### DIFF
--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -1,16 +1,16 @@
 //! Free `#[pyfunction]`s exposed via `within._within`: [`solve`] and
 //! [`solve_batch`].
 
-use numpy::{PyReadonlyArray1, PyReadonlyArray2};
+use numpy::{PyReadonlyArray1, PyReadonlyArray2, PyUntypedArray};
 use pyo3::prelude::*;
 
 use within::observation::FactorMajorStore;
 use within::{
-    solve as solve_native, solve_batch as solve_batch_native, BuildError, Design, SolveResult,
-    Solver, WithinError,
+    solve as solve_native, solve_batch as solve_batch_native, BuildError, Design, Effect,
+    SolveResult, Solver, WithinError,
 };
 
-use crate::config::{resolve_lsmr_config, resolve_precond_input, PrecondInput, PyPreconditioner};
+use crate::config::{resolve_lsmr_config, resolve_precond_input, PyPreconditioner};
 use crate::convert::{coerce_to_slice, column_refs, extract_columns, value_err, warn_c_contiguous};
 use crate::results::{run_batch, run_solve, PyBatchSolveResult, PySolveResult};
 
@@ -19,37 +19,41 @@ use crate::results::{run_batch, run_solve, PyBatchSolveResult, PySolveResult};
 // ---------------------------------------------------------------------------
 
 #[pyfunction]
-#[pyo3(signature = (categories, y, options=None, weights=None, preconditioner=None))]
+#[pyo3(signature = (design, y, options=None, weights=None, preconditioner=None))]
 pub fn solve<'py>(
     py: Python<'py>,
-    categories: PyReadonlyArray2<'py, u32>,
+    design: &Bound<'py, PyAny>,
     y: PyReadonlyArray1<'py, f64>,
     options: Option<&Bound<'py, PyAny>>,
     weights: Option<PyReadonlyArray1<'py, f64>>,
     preconditioner: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<PySolveResult> {
-    let cats = categories.as_array();
-    warn_c_contiguous(py, &cats)?;
+    let params = resolve_lsmr_config(options)?;
+    let precond = resolve_precond_input(py, preconditioner)?;
 
     // Borrow the array views while the GIL is held (`PyReadonlyArray` needs the
-    // token), but defer the slice coercion -- and any copy of strided input --
-    // into the GIL-released closures below. The common F-contiguous path then
-    // borrows both `y` and `weights` with no copy at all.
+    // token), but defer slice coercion -- and any copy of strided input -- into
+    // the GIL-released closures below, so the F-contiguous path copies nothing.
     let y_arr = y.as_array();
     let w_view = weights.as_ref().map(|w| w.as_array());
-    let params = resolve_lsmr_config(options)?;
 
-    match resolve_precond_input(py, preconditioner)? {
-        PrecondInput::Prebuilt(built) => run_solve(py, || -> Result<SolveResult, WithinError> {
-            let y_cow = coerce_to_slice(&y_arr);
-            let w_cow = w_view.as_ref().map(coerce_to_slice);
-            solve_native(cats, &y_cow, w_cow.as_deref(), &params, built)
-        }),
-        PrecondInput::Config(precond) => run_solve(py, || {
-            let y_cow = coerce_to_slice(&y_arr);
-            let w_cow = w_view.as_ref().map(coerce_to_slice);
-            solve_native(cats, &y_cow, w_cow.as_deref(), &params, precond.as_ref())
-        }),
+    match extract_design(py, design)? {
+        DesignSource::Categories(categories) => {
+            let cats = categories.as_array();
+            run_solve(py, move || -> Result<SolveResult, WithinError> {
+                let y_cow = coerce_to_slice(&y_arr);
+                let w_cow = w_view.as_ref().map(coerce_to_slice);
+                solve_native(cats, &y_cow, w_cow.as_deref(), &params, precond)
+            })
+        }
+        DesignSource::Effects(terms) => {
+            run_solve(py, move || -> Result<SolveResult, WithinError> {
+                let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
+                let y_cow = coerce_to_slice(&y_arr);
+                let w_cow = w_view.as_ref().map(coerce_to_slice);
+                solve_native(effects, &y_cow, w_cow.as_deref(), &params, precond)
+            })
+        }
     }
 }
 
@@ -79,26 +83,101 @@ pub fn solve_batch<'py>(
         )));
     }
 
-    // Defer column extraction and weight coercion into the GIL-released closures
+    // Defer column extraction and weight coercion into the GIL-released closure
     // below: F-contiguous columns and contiguous weights are borrowed directly,
     // only strided input is copied (off-GIL).
     let w_view = weights.as_ref().map(|w| w.as_array());
     let params = resolve_lsmr_config(options)?;
+    let precond = resolve_precond_input(py, preconditioner)?;
 
-    match resolve_precond_input(py, preconditioner)? {
-        PrecondInput::Prebuilt(built) => run_batch(py, || -> Result<_, WithinError> {
-            let columns = extract_columns(&y_arr);
-            let col_refs = column_refs(&columns);
-            let w_cow = w_view.as_ref().map(coerce_to_slice);
-            solve_batch_native(cats, &col_refs, w_cow.as_deref(), &params, built)
-        }),
-        PrecondInput::Config(precond) => run_batch(py, || {
-            let columns = extract_columns(&y_arr);
-            let col_refs = column_refs(&columns);
-            let w_cow = w_view.as_ref().map(coerce_to_slice);
-            solve_batch_native(cats, &col_refs, w_cow.as_deref(), &params, precond.as_ref())
-        }),
+    run_batch(py, move || -> Result<_, WithinError> {
+        let columns = extract_columns(&y_arr);
+        let col_refs = column_refs(&columns);
+        let w_cow = w_view.as_ref().map(coerce_to_slice);
+        solve_batch_native(cats, &col_refs, w_cow.as_deref(), &params, precond)
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Effect-term design
+// ---------------------------------------------------------------------------
+
+/// One factor's effect: level codes, an optional intercept, and slope covariates.
+///
+/// Holds its columns natively (copied out of numpy) so the borrowed [`Effect`]
+/// it lowers to can be rebuilt off-GIL, where `Py` handles can't reach.
+#[pyclass(frozen, module = "within._within")]
+#[pyo3(name = "Effect")]
+#[derive(Clone)]
+pub struct PyEffect {
+    levels: Vec<u32>,
+    intercept: bool,
+    slopes: Vec<Vec<f64>>,
+}
+
+#[pymethods]
+impl PyEffect {
+    #[new]
+    #[pyo3(signature = (levels, intercept, slopes=None))]
+    fn new<'py>(
+        levels: PyReadonlyArray1<'py, u32>,
+        intercept: bool,
+        slopes: Option<Vec<PyReadonlyArray1<'py, f64>>>,
+    ) -> PyResult<Self> {
+        let levels = levels.as_array().to_vec();
+        let slopes: Vec<Vec<f64>> = slopes
+            .unwrap_or_default()
+            .iter()
+            .map(|s| s.as_array().to_vec())
+            .collect();
+        // Validate through the native constructor so the rules live in one place.
+        Effect::new(&levels, intercept, slopes.iter().map(Vec::as_slice)).map_err(value_err)?;
+        Ok(Self {
+            levels,
+            intercept,
+            slopes,
+        })
     }
+}
+
+impl PyEffect {
+    /// Rebuild the borrowed native [`Effect`]. Infallible: `PyEffect::new`
+    /// already validated these exact columns through `Effect::new`.
+    fn as_effect(&self) -> Effect<'_> {
+        Effect::new(
+            &self.levels,
+            self.intercept,
+            self.slopes.iter().map(Vec::as_slice),
+        )
+        .expect("PyEffect columns were validated at construction")
+    }
+}
+
+/// A solve's design, as interpreted from the Python `design` argument.
+enum DesignSource<'py> {
+    /// An `(n_obs, n_factors)` categories matrix, borrowed from numpy.
+    Categories(PyReadonlyArray2<'py, u32>),
+    /// Effect terms, cloned out of Python so they can be rebuilt off-GIL.
+    Effects(Vec<PyEffect>),
+}
+
+/// Interpret the Python `design` argument: a 2-D `uint32` categories matrix
+/// (borrowed) or a list of [`Effect`] terms (cloned out of Python).
+fn extract_design<'py>(py: Python<'_>, design: &Bound<'py, PyAny>) -> PyResult<DesignSource<'py>> {
+    if design.downcast::<PyUntypedArray>().is_ok() {
+        let categories = design.extract::<PyReadonlyArray2<u32>>()?;
+        warn_c_contiguous(py, &categories.as_array())?;
+        return Ok(DesignSource::Categories(categories));
+    }
+    let effects: Vec<Py<PyEffect>> = design
+        .extract()
+        .map_err(|_| value_err("design must be a 2-D uint32 array or a list of Effect"))?;
+    Ok(DesignSource::Effects(
+        effects
+            .iter()
+            .map(|e| e.bind(py).borrow().clone())
+            .collect(),
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -119,46 +198,37 @@ pub struct PySolver {
 #[pymethods]
 impl PySolver {
     #[new]
-    #[pyo3(signature = (categories, weights=None, preconditioner=None))]
+    #[pyo3(signature = (design, weights=None, preconditioner=None))]
     fn new<'py>(
         py: Python<'py>,
-        categories: PyReadonlyArray2<'py, u32>,
+        design: &Bound<'py, PyAny>,
         weights: Option<PyReadonlyArray1<'py, f64>>,
         preconditioner: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Self> {
-        let cats = categories.as_array();
-        warn_c_contiguous(py, &cats)?;
-
-        let n_obs = cats.nrows();
-        let n_factors = cats.ncols();
-        let weights_vec: Option<Vec<f64>> = weights
-            .as_ref()
-            .map(|w| w.as_array().iter().copied().collect());
-
-        // Resolve the preconditioner argument while the GIL is held (it inspects
-        // Python objects); the result carries only native data.
+        let weights_vec: Option<Vec<f64>> = weights.as_ref().map(|w| w.as_array().to_vec());
         let precond = resolve_precond_input(py, preconditioner)?;
 
-        // Release the GIL for the CPU-heavy work: the factor-major copy out of
-        // the numpy array, the store/design construction, and the preconditioner
-        // factorisation. The `BuildError` carries no GIL types, so it is mapped
-        // to a Python exception only after the GIL is reacquired.
-        let solver = py
-            .allow_threads(move || -> Result<Solver<FactorMajorStore>, BuildError> {
-                let factor_levels: Vec<Vec<u32>> = (0..n_factors)
-                    .map(|f| cats.column(f).iter().copied().collect())
-                    .collect();
-                let store = FactorMajorStore::new(factor_levels, n_obs)?;
-                let design = Design::from_store(store)?;
-                match precond {
-                    PrecondInput::Prebuilt(built) => Solver::new(design, weights_vec, built),
-                    PrecondInput::Config(config) => {
-                        Solver::new(design, weights_vec, config.as_ref())
-                    }
-                }
-            })
-            .map_err(value_err)?;
-
+        // Release the GIL for the design copy/build and preconditioner
+        // factorisation; `BuildError` carries no Python types, so it is mapped
+        // to a Python exception only once the GIL is reacquired.
+        let solver = match extract_design(py, design)? {
+            DesignSource::Categories(categories) => {
+                let cats = categories.as_array();
+                py.allow_threads(move || -> Result<Solver<FactorMajorStore>, BuildError> {
+                    let factor_levels =
+                        (0..cats.ncols()).map(|f| cats.column(f).to_vec()).collect();
+                    let store = FactorMajorStore::new(factor_levels, cats.nrows())?;
+                    Solver::new(Design::from_store(store)?, weights_vec, precond)
+                })
+            }
+            DesignSource::Effects(terms) => {
+                py.allow_threads(move || -> Result<Solver<FactorMajorStore>, BuildError> {
+                    let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
+                    Solver::new(effects, weights_vec, precond)
+                })
+            }
+        }
+        .map_err(value_err)?;
         Ok(Self { solver })
     }
 

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -11,7 +11,7 @@ use within::config::{
     ApproxCholConfig, ApproxSchurConfig, LocalSolverConfig, LsmrOptions, PreconditionerConfig,
     ReductionStrategy,
 };
-use within::Preconditioner;
+use within::{Preconditioner, PreconditionerInput};
 
 // ---------------------------------------------------------------------------
 // Low-level config classes (available via `_within` for benchmarks)
@@ -297,6 +297,15 @@ impl PyPreconditioner {
 pub(crate) enum PrecondInput {
     Prebuilt(Preconditioner),
     Config(Option<PreconditionerConfig>),
+}
+
+impl From<PrecondInput> for PreconditionerInput {
+    fn from(input: PrecondInput) -> Self {
+        match input {
+            PrecondInput::Prebuilt(p) => p.into(),
+            PrecondInput::Config(c) => c.as_ref().into(),
+        }
+    }
 }
 
 /// Resolve the Python `preconditioner` argument into a [`PrecondInput`].

--- a/crates/within-py/src/lib.rs
+++ b/crates/within-py/src/lib.rs
@@ -13,7 +13,7 @@ mod config;
 mod convert;
 mod results;
 
-use api::{solve, solve_batch, PySolver};
+use api::{solve, solve_batch, PyEffect, PySolver};
 use config::{
     PyAdditiveSchwarz, PyApproxCholConfig, PyApproxSchurConfig, PyLocalSolverConfig, PyLsmrOptions,
     PyPreconditioner, PyPreconditionerConfig, PyReductionStrategy,
@@ -37,6 +37,7 @@ fn _within(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyLocalSolverConfig>()?;
     m.add_class::<PyPreconditioner>()?;
     m.add_class::<PySolver>()?;
+    m.add_class::<PyEffect>()?;
     m.add_function(wrap_pyfunction!(solve, m)?)?;
     m.add_function(wrap_pyfunction!(solve_batch, m)?)?;
     Ok(())

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -1,9 +1,12 @@
 //! Domain layer: [`Design`] (design-matrix metadata) and factor-pair [`Subdomain`] construction.
 
 pub(crate) mod cross_tab;
+mod effect;
 pub(crate) mod factor_pairs;
 
 pub(crate) use cross_tab::{find_all_active_levels, BlockDiagonals, CrossTab};
+
+pub use effect::Effect;
 
 pub(crate) use factor_pairs::{build_local_domains, LocalDomain};
 
@@ -93,6 +96,30 @@ pub struct Design<S: Store> {
     /// Locality permutation applied at construction, if any: `obs_perm[k]` is
     /// the caller's original index of the observation at internal position `k`.
     pub(crate) obs_perm: Option<Vec<u32>>,
+}
+
+impl Design<FactorMajorStore> {
+    /// Lowers each effect's level column onto the categories path, yielding a
+    /// design bit-compatible with one built from a categories matrix. Slope-bearing
+    /// effects are rejected for now (slopes land in a later slice).
+    pub fn new<'a>(effects: impl IntoIterator<Item = Effect<'a>>) -> Result<Self, BuildError> {
+        let mut columns: Vec<Vec<u32>> = Vec::new();
+        for (idx, effect) in effects.into_iter().enumerate() {
+            if !effect.slopes().is_empty() {
+                return Err(BuildError::SlopesNotYetSupported { effect: idx });
+            }
+            // A slope-free effect must carry an intercept: `Effect::new` rejects
+            // the one with neither, so this is the only intercept-only shape left.
+            debug_assert!(
+                effect.intercept(),
+                "slope-free effect must be intercept-only"
+            );
+            columns.push(effect.levels().to_vec());
+        }
+        let n_obs = columns.first().map_or(0, Vec::len);
+        let store = FactorMajorStore::new(columns, n_obs)?;
+        Design::from_store(store)
+    }
 }
 
 impl<S: Store> Design<S> {
@@ -339,5 +366,20 @@ mod tests {
         };
         assert_eq!(col(0), [0, 0, 1, 2]);
         assert_eq!(col(1), [0, 1, 1, 0]);
+    }
+
+    #[test]
+    fn new_rejects_slope_bearing_effect_naming_its_index() {
+        let plain = [0u32, 1, 0, 1];
+        let slope = [1.0, 2.0, 3.0, 4.0];
+        let effects = vec![
+            Effect::new(&plain, true, []).unwrap(),
+            Effect::new(&plain, true, [&slope[..]]).unwrap(),
+        ];
+        let err = Design::new(effects).unwrap_err();
+        assert!(matches!(
+            err,
+            BuildError::SlopesNotYetSupported { effect: 1 }
+        ));
     }
 }

--- a/crates/within/src/domain/effect.rs
+++ b/crates/within/src/domain/effect.rs
@@ -1,0 +1,79 @@
+use crate::BuildError;
+
+/// One factor's contribution to a design: level codes, an optional per-level
+/// intercept, and per-level slope covariates.
+#[derive(Clone, Debug)]
+pub struct Effect<'a> {
+    levels: &'a [u32],
+    intercept: bool,
+    slopes: Box<[&'a [f64]]>,
+}
+
+impl<'a> Effect<'a> {
+    /// Validates the effect is non-empty and every slope matches the level count.
+    pub fn new(
+        levels: &'a [u32],
+        intercept: bool,
+        slopes: impl IntoIterator<Item = &'a [f64]>,
+    ) -> Result<Self, BuildError> {
+        let slopes: Box<[&[f64]]> = slopes.into_iter().collect();
+        if !intercept && slopes.is_empty() {
+            return Err(BuildError::EmptyEffect);
+        }
+        let n = levels.len();
+        for (slope, s) in slopes.iter().enumerate() {
+            if s.len() != n {
+                return Err(BuildError::SlopeLengthMismatch {
+                    slope,
+                    expected: n,
+                    got: s.len(),
+                });
+            }
+        }
+        Ok(Self {
+            levels,
+            intercept,
+            slopes,
+        })
+    }
+
+    pub(crate) fn levels(&self) -> &[u32] {
+        self.levels
+    }
+
+    pub(crate) fn intercept(&self) -> bool {
+        self.intercept
+    }
+
+    pub(crate) fn slopes(&self) -> &[&'a [f64]] {
+        &self.slopes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_rejects_slope_length_mismatch_naming_the_offending_slope() {
+        let levels = [0u32, 1, 0, 1];
+        let ok = [1.0, 2.0, 3.0, 4.0];
+        let short = [1.0, 2.0];
+        let err = Effect::new(&levels, true, [&ok[..], &short[..]]).unwrap_err();
+        assert!(matches!(
+            err,
+            BuildError::SlopeLengthMismatch {
+                slope: 1,
+                expected: 4,
+                got: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn new_rejects_effect_with_no_intercept_and_no_slopes() {
+        let levels = [0u32, 1, 0, 1];
+        let err = Effect::new(&levels, false, []).unwrap_err();
+        assert!(matches!(err, BuildError::EmptyEffect));
+    }
+}

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -21,6 +21,25 @@ pub enum BuildError {
         /// Actual number of observations in this factor's column.
         got: usize,
     },
+    /// An effect with neither an intercept nor a slope.
+    #[error("an effect must have an intercept or at least one slope")]
+    EmptyEffect,
+    /// A slope covariate's length does not match the effect's level count.
+    #[error("slope {slope} has {got} values, expected {expected}")]
+    SlopeLengthMismatch {
+        /// Index of the slope covariate within its effect.
+        slope: usize,
+        /// Expected length (the effect's level count).
+        expected: usize,
+        /// Actual length.
+        got: usize,
+    },
+    /// An effect carries varying slopes, which the solver does not yet support.
+    #[error("effect {effect} has varying slopes, not yet supported by the solver")]
+    SlopesNotYetSupported {
+        /// Index of the offending effect.
+        effect: usize,
+    },
     /// Weight vector does not match the number of observations.
     #[error("weights has length {got}, expected {expected}")]
     WeightCountMismatch {

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -24,7 +24,7 @@ pub(crate) mod operator;
 pub(crate) mod solver;
 
 pub use config::{LsmrOptions, PreconditionerConfig};
-pub use domain::Design;
+pub use domain::{Design, Effect};
 pub use error::{BuildError, SolveError, WithinError};
 pub use operator::schwarz::Preconditioner;
-pub use solver::{solve, solve_batch, BatchSolveResult, SolveResult, Solver};
+pub use solver::{solve, solve_batch, BatchSolveResult, PreconditionerInput, SolveResult, Solver};

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -9,8 +9,8 @@ use rayon::prelude::*;
 use schwarz_precond::{lsmr as lsmr_solve, mlsmr, Operator as _};
 
 use crate::config::{LsmrOptions, PreconditionerConfig};
-use crate::domain::Design;
-use crate::observation::{validate_weights, ArrayStore, Store};
+use crate::domain::{Design, Effect};
+use crate::observation::{validate_weights, ArrayStore, FactorMajorStore, Store};
 use crate::operator::design::gather_apply;
 use crate::operator::schwarz::{build_preconditioner, Preconditioner};
 use crate::operator::DesignOperator;
@@ -24,6 +24,7 @@ fn norm(v: &[f64]) -> f64 {
 ///
 /// Implemented for:
 /// - `ArrayView2<'a, u32>` — categories matrix; an `ArrayStore`-backed [`Design`] is built
+/// - `Vec<Effect<'a>>` — effect terms lowered to a [`Design`] via [`Design::new`]
 /// - `Design<S>` — pass-through for an already-built design
 pub trait IntoDesign<'a> {
     /// Storage backend the resulting [`Design`] uses.
@@ -43,6 +44,13 @@ impl<S: Store> IntoDesign<'_> for Design<S> {
     type Store = S;
     fn into_design(self) -> Result<Design<S>, BuildError> {
         Ok(self)
+    }
+}
+
+impl<'a> IntoDesign<'a> for Vec<Effect<'a>> {
+    type Store = FactorMajorStore;
+    fn into_design(self) -> Result<Design<FactorMajorStore>, BuildError> {
+        Design::new(self)
     }
 }
 
@@ -386,11 +394,11 @@ impl<S: Store> Solver<S> {
 // High-level one-shot API
 // ===========================================================================
 
-/// Solve fixed-effects least squares from raw category data.
+/// Solve fixed-effects least squares for a design input.
 ///
-/// `categories` is an observation-major `(n_obs, n_factors)` array where
-/// `categories[[i, q]]` is the level of observation `i` in factor `q`.
-/// Levels must be `0..max_level` per factor; the number of levels is inferred.
+/// `design` is anything implementing [`IntoDesign`]: an observation-major
+/// `(n_obs, n_factors)` categories array (levels `0..max_level` per factor,
+/// count inferred) or a list of [`Effect`] terms.
 /// `y` is the response vector (length = n_obs).
 ///
 /// Zero-copy when the dominant factor is already sorted: the category array is
@@ -402,15 +410,15 @@ impl<S: Store> Solver<S> {
 /// [`crate::Preconditioner`], or a `&Preconditioner` for amortized reuse.
 ///
 /// This is a convenience wrapper around [`Solver::new`] + [`Solver::solve`].
-pub fn solve(
-    categories: ArrayView2<u32>,
+pub fn solve<'a>(
+    design: impl IntoDesign<'a>,
     y: &[f64],
     weights: Option<&[f64]>,
     lsmr: &LsmrOptions,
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<SolveResult, WithinError> {
     let t_start = Instant::now();
-    let solver = Solver::new(categories, weights.map(|w| w.to_vec()), preconditioner)?;
+    let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve(y, lsmr)?;
     // Include solver construction (preconditioner build) in setup time
@@ -423,15 +431,15 @@ pub fn solve(
 ///
 /// Same as [`solve`] but solves all RHS vectors in parallel (via rayon),
 /// reusing the preconditioner across all solves.
-pub fn solve_batch(
-    categories: ArrayView2<u32>,
+pub fn solve_batch<'a>(
+    design: impl IntoDesign<'a>,
     ys: &[&[f64]],
     weights: Option<&[f64]>,
     lsmr: &LsmrOptions,
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<BatchSolveResult, WithinError> {
     let t_start = Instant::now();
-    let solver = Solver::new(categories, weights.map(|w| w.to_vec()), preconditioner)?;
+    let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
     let mut result = solver.solve_batch(ys, lsmr)?;
     result.time_total = t_start.elapsed().as_secs_f64();
     Ok(result)

--- a/crates/within/tests/domain.rs
+++ b/crates/within/tests/domain.rs
@@ -162,3 +162,59 @@ fn test_single_factor_design_solve_without_precond() {
         result.residual
     );
 }
+
+// ---------------------------------------------------------------------------
+// 4. Effect-term design API (issue #58)
+// ---------------------------------------------------------------------------
+
+/// Intercept-only `Effect` design vs. the categories path. Both run through the
+/// same `from_store` locality sort, so rows sum in the same order and the result
+/// is bit-identical — hence the exact `assert_eq`, not a tolerance.
+#[test]
+fn test_intercept_only_effects_match_categories_bitwise() {
+    use within::{Effect, LsmrOptions, PreconditionerConfig, Solver};
+
+    // Non-monotonic dominant factor so the locality sort is genuinely exercised.
+    let col0: Vec<u32> = vec![3, 0, 2, 1, 3, 0, 2, 1, 3, 0, 2, 1];
+    let col1: Vec<u32> = vec![0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1];
+    let n_obs = col0.len();
+    let y: Vec<f64> = (0..n_obs)
+        .map(|i| (i as f64 * 1.3 - 2.0).sin() + 0.5)
+        .collect();
+    let params = LsmrOptions::default();
+    let precond = PreconditionerConfig::default();
+
+    let categories = Design::from_store(
+        FactorMajorStore::new(vec![col0.clone(), col1.clone()], n_obs).expect("store"),
+    )
+    .expect("categories design");
+    let cat = Solver::new(categories, None, &precond)
+        .expect("categories solver")
+        .solve(&y, &params)
+        .expect("categories solve");
+
+    let eff = Solver::new(
+        vec![
+            Effect::new(&col0, true, []).expect("effect 0"),
+            Effect::new(&col1, true, []).expect("effect 1"),
+        ],
+        None,
+        &precond,
+    )
+    .expect("effect solver")
+    .solve(&y, &params)
+    .expect("effect solve");
+
+    // Bit-identity is only meaningful if both solves actually converged:
+    // `Solver::solve` returns `Ok` even at `maxiter`, so without this the
+    // assert_eqs could pass on two identical non-converged states.
+    assert!(
+        eff.converged && cat.converged,
+        "both solves must converge for bit-identity to be meaningful"
+    );
+    assert_eq!(eff.x, cat.x, "coefficients must be bit-identical");
+    assert_eq!(
+        eff.demeaned, cat.demeaned,
+        "residuals must be bit-identical"
+    );
+}

--- a/python/within/__init__.py
+++ b/python/within/__init__.py
@@ -45,6 +45,7 @@ For Rust-level internals, build the API docs with ``cargo doc --open``.
 
 from within._within import (
     BatchSolveResult,
+    Effect,
     LsmrOptions,
     Preconditioner,
     PreconditionerConfig,
@@ -57,6 +58,7 @@ from within import config  # noqa: F401 — expose submodule on `within.config`
 
 __all__ = [
     "BatchSolveResult",
+    "Effect",
     "LsmrOptions",
     "Preconditioner",
     "PreconditionerConfig",

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -134,8 +134,18 @@ class BatchSolveResult:
     @property
     def time_total(self) -> float: ...
 
+class Effect:
+    """One factor's effect: level codes, an optional intercept, and slope covariates."""
+
+    def __init__(
+        self,
+        levels: NDArray[np.uint32],
+        intercept: bool,
+        slopes: list[NDArray[np.float64]] | None = None,
+    ) -> None: ...
+
 def solve(
-    categories: NDArray[np.uint32],
+    design: NDArray[np.uint32] | list[Effect],
     y: NDArray[np.float64],
     options: LsmrOptions | None = None,
     weights: NDArray[np.float64] | None = None,
@@ -150,10 +160,9 @@ def solve(
     implied by ``categories`` and ``W`` is the diagonal weight matrix.
 
     Args:
-        categories: Factor assignments, shape ``(n_obs, n_factors)``,
-            dtype ``uint32``. Each column contains zero-based level indices
-            for one factor. Should be F-contiguous (column-major) for best
-            performance; a ``UserWarning`` is emitted for C-contiguous arrays.
+        design: Either a ``(n_obs, n_factors)`` ``uint32`` array of factor
+            assignments (F-contiguous for best performance; a ``UserWarning``
+            is emitted otherwise), or a list of :class:`Effect` terms.
         y: Response vector, shape ``(n_obs,)``, dtype ``float64``.
         options: LSMR solver tuning. Pass ``LsmrOptions(...)`` to override
             defaults. Default: ``LsmrOptions(tol=1e-8, maxiter=1000)``.
@@ -247,7 +256,7 @@ class Solver:
 
     def __init__(
         self,
-        categories: NDArray[np.uint32],
+        design: NDArray[np.uint32] | list[Effect],
         weights: NDArray[np.float64] | None = None,
         preconditioner: (
             PreconditionerConfig | AdditiveSchwarz | Preconditioner | None

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from within import solve
+from within import Effect, solve
 from within._within import ApproxSchurConfig
 
 
@@ -74,3 +74,21 @@ class TestErrorHandling:
         """ApproxSchurConfig(split=0) should raise ValueError."""
         with pytest.raises((ValueError, OverflowError)):
             ApproxSchurConfig(split=0)
+
+
+class TestEffectErrors:
+    def test_empty_effect_raises(self):
+        with pytest.raises(ValueError, match="intercept or at least one slope"):
+            Effect(np.array([0, 1, 0], dtype=np.uint32), intercept=False)
+
+    def test_slope_length_mismatch_names_slope(self):
+        levels = np.array([0, 1, 0], dtype=np.uint32)
+        with pytest.raises(ValueError, match="slope 0"):
+            Effect(levels, intercept=True, slopes=[np.array([1.0, 2.0])])
+
+    def test_slope_bearing_design_raises(self):
+        levels = np.array([0, 1, 0], dtype=np.uint32)
+        slope = np.array([1.0, 2.0, 3.0])
+        y = np.array([1.0, 2.0, 3.0])
+        with pytest.raises(ValueError, match="slope"):
+            solve([Effect(levels, intercept=True, slopes=[slope])], y)

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -7,6 +7,7 @@ import pytest
 
 from within import (
     BatchSolveResult,
+    Effect,
     LsmrOptions,
     Preconditioner,
     PreconditionerConfig,
@@ -413,3 +414,24 @@ class TestGenerateSyntheticData:
         np.testing.assert_array_equal(c1, c2)
         np.testing.assert_array_equal(x1, x2)
         np.testing.assert_array_equal(y1, y2)
+
+
+class TestEffectDesign:
+    def test_intercept_only_matches_categories_path(self):
+        # The issue's trust anchor: an intercept-only effect design must be
+        # bit-identical to the equivalent categories-matrix solve.
+        rng = np.random.default_rng(0)
+        n = 300
+        col0 = rng.integers(0, 4, size=n).astype(np.uint32)
+        col1 = rng.integers(0, 6, size=n).astype(np.uint32)
+        y = rng.standard_normal(n)
+
+        categories = np.asfortranarray(np.column_stack([col0, col1]))
+        from_categories = solve(categories, y)
+        from_effects = solve(
+            [Effect(col0, intercept=True), Effect(col1, intercept=True)], y
+        )
+
+        assert from_effects.converged
+        np.testing.assert_array_equal(from_effects.x, from_categories.x)
+        np.testing.assert_array_equal(from_effects.demeaned, from_categories.demeaned)


### PR DESCRIPTION
`solve`/`Solver` now accept either a categories matrix or a `list[Effect]` (one
factor's level codes + optional intercept + per-level slopes). Intercept-only
terms lower to the existing fixed-effects path, bit-identical to the categories
solve; slope-bearing terms are validated but rejected for now.

- `Effect` (core + PyO3): eager validation — empty-effect, per-slope length naming the bad slope.
- `Design::new(effects)`: lowers intercept-only terms; rejects slope-bearing, naming the term.
- Free `solve`/`solve_batch` + `Solver` generalized over `IntoDesign` (adds a `Vec<Effect>` impl).

**Parity**: Rust + Python tests assert `x`/`demeaned` bit-identical to the categories solve; error tests cover the rejection cases.

Base `feature/slopes` (carries prerequisite #65).
