### PR TITLE
Varying slopes: solve-result side-channel for unidentified directions (#69)

### DIFF
--- a/crates/within-py/src/results.rs
+++ b/crates/within-py/src/results.rs
@@ -18,6 +18,8 @@ pub struct PySolveResult {
     #[pyo3(get)]
     pub x: Py<numpy::PyArray1<f64>>,
     #[pyo3(get)]
+    pub unidentified: Vec<(usize, usize, usize)>,
+    #[pyo3(get)]
     pub demeaned: Py<numpy::PyArray1<f64>>,
     #[pyo3(get)]
     pub converged: bool,
@@ -39,6 +41,8 @@ pub struct PyBatchSolveResult {
     #[pyo3(get)]
     pub x: Py<numpy::PyArray2<f64>>,
     #[pyo3(get)]
+    pub unidentified: Vec<(usize, usize, usize)>,
+    #[pyo3(get)]
     pub demeaned: Py<numpy::PyArray2<f64>>,
     #[pyo3(get)]
     pub converged: Vec<bool>,
@@ -59,6 +63,11 @@ pub struct PyBatchSolveResult {
 pub(crate) fn into_py_result(py: Python<'_>, result: SolveResult) -> PySolveResult {
     PySolveResult {
         x: result.x.into_pyarray(py).unbind(),
+        unidentified: result
+            .unidentified
+            .iter()
+            .map(|u| (u.term, u.level, u.column))
+            .collect(),
         demeaned: result.demeaned.into_pyarray(py).unbind(),
         converged: result.converged,
         iterations: result.iterations,
@@ -83,6 +92,11 @@ pub(crate) fn into_py_batch_result(
 
     Ok(PyBatchSolveResult {
         x: x.into_pyarray(py).unbind(),
+        unidentified: result
+            .unidentified
+            .iter()
+            .map(|u| (u.term, u.level, u.column))
+            .collect(),
         demeaned: demeaned.into_pyarray(py).unbind(),
         converged: result.converged,
         iterations: result.iterations,

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -29,4 +29,5 @@ pub use error::{BuildError, SolveError, WithinError};
 pub use operator::schwarz::Preconditioner;
 pub use solver::{
     solve, solve_batch, BatchSolveResult, IntoDesign, PreconditionerInput, SolveResult, Solver,
+    UnidentifiedDirection,
 };

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -108,12 +108,30 @@ impl From<&Preconditioner> for PreconditionerInput {
     }
 }
 
+/// A per-level direction of the design that the data cannot identify.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnidentifiedDirection {
+    /// Index into the design's term list.
+    pub term: usize,
+    /// Level index within the term (`0..n_levels`).
+    pub level: usize,
+    /// Column within the term's per-level block: intercept first (when
+    /// present), then slopes in declaration order.
+    pub column: usize,
+}
+
 /// Common solve output for all orchestration entry points.
 #[derive(Debug, Clone)]
 #[must_use]
 pub struct SolveResult {
     /// Fixed-effect coefficients (length = total DOFs across all factors).
+    ///
+    /// Slots for unidentified directions hold the minimal-norm value `0`,
+    /// never NaN; see [`SolveResult::unidentified`].
     pub x: Vec<f64>,
+    /// Per-level directions the data cannot identify. Empty until
+    /// [`Solver::new`] accepts slope terms.
+    pub unidentified: Vec<UnidentifiedDirection>,
     /// Demeaned response: `y - D x` (length = n_obs), in caller order.
     ///
     /// Invariant: any per-observation field added here must be translated
@@ -138,7 +156,13 @@ pub struct SolveResult {
 #[derive(Debug, Clone)]
 pub struct BatchSolveResult {
     /// All coefficient vectors concatenated (length = n_dofs * n_rhs).
+    ///
+    /// Slots for unidentified directions hold the minimal-norm value `0`,
+    /// never NaN; see [`BatchSolveResult::unidentified`].
     pub x: Vec<f64>,
+    /// Per-level directions the data cannot identify, shared across all RHS:
+    /// identification depends only on the design and weights, never on `y`.
+    pub unidentified: Vec<UnidentifiedDirection>,
     /// All demeaned responses concatenated (length = n_obs * n_rhs).
     pub demeaned: Vec<f64>,
     /// Per-RHS convergence flags.
@@ -325,6 +349,7 @@ impl<'a> Solver<'a> {
 
         Ok(SolveResult {
             x: r.x,
+            unidentified: Vec::new(),
             // Back to the caller's observation order (no-op if not reordered).
             demeaned: self.design.permute_obs_out(demeaned),
             converged: r.converged,
@@ -359,6 +384,13 @@ impl<'a> Solver<'a> {
         let mut residual = Vec::with_capacity(n_rhs);
         let mut time_solve = Vec::with_capacity(n_rhs);
 
+        // Identical for every RHS: identification depends only on the design
+        // and weights, never on `y`.
+        let unidentified = results
+            .first()
+            .map(|r| r.unidentified.clone())
+            .unwrap_or_default();
+
         for r in results {
             x.extend_from_slice(&r.x);
             demeaned.extend_from_slice(&r.demeaned);
@@ -370,6 +402,7 @@ impl<'a> Solver<'a> {
 
         Ok(BatchSolveResult {
             x,
+            unidentified,
             demeaned,
             converged,
             iterations,

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -134,6 +134,22 @@ fn test_solver_batch() {
 }
 
 #[test]
+fn test_unidentified_empty_for_plain_factors() {
+    let (categories, y) = categories_and_y();
+    let params = default_params();
+    let precond = additive_precond();
+
+    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+
+    let single = solver.solve(&y, &params).expect("solve");
+    assert!(single.unidentified.is_empty());
+    assert!(single.x.iter().all(|v| v.is_finite()));
+
+    let batch = solver.solve_batch(&[&y], &params).expect("solve batch");
+    assert!(batch.unidentified.is_empty());
+}
+
+#[test]
 fn test_solver_properties() {
     let (categories, _) = categories_and_y();
 

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -74,7 +74,10 @@ class SolveResult:
     Attributes:
         x: Fixed-effect coefficients, shape ``(n_dofs,)``. The DOF ordering
             matches the factor levels: all levels of factor 0 first, then
-            factor 1, etc.
+            factor 1, etc. Slots for unidentified directions hold the
+            minimal-norm value ``0``, never NaN.
+        unidentified: Per-level directions the data cannot identify, as
+            ``(term, level, column)`` tuples.
         demeaned: Response vector after subtracting estimated fixed effects,
             shape ``(n_obs,)``.
         converged: Whether the LSMR solver met the convergence tolerance.
@@ -88,6 +91,8 @@ class SolveResult:
 
     @property
     def x(self) -> NDArray[np.float64]: ...
+    @property
+    def unidentified(self) -> list[tuple[int, int, int]]: ...
     @property
     def demeaned(self) -> NDArray[np.float64]: ...
     @property
@@ -110,6 +115,10 @@ class BatchSolveResult:
 
     Attributes:
         x: Fixed-effect coefficients, shape ``(n_dofs, k)`` (column-major).
+            Slots for unidentified directions hold the minimal-norm value
+            ``0``, never NaN.
+        unidentified: Per-level directions the data cannot identify, as
+            ``(term, level, column)`` tuples; shared across all RHS.
         demeaned: Demeaned responses, shape ``(n_obs, k)`` (column-major).
         converged: Whether each RHS converged.
         iterations: Total LSMR iterations for each RHS.
@@ -121,6 +130,8 @@ class BatchSolveResult:
 
     @property
     def x(self) -> NDArray[np.float64]: ...
+    @property
+    def unidentified(self) -> list[tuple[int, int, int]]: ...
     @property
     def demeaned(self) -> NDArray[np.float64]: ...
     @property

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -163,6 +163,7 @@ class TestSolveResult:
         assert isinstance(result.x, np.ndarray)
         assert result.x.dtype == np.float64
         assert len(result.x) == 100  # 50 + 50 levels
+        assert result.unidentified == []
         assert result.time_total >= 0
         assert result.time_setup >= 0
         assert result.time_solve >= 0
@@ -271,6 +272,7 @@ class TestSolverBatch:
         assert len(batch.residual) == 2
         assert len(batch.time_solve) == 2
         assert batch.time_total >= 0
+        assert batch.unidentified == []
 
 
 class TestSolverSerde:


### PR DESCRIPTION
Implements the contract for #69 (contract only — nothing detects rank drops until #59 relaxes the slope guard).

- `UnidentifiedDirection { term, level, column }` entries on `SolveResult` and `BatchSolveResult`; the batch list is shared across RHS (identification depends only on design + weights).
- Coefficient-array contract documented on `x`: dropped slots hold minimal-norm `0`, never NaN.
- Python surface: `unidentified` on both result classes as `(term, level, column)` tuples, with stubs.
- The issue's done-when assertion (constant-within-level slope → `0` + one entry) lands as #59's first test.

Note: merging into `feature/slopes` won't auto-close #69 — close it manually after merge.