### PR TITLE
Varying slopes: single slope on one factor (V=1) — centering + back-transform (#59)

### DIFF
--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -34,8 +34,8 @@ pub enum BuildError {
         /// Actual length.
         got: usize,
     },
-    /// An effect carries varying slopes, which the solver does not yet support.
-    #[error("effect {effect} has varying slopes, not yet supported by the solver")]
+    /// An effect carries varying slopes in a form the solver does not yet support.
+    #[error("effect {effect} has varying slopes, not yet supported alongside other effects or with more than one slope")]
     SlopesNotYetSupported {
         /// Index of the offending effect.
         effect: usize,

--- a/crates/within/src/observation.rs
+++ b/crates/within/src/observation.rs
@@ -69,6 +69,12 @@ impl<'a> ObservationFrame<'a> {
         &self.continuous[k]
     }
 
+    /// Replace loading column `i` with an owned column of matching row count.
+    pub(crate) fn set_loading_column(&mut self, i: usize, column: Vec<f64>) {
+        debug_assert_eq!(column.len(), self.n_obs);
+        self.continuous[i] = Cow::Owned(column);
+    }
+
     /// Convert every column to owned, dropping ties to caller buffers.
     pub fn into_owned(self) -> ObservationFrame<'static> {
         ObservationFrame {

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -200,10 +200,29 @@ fn build_diagonal(
 ) -> Result<DiagonalPreconditioner, BuildError> {
     let mut diag = vec![0.0; design.n_dofs];
 
-    for (factor_idx, factor) in design.terms.iter().enumerate() {
-        let slice = &mut diag[factor.offset..factor.offset + factor.n_levels];
-        for (uid, &level) in design.frame.level_column(factor_idx).iter().enumerate() {
-            slice[level as usize] += weights.map_or(1.0, |w| w[uid]);
+    // diag(DᵀWD): each column contributes w·loading² per observation — the
+    // loading is 1 for an intercept column and the slope value otherwise.
+    for (factor_idx, term) in design.terms.iter().enumerate() {
+        let levels = design.frame.level_column(factor_idx);
+        let w = |uid: usize| weights.map_or(1.0, |ws| ws[uid]);
+        let mut column = 0;
+        if term.intercept {
+            let slice = &mut diag[term.offset..term.offset + term.n_levels];
+            for (uid, &level) in levels.iter().enumerate() {
+                slice[level as usize] += w(uid);
+            }
+            column = 1;
+        }
+        for &z_col in &term.slopes {
+            let z = design.frame.loading_column(z_col);
+            let base = term.offset + column * term.n_levels;
+            let slice = &mut diag[base..base + term.n_levels];
+            for (uid, &level) in levels.iter().enumerate() {
+                // Keep `w * z * z` left-to-right: a zero weight then kills a
+                // huge `z` before the square can overflow (0 * inf = NaN).
+                slice[level as usize] += w(uid) * z[uid] * z[uid];
+            }
+            column += 1;
         }
     }
 

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -17,6 +17,9 @@ use crate::operator::schwarz::{build_preconditioner, Preconditioner};
 use crate::operator::DesignOperator;
 use crate::{BuildError, SolveError, WithinError};
 
+mod reparam;
+use reparam::SlopeReparam;
+
 fn norm(v: &[f64]) -> f64 {
     v.iter().map(|x| x * x).sum::<f64>().sqrt()
 }
@@ -126,11 +129,12 @@ pub struct UnidentifiedDirection {
 pub struct SolveResult {
     /// Fixed-effect coefficients (length = total DOFs across all factors).
     ///
-    /// Slots for unidentified directions hold the minimal-norm value `0`,
-    /// never NaN; see [`SolveResult::unidentified`].
+    /// Term-major: coefficient column `c` of level `level` sits at
+    /// `term_offset + c * n_levels + level`, columns ordered
+    /// `[intercept?, slopes…]`. Slots for unidentified directions hold the
+    /// minimal-norm value `0`, never NaN; see [`SolveResult::unidentified`].
     pub x: Vec<f64>,
-    /// Per-level directions the data cannot identify. Empty until
-    /// [`Solver::new`] accepts slope terms.
+    /// Per-level directions the data cannot identify.
     pub unidentified: Vec<UnidentifiedDirection>,
     /// Demeaned response: `y - D x` (length = n_obs), in caller order.
     ///
@@ -155,7 +159,8 @@ pub struct SolveResult {
 /// Result of a batch solve across multiple RHS vectors.
 #[derive(Debug, Clone)]
 pub struct BatchSolveResult {
-    /// All coefficient vectors concatenated (length = n_dofs * n_rhs).
+    /// All coefficient vectors concatenated (length = n_dofs * n_rhs), each
+    /// block laid out as in [`SolveResult::x`].
     ///
     /// Slots for unidentified directions hold the minimal-norm value `0`,
     /// never NaN; see [`BatchSolveResult::unidentified`].
@@ -211,6 +216,7 @@ pub struct Solver<'a> {
     design: Design<'a>,
     weights: Option<Vec<f64>>,
     preconditioner: Option<Preconditioner>,
+    reparam: Option<SlopeReparam>,
 }
 
 impl std::fmt::Debug for Solver<'_> {
@@ -247,11 +253,14 @@ impl<'a> Solver<'a> {
         weights: Option<Vec<f64>>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
-        let design = design.into_design()?;
-        // Slope-bearing designs build and their operator is exercisable, but
-        // the solve transform and preconditioner land in later slices (#59+).
+        let mut design = design.into_design()?;
+        // A sole V=1 term is solvable via within-level reparametrization (the
+        // whitening below); slopes alongside other terms (#61) or multiple
+        // slopes per factor (#60) land in later slices.
         if let Some(idx) = design.terms.iter().position(|t| !t.slopes.is_empty()) {
-            return Err(BuildError::SlopesNotYetSupported { effect: idx });
+            if design.terms.len() > 1 || design.terms[idx].slopes.len() > 1 {
+                return Err(BuildError::SlopesNotYetSupported { effect: idx });
+            }
         }
         design.validate_weights(weights.as_deref())?;
 
@@ -262,6 +271,9 @@ impl<'a> Solver<'a> {
             Some(_) => weights.map(|w| design.permute_obs_in(&w).into_owned()),
             None => weights,
         };
+
+        // Whiten the slope column (if any) before the preconditioner reads the frame.
+        let reparam = SlopeReparam::build(&mut design, weights.as_deref());
 
         let preconditioner = match preconditioner.into() {
             PreconditionerInput::Default => {
@@ -286,6 +298,7 @@ impl<'a> Solver<'a> {
             design,
             weights,
             preconditioner,
+            reparam,
         })
     }
 
@@ -347,9 +360,18 @@ impl<'a> Solver<'a> {
         rect_op.apply_adjoint(weighted_demeaned.as_ref(), &mut residual_dof)?;
         let residual = norm(&residual_dof) / rhs_norm;
 
+        let mut x = r.x;
+        let unidentified = match &self.reparam {
+            Some(rp) => {
+                rp.back_transform(&mut x);
+                rp.unidentified.clone()
+            }
+            None => Vec::new(),
+        };
+
         Ok(SolveResult {
-            x: r.x,
-            unidentified: Vec::new(),
+            x,
+            unidentified,
             // Back to the caller's observation order (no-op if not reordered).
             demeaned: self.design.permute_obs_out(demeaned),
             converged: r.converged,

--- a/crates/within/src/solver/reparam.rs
+++ b/crates/within/src/solver/reparam.rs
@@ -1,0 +1,147 @@
+//! Within-level reparametrization of a design's sole varying-slope term.
+
+use crate::domain::Design;
+
+use super::UnidentifiedDirection;
+
+/// Per-level affine change of basis for the design's sole slope column: the
+/// solve sees `(z - center) / scale`, which zeroes each level's
+/// intercept–slope cross-term and normalizes the slope block, leaving fitted
+/// values invariant. [`Self::back_transform`] returns coefficients to the
+/// user's parametrization.
+pub(crate) struct SlopeReparam {
+    offset: usize,
+    n_levels: usize,
+    intercept: bool,
+    /// Per-level `(center, scale)`; `None` at dropped and empty levels, whose
+    /// whitened column entries are zeroed and whose coefficients stay `0`.
+    transforms: Vec<Option<(f64, f64)>>,
+    /// Directions the data cannot identify, ascending in `(level, column)`.
+    pub(crate) unidentified: Vec<UnidentifiedDirection>,
+}
+
+impl SlopeReparam {
+    /// Whiten the sole slope term's loading column in place and record how to
+    /// undo it. Returns `None` for slope-free designs.
+    ///
+    /// Identification is judged structurally over positive-weight rows so the
+    /// dropped set is deterministic: an empty level drops the term's every
+    /// column; a slope with no within-level variation (no nonzero value, for
+    /// a slope-only term) drops its slope column. Dropped slope entries are
+    /// materialized as exact zeros, so the minimal-norm LSMR solution leaves
+    /// an exact `0` in the coefficient slot.
+    pub(crate) fn build(design: &mut Design<'_>, weights: Option<&[f64]>) -> Option<Self> {
+        let term = design.terms.iter().position(|t| !t.slopes.is_empty())?;
+        let meta = &design.terms[term];
+        debug_assert_eq!(meta.slopes.len(), 1, "reparametrization is V=1-only");
+        let (offset, n_levels, intercept) = (meta.offset, meta.n_levels, meta.intercept);
+        let z_col = meta.slopes[0];
+        let levels = design.frame.level_column(term);
+        let z = design.frame.loading_column(z_col);
+
+        let mut stats = vec![LevelStats::default(); n_levels];
+        for (i, (&level, &zi)) in levels.iter().zip(z).enumerate() {
+            stats[level as usize].observe(zi, weights.map_or(1.0, |ws| ws[i]));
+        }
+
+        let slope_column = usize::from(intercept);
+        let mut transforms = Vec::with_capacity(n_levels);
+        let mut unidentified = Vec::new();
+        for (level, s) in stats.iter().enumerate() {
+            let transform = s.whitening(intercept);
+            if transform.is_none() {
+                // An empty level loses every column, a degenerate slope only its own.
+                let first = if s.is_empty() { 0 } else { slope_column };
+                for column in first..=slope_column {
+                    unidentified.push(UnidentifiedDirection {
+                        term,
+                        level,
+                        column,
+                    });
+                }
+            }
+            transforms.push(transform);
+        }
+
+        let whitened: Vec<f64> = levels
+            .iter()
+            .zip(z)
+            .map(|(&level, &zi)| match transforms[level as usize] {
+                Some((center, scale)) => (zi - center) / scale,
+                None => 0.0,
+            })
+            .collect();
+        design.frame.set_loading_column(z_col, whitened);
+
+        Some(Self {
+            offset,
+            n_levels,
+            intercept,
+            transforms,
+            unidentified,
+        })
+    }
+
+    /// Map solve-basis coefficients back to the user's parametrization.
+    pub(crate) fn back_transform(&self, x: &mut [f64]) {
+        let slope_base = self.offset + if self.intercept { self.n_levels } else { 0 };
+        for (l, t) in self.transforms.iter().enumerate() {
+            // Dropped levels were never transformed; their coefficients are 0.
+            let Some((center, scale)) = *t else { continue };
+            let b = x[slope_base + l] / scale;
+            x[slope_base + l] = b;
+            if self.intercept {
+                x[self.offset + l] -= b * center;
+            }
+        }
+    }
+}
+
+/// Weighted running moments of `z` within one level (Welford), plus the
+/// structural variation flags, over positive-weight rows only.
+#[derive(Clone, Copy, Default)]
+struct LevelStats {
+    w_sum: f64,
+    mean: f64,
+    m2: f64,
+    first_z: f64,
+    varies: bool,
+}
+
+impl LevelStats {
+    fn observe(&mut self, z: f64, w: f64) {
+        // Zero-weight rows may carry arbitrary values; they must not affect
+        // identification or the scale.
+        if w <= 0.0 {
+            return;
+        }
+        if self.w_sum == 0.0 {
+            self.first_z = z;
+        } else {
+            self.varies |= z != self.first_z;
+        }
+        self.w_sum += w;
+        let delta = z - self.mean;
+        self.mean += (w / self.w_sum) * delta;
+        self.m2 += w * delta * (z - self.mean);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.w_sum == 0.0
+    }
+
+    /// The level's `(center, scale)`, or `None` when the slope direction is
+    /// structurally unidentifiable: `z` constant against a pinned intercept,
+    /// identically zero without one, or an empty level.
+    fn whitening(&self, intercept: bool) -> Option<(f64, f64)> {
+        let (identified, center, ssq) = if intercept {
+            (self.varies, self.mean, self.m2)
+        } else {
+            // Uncentered second moment: Σwz² = m2 + w·mean², both non-negative.
+            let ssq = self.m2 + self.w_sum * self.mean * self.mean;
+            (self.varies || self.first_z != 0.0, 0.0, ssq)
+        };
+        let scale = ssq.sqrt();
+        (identified && scale > 0.0 && scale.is_finite()).then_some((center, scale))
+    }
+}

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -290,3 +290,18 @@ fn test_solver_rejects_slope_bearing_design_naming_its_term() {
         other => panic!("Expected SlopesNotYetSupported for term 1, got: {other:?}"),
     }
 }
+
+#[test]
+fn test_solver_rejects_multiple_slopes_on_one_factor() {
+    let levels = [0u32, 1, 0, 1];
+    let z1 = [1.0, 2.0, 3.0, 4.0];
+    let z2 = [0.5, -1.0, 2.0, 0.0];
+    let effects = vec![within::Effect::new(&levels, true, [&z1[..], &z2[..]]).expect("V=2 effect")];
+    // A sole V=1 term solves (#59); V≥2 waits on the rank-drop contract (#60).
+    let design = Design::new(effects).expect("V=2 design builds");
+    let err = Solver::new(design, None, None).unwrap_err();
+    match err {
+        BuildError::SlopesNotYetSupported { effect: 0 } => {}
+        other => panic!("Expected SlopesNotYetSupported for term 0, got: {other:?}"),
+    }
+}

--- a/crates/within/tests/slopes.rs
+++ b/crates/within/tests/slopes.rs
@@ -1,0 +1,277 @@
+//! Single varying slope on one factor (#59): coefficient recovery in the
+//! user's parametrization, fitted-value invariance under the internal
+//! reparametrization, and deterministic rank-drop reporting.
+
+use within::{Effect, LsmrOptions, PreconditionerConfig, SolveResult, Solver};
+
+const TOL: f64 = 1e-6;
+
+fn assert_close(actual: f64, expected: f64, what: &str) {
+    assert!(
+        (actual - expected).abs() <= TOL * (1.0 + expected.abs()),
+        "{what}: got {actual}, expected {expected}"
+    );
+}
+
+/// Per-level weighted OLS of `y` on `[1, z]` — the un-reparametrized
+/// reference fit for an `f[z]` term. Levels with degenerate `z` are the
+/// caller's concern.
+fn per_level_intercept_slope(
+    levels: &[u32],
+    z: &[f64],
+    y: &[f64],
+    w: Option<&[f64]>,
+    n_levels: usize,
+) -> (Vec<f64>, Vec<f64>) {
+    let mut s = vec![[0.0f64; 5]; n_levels];
+    for i in 0..levels.len() {
+        let wi = w.map_or(1.0, |w| w[i]);
+        let acc = &mut s[levels[i] as usize];
+        acc[0] += wi;
+        acc[1] += wi * z[i];
+        acc[2] += wi * z[i] * z[i];
+        acc[3] += wi * y[i];
+        acc[4] += wi * z[i] * y[i];
+    }
+    let mut a = vec![0.0; n_levels];
+    let mut b = vec![0.0; n_levels];
+    for l in 0..n_levels {
+        let [sw, sz, szz, sy, szy] = s[l];
+        let denom = sw * szz - sz * sz;
+        b[l] = (sw * szy - sz * sy) / denom;
+        a[l] = (sy - b[l] * sz) / sw;
+    }
+    (a, b)
+}
+
+fn synthetic_y(n: usize) -> Vec<f64> {
+    (0..n)
+        .map(|i| (i as f64 * 0.9 - 1.0).sin() * 2.0 + 0.5)
+        .collect()
+}
+
+fn solve_with(
+    levels: &[u32],
+    z: &[f64],
+    intercept: bool,
+    weights: Option<Vec<f64>>,
+    y: &[f64],
+    config: &PreconditionerConfig,
+) -> SolveResult {
+    Solver::new(
+        vec![Effect::new(levels, intercept, [z]).expect("effect")],
+        weights,
+        config,
+    )
+    .expect("solver")
+    .solve(y, &LsmrOptions::default())
+    .expect("solve")
+}
+
+fn solve_single(
+    levels: &[u32],
+    z: &[f64],
+    intercept: bool,
+    weights: Option<Vec<f64>>,
+    y: &[f64],
+) -> SolveResult {
+    solve_with(
+        levels,
+        z,
+        intercept,
+        weights,
+        y,
+        &PreconditionerConfig::default(),
+    )
+}
+
+/// `unidentified` as comparable `(term, level, column)` triples.
+fn drops(r: &SolveResult) -> Vec<(usize, usize, usize)> {
+    r.unidentified
+        .iter()
+        .map(|d| (d.term, d.level, d.column))
+        .collect()
+}
+
+#[test]
+fn single_slope_recovers_per_level_ols_and_fitted_values() {
+    // Non-monotonic factor so the locality sort is genuinely exercised.
+    let levels: Vec<u32> = vec![2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1];
+    let z: Vec<f64> = vec![
+        0.5, -1.2, 3.3, 1.5, 0.7, -2.1, 2.5, 1.9, 0.4, -0.5, -1.0, 1.1,
+    ];
+    let y = synthetic_y(levels.len());
+
+    let r = solve_single(&levels, &z, true, None, &y);
+    assert!(r.converged);
+    assert!(r.unidentified.is_empty());
+
+    let (a, b) = per_level_intercept_slope(&levels, &z, &y, None, 3);
+    for l in 0..3 {
+        assert_close(r.x[l], a[l], &format!("intercept of level {l}"));
+        assert_close(r.x[3 + l], b[l], &format!("slope of level {l}"));
+    }
+    // Fitted values must equal the un-reparametrized fit.
+    for i in 0..levels.len() {
+        let l = levels[i] as usize;
+        assert_close(
+            y[i] - r.demeaned[i],
+            a[l] + b[l] * z[i],
+            &format!("fitted value {i}"),
+        );
+    }
+}
+
+#[test]
+fn slope_only_term_recovers_per_level_projection() {
+    let levels: Vec<u32> = vec![0, 0, 0, 1, 1, 1, 2, 2, 2];
+    let z: Vec<f64> = vec![1.0, 2.0, -1.5, 0.5, 3.0, 1.0, -2.0, 0.7, 1.3];
+    let y = synthetic_y(levels.len());
+
+    let r = solve_single(&levels, &z, false, None, &y);
+    assert!(r.converged);
+    assert!(r.unidentified.is_empty());
+    assert_eq!(r.x.len(), 3);
+
+    // Reference: per-level projection onto z alone, b = Σzy / Σz².
+    for l in 0..3 {
+        let (szy, szz) = levels
+            .iter()
+            .zip(z.iter().zip(y.iter()))
+            .filter(|(&li, _)| li as usize == l)
+            .fold((0.0, 0.0), |(szy, szz), (_, (&zi, &yi))| {
+                (szy + zi * yi, szz + zi * zi)
+            });
+        assert_close(r.x[l], szy / szz, &format!("slope of level {l}"));
+    }
+    for i in 0..levels.len() {
+        let l = levels[i] as usize;
+        assert_close(
+            y[i] - r.demeaned[i],
+            r.x[l] * z[i],
+            &format!("fitted value {i}"),
+        );
+    }
+}
+
+#[test]
+fn rank_drops_report_deterministically_with_exact_zeros() {
+    // Level 1 never occurs (drops every column); level 2's slope is constant
+    // (collinear with its intercept, drops the slope only); 0 and 3 are fine.
+    let levels: Vec<u32> = vec![0, 0, 0, 2, 2, 2, 3, 3, 3];
+    let z: Vec<f64> = vec![1.0, 2.0, -1.5, 2.5, 2.5, 2.5, -2.0, 0.7, 1.3];
+    let y = synthetic_y(levels.len());
+    let run = |config: &PreconditionerConfig| solve_with(&levels, &z, true, None, &y, config);
+
+    let r = run(&PreconditionerConfig::default());
+    assert!(r.converged);
+    // Ascending (level, column) order.
+    assert_eq!(drops(&r), [(0, 1, 0), (0, 1, 1), (0, 2, 1)]);
+
+    // Minimal-norm 0 at exactly the dropped slots; everything else finite.
+    for slot in [1, 4 + 1, 4 + 2] {
+        assert_eq!(r.x[slot], 0.0);
+    }
+    assert!(r.x.iter().all(|v| v.is_finite()));
+
+    // The constant level degrades to intercept-only: a = mean(y within level);
+    // identified levels still match the full reference.
+    assert_close(
+        r.x[2],
+        (y[3] + y[4] + y[5]) / 3.0,
+        "constant level intercept",
+    );
+    let (a, b) = per_level_intercept_slope(&levels, &z, &y, None, 4);
+    for l in [0usize, 3] {
+        assert_close(r.x[l], a[l], &format!("intercept of level {l}"));
+        assert_close(r.x[4 + l], b[l], &format!("slope of level {l}"));
+    }
+
+    // The explicit diagonal preconditioner (zero-diag pseudo-inverse at the
+    // dropped columns) agrees with the default path.
+    let diag = run(&PreconditionerConfig::Diagonal);
+    assert_eq!(diag.unidentified, r.unidentified);
+    for (i, (d, j)) in r.x.iter().zip(diag.x.iter()).enumerate() {
+        assert_close(*j, *d, &format!("coefficient {i}"));
+    }
+}
+
+#[test]
+fn weighted_solve_matches_closed_form_and_masks_zero_weight_rows() {
+    // Level 2's slope varies only on its zero-weight row: identification is
+    // judged over positive-weight rows, so it drops.
+    let levels: Vec<u32> = vec![0, 1, 0, 1, 0, 1, 2, 2, 2];
+    let z: Vec<f64> = vec![0.5, -1.2, 3.3, 1.5, 0.7, -2.1, 5.0, 5.0, 7.0];
+    let w: Vec<f64> = vec![1.0, 0.5, 2.0, 1.5, 3.0, 1.0, 1.0, 1.0, 0.0];
+    let y = synthetic_y(levels.len());
+
+    let r = solve_single(&levels, &z, true, Some(w.clone()), &y);
+    assert!(r.converged);
+    assert_eq!(drops(&r), [(0, 2, 1)]);
+    assert_eq!(r.x[3 + 2], 0.0);
+
+    let (a, b) = per_level_intercept_slope(&levels, &z, &y, Some(&w), 3);
+    for l in 0..2 {
+        assert_close(r.x[l], a[l], &format!("intercept of level {l}"));
+        assert_close(r.x[3 + l], b[l], &format!("slope of level {l}"));
+    }
+    // The masked level's intercept is the weighted mean over its w>0 rows.
+    assert_close(r.x[2], (y[6] + y[7]) / 2.0, "masked level intercept");
+}
+
+#[test]
+fn zero_weight_garbage_does_not_poison_identification() {
+    let levels: Vec<u32> = vec![0, 0, 0, 1, 1, 1];
+    // The excluded row's loading is huge enough that squaring it overflows to
+    // inf. Identification skips zero-weight rows outright; the diagonal
+    // preconditioner build stays inert only because its `w * z * z` multiplies
+    // left-to-right (0 * z kills it before the square) — this pins that order.
+    let z: Vec<f64> = vec![1.0, 2.0, 3.0, 5.0, 7.0, 1e300];
+    let w: Vec<f64> = vec![1.0, 1.0, 1.0, 1.0, 1.0, 0.0];
+    let y = synthetic_y(levels.len());
+    let run =
+        |config: &PreconditionerConfig| solve_with(&levels, &z, true, Some(w.clone()), &y, config);
+
+    let r = run(&PreconditionerConfig::default());
+    assert!(r.unidentified.is_empty());
+    let (a, b) = per_level_intercept_slope(&levels, &z, &y, Some(&w), 2);
+    for l in 0..2 {
+        assert_close(r.x[l], a[l], &format!("intercept of level {l}"));
+        assert_close(r.x[2 + l], b[l], &format!("slope of level {l}"));
+    }
+
+    let diag = run(&PreconditionerConfig::Diagonal);
+    for (i, (d, j)) in r.x.iter().zip(diag.x.iter()).enumerate() {
+        assert_close(*j, *d, &format!("coefficient {i}"));
+    }
+}
+
+#[test]
+fn batch_solve_shares_unidentified_and_back_transforms_each_rhs() {
+    let levels: Vec<u32> = vec![0, 0, 0, 1, 1, 1];
+    let z: Vec<f64> = vec![1.0, 2.0, 3.0, 2.5, 2.5, 2.5];
+    let y1 = synthetic_y(levels.len());
+    let y2: Vec<f64> = y1.iter().map(|v| v * -1.5 + 0.3).collect();
+
+    let solver = Solver::new(
+        vec![Effect::new(&levels, true, [&z[..]]).expect("effect")],
+        None,
+        PreconditionerConfig::default(),
+    )
+    .expect("solver");
+    let opts = LsmrOptions::default();
+    let batch = solver.solve_batch(&[&y1, &y2], &opts).expect("batch");
+
+    let batch_drops: Vec<_> = batch
+        .unidentified
+        .iter()
+        .map(|d| (d.term, d.level, d.column))
+        .collect();
+    assert_eq!(batch_drops, [(0, 1, 1)]);
+    // Each RHS block is bit-identical to its single solve, back-transform included.
+    let single1 = solver.solve(&y1, &opts).expect("solve y1");
+    let single2 = solver.solve(&y2, &opts).expect("solve y2");
+    let n = single1.x.len();
+    assert_eq!(&batch.x[..n], &single1.x[..]);
+    assert_eq!(&batch.x[n..], &single2.x[..]);
+}

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -72,10 +72,12 @@ class SolveResult:
     """Result of a single fixed-effects solve.
 
     Attributes:
-        x: Fixed-effect coefficients, shape ``(n_dofs,)``. The DOF ordering
-            matches the factor levels: all levels of factor 0 first, then
-            factor 1, etc. Slots for unidentified directions hold the
-            minimal-norm value ``0``, never NaN.
+        x: Fixed-effect coefficients, shape ``(n_dofs,)``. Term-major:
+            coefficient column ``c`` of level ``level`` sits at
+            ``term_offset + c * n_levels + level``, columns ordered
+            ``[intercept?, slopes...]`` (for plain factors: all levels of
+            factor 0 first, then factor 1, etc.). Slots for unidentified
+            directions hold the minimal-norm value ``0``, never NaN.
         unidentified: Per-level directions the data cannot identify, as
             ``(term, level, column)`` tuples.
         demeaned: Response vector after subtracting estimated fixed effects,

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -86,9 +86,10 @@ class TestEffectErrors:
         with pytest.raises(ValueError, match="slope 0"):
             Effect(levels, intercept=True, slopes=[np.array([1.0, 2.0])])
 
-    def test_slope_bearing_design_raises(self):
+    def test_multi_slope_design_raises(self):
         levels = np.array([0, 1, 0], dtype=np.uint32)
-        slope = np.array([1.0, 2.0, 3.0])
+        slopes = [np.array([1.0, 2.0, 3.0]), np.array([0.5, -1.0, 2.0])]
         y = np.array([1.0, 2.0, 3.0])
-        with pytest.raises(ValueError, match="slope"):
-            solve([Effect(levels, intercept=True, slopes=[slope])], y)
+        # A sole V=1 slope term solves (#59); V>=2 waits on #60.
+        with pytest.raises(ValueError, match="more than one slope"):
+            solve([Effect(levels, intercept=True, slopes=slopes)], y)

--- a/tests/test_slopes.py
+++ b/tests/test_slopes.py
@@ -1,0 +1,95 @@
+"""Single varying slope on one factor (#59), cross-checked against pyfixest.
+
+pyfixest has no native ``f[z]`` syntax; the reference is the explicit
+interaction parametrization ``y ~ C(f) + i(f, z) - 1``, which estimates the
+same per-level intercepts and slopes with no absorption or reference coding.
+"""
+
+import numpy as np
+import pytest
+
+import within
+from within import Effect, LsmrOptions
+
+pf = pytest.importorskip("pyfixest")
+pd = pytest.importorskip("pandas")
+
+OPTS = LsmrOptions(tol=1e-12, maxiter=2000)
+N_LEVELS = 6
+
+
+def _panel(seed, n=400):
+    rng = np.random.default_rng(seed)
+    f = rng.integers(0, N_LEVELS, n).astype(np.uint32)
+    z = rng.normal(size=n)
+    a = rng.normal(size=N_LEVELS)
+    b = rng.normal(size=N_LEVELS)
+    y = a[f] + b[f] * z + rng.normal(scale=0.1, size=n)
+    return f, z, y
+
+
+def _pyfixest_coef(f, z, y, formula, w=None):
+    df = pd.DataFrame({"f": [f"L{v}" for v in f], "z": z, "y": y})
+    weights = None
+    if w is not None:
+        df["w"] = w
+        weights = "w"
+    return pf.feols(formula, data=df, weights=weights).coef()
+
+
+def _assert_matches(res, coef, *, intercepts=True, skip_slopes=()):
+    base = N_LEVELS if intercepts else 0
+    for lvl in range(N_LEVELS):
+        if intercepts:
+            assert res.x[lvl] == pytest.approx(
+                coef[f"C(f)[L{lvl}]"], rel=1e-6, abs=1e-8
+            )
+        if lvl not in skip_slopes:
+            assert res.x[base + lvl] == pytest.approx(
+                coef[f"f::L{lvl}:z"], rel=1e-6, abs=1e-8
+            )
+
+
+def test_single_slope_matches_pyfixest():
+    f, z, y = _panel(seed=42)
+    res = within.solve([Effect(f, True, [z])], y, OPTS)
+    assert res.converged
+    assert res.unidentified == []
+
+    _assert_matches(res, _pyfixest_coef(f, z, y, "y ~ C(f) + i(f, z) - 1"))
+
+
+def test_weighted_single_slope_matches_pyfixest():
+    f, z, y = _panel(seed=7)
+    w = np.random.default_rng(11).uniform(0.2, 3.0, size=len(y))
+    res = within.solve([Effect(f, True, [z])], y, OPTS, weights=w)
+    assert res.converged
+
+    _assert_matches(res, _pyfixest_coef(f, z, y, "y ~ C(f) + i(f, z) - 1", w=w))
+
+
+def test_slope_only_term_matches_pyfixest():
+    f, z, y = _panel(seed=3)
+    res = within.solve([Effect(f, False, [z])], y, OPTS)
+    assert res.converged
+    assert res.unidentified == []
+    assert len(res.x) == N_LEVELS
+
+    _assert_matches(res, _pyfixest_coef(f, z, y, "y ~ i(f, z) - 1"), intercepts=False)
+
+
+def test_constant_slope_level_reports_drop_with_exact_zero():
+    f, z, y = _panel(seed=5)
+    z = z.copy()
+    z[f == 1] = 2.5
+    res = within.solve([Effect(f, True, [z])], y, OPTS)
+
+    assert res.unidentified == [(0, 1, 1)]
+    assert res.x[N_LEVELS + 1] == 0.0
+    assert np.isfinite(res.x).all()
+
+    # The un-dropped coefficients still match the reference, which drops the
+    # collinear column on its own.
+    _assert_matches(
+        res, _pyfixest_coef(f, z, y, "y ~ C(f) + i(f, z) - 1"), skip_slopes={1}
+    )


### PR DESCRIPTION
Implements #59.

A design whose sole term carries one slope column (`f[z]` / `f[[z]]`) now solves:

- the slope column is centered against the pinned intercept (skipped when absent) and weighted-normalized per level, materialized into the frame before the preconditioner build; coefficients are back-transformed to the user's parametrization after the solve, so fitted values are invariant
- rank drops (constant slope within a level, empty level) are detected structurally over positive-weight rows and reported via the unidentified-directions side-channel, with an exact minimal-norm `0` in the coefficient slot
- `build_diagonal` now fills slope-column diagonal entries (was intercept-only)
- slopes alongside other terms (#61) and V≥2 per factor (#60) stay gated

Tested against per-level closed forms (Rust) and pyfixest computed at test time (Python).