### PR TITLE
Varying slopes: multiple slopes per factor (V≥2) + full rank-drop contract (#60)

### DIFF
--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -35,7 +35,7 @@ pub enum BuildError {
         got: usize,
     },
     /// An effect carries varying slopes in a form the solver does not yet support.
-    #[error("effect {effect} has varying slopes, not yet supported alongside other effects or with more than one slope")]
+    #[error("effect {effect} has varying slopes, not yet supported alongside other effects")]
     SlopesNotYetSupported {
         /// Index of the offending effect.
         effect: usize,

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -255,8 +255,8 @@ impl<'a> Solver<'a> {
     ) -> Result<Self, BuildError> {
         let mut design = design.into_design()?;
         // A sole slope term is solvable via within-level reparametrization
-        // (the whitening below); slopes alongside other terms (#61) land in a
-        // later slice.
+        // (`SlopeReparam::build` below); slopes alongside other terms (#61)
+        // land in a later slice.
         if design.terms.len() > 1 {
             if let Some(idx) = design.terms.iter().position(|t| !t.slopes.is_empty()) {
                 return Err(BuildError::SlopesNotYetSupported { effect: idx });
@@ -272,7 +272,7 @@ impl<'a> Solver<'a> {
             None => weights,
         };
 
-        // Whiten the slope columns (if any) before the preconditioner reads the frame.
+        // Reparametrize the slope columns (if any) before the preconditioner reads the frame.
         let reparam = SlopeReparam::build(&mut design, weights.as_deref());
 
         let preconditioner = match preconditioner.into() {

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -254,11 +254,11 @@ impl<'a> Solver<'a> {
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
         let mut design = design.into_design()?;
-        // A sole V=1 term is solvable via within-level reparametrization (the
-        // whitening below); slopes alongside other terms (#61) or multiple
-        // slopes per factor (#60) land in later slices.
-        if let Some(idx) = design.terms.iter().position(|t| !t.slopes.is_empty()) {
-            if design.terms.len() > 1 || design.terms[idx].slopes.len() > 1 {
+        // A sole slope term is solvable via within-level reparametrization
+        // (the whitening below); slopes alongside other terms (#61) land in a
+        // later slice.
+        if design.terms.len() > 1 {
+            if let Some(idx) = design.terms.iter().position(|t| !t.slopes.is_empty()) {
                 return Err(BuildError::SlopesNotYetSupported { effect: idx });
             }
         }
@@ -272,7 +272,7 @@ impl<'a> Solver<'a> {
             None => weights,
         };
 
-        // Whiten the slope column (if any) before the preconditioner reads the frame.
+        // Whiten the slope columns (if any) before the preconditioner reads the frame.
         let reparam = SlopeReparam::build(&mut design, weights.as_deref());
 
         let preconditioner = match preconditioner.into() {

--- a/crates/within/src/solver/reparam.rs
+++ b/crates/within/src/solver/reparam.rs
@@ -7,17 +7,12 @@ use super::UnidentifiedDirection;
 #[cfg(test)]
 mod tests;
 
-/// Relative rank tolerance: a slope direction is dropped once its remaining
-/// within-level variance is no longer above `RANK_TOL` × its own initial
-/// variance. Zero keeps every direction whose remaining variance stays
-/// positive, so only exact structural zeros drop.
+/// Relative rank tolerance: a slope direction drops once its remaining
+/// within-level variance falls to `RANK_TOL` × its own initial variance.
 const RANK_TOL: f64 = 1e-10;
 
-/// Per-level change of basis for the design's sole slope term: the solve sees
-/// weighted-orthonormal slope directions that are uncorrelated with the
-/// level's intercept, leaving fitted values invariant while the per-level
-/// Gram becomes diagonal. [`Self::back_transform`] returns coefficients to
-/// the user's parametrization.
+/// Per-level change of basis making the sole slope term's within-level Gram
+/// the identity; [`Self::back_transform`] restores the user's parametrization.
 pub(crate) struct SlopeReparam {
     offset: usize,
     n_levels: usize,
@@ -28,11 +23,8 @@ pub(crate) struct SlopeReparam {
     pub(crate) unidentified: Vec<UnidentifiedDirection>,
 }
 
-/// One level's whitening map `u = W·(z − center)` with `W` of shape
-/// `rank × V` (row-major). `Wᵀ` maps solved coefficients back to the user's
-/// basis; a dropped slope is a zero column of `W`, so its coefficient comes
-/// back as an exact `0`. An empty `w` marks a level whose every slope
-/// direction dropped (or an empty level).
+/// One level's `u = W·(z − center)`, `W` row-major `rank × V`; an empty `w`
+/// marks a fully dropped level, a dropped slope is a zero column of `W`.
 struct LevelTransform {
     w: Box<[f64]>,
     /// Within-level weighted means; all-zero for slope-only terms.
@@ -40,16 +32,9 @@ struct LevelTransform {
 }
 
 impl SlopeReparam {
-    /// Whiten the sole slope term's loading columns in place and record how
-    /// to undo it. Returns `None` for slope-free designs.
-    ///
-    /// Identification is judged over positive-weight rows: an empty level
-    /// drops the term's every column; within-level rank deficiency (constant
-    /// or collinear slopes, per [`RANK_TOL`]) drops the directions the pivot
-    /// order rejects, keeping the largest-remaining-variance direction at
-    /// each step. Dropped directions are materialized as exact zeros, so the
-    /// minimal-norm LSMR solution leaves an exact `0` in the coefficient
-    /// slot and the layout stays data-independent.
+    /// Orthonormalize the sole slope term's loading columns in place; `None`
+    /// for slope-free designs. Unidentified directions become exact-zero
+    /// columns, so the minimal-norm solve leaves exact-`0` coefficients.
     pub(crate) fn build(design: &mut Design<'_>, weights: Option<&[f64]>) -> Option<Self> {
         let term = design.terms.iter().position(|t| !t.slopes.is_empty())?;
         let meta = &design.terms[term];
@@ -76,9 +61,7 @@ impl SlopeReparam {
         let mut gram = vec![0.0; v * v];
         for level in 0..n_levels {
             moments.gram(level, intercept, &mut gram);
-            let (w, kept) = whitening_rows(&gram, v, RANK_TOL);
-            // An empty level loses its intercept column too; its every slope
-            // direction already drops through the all-zero Gram.
+            let (w, kept) = pivoted_gram_schmidt(&gram, v, RANK_TOL);
             if intercept && moments.w_sum[level] == 0.0 {
                 unidentified.push(UnidentifiedDirection {
                     term,
@@ -86,8 +69,8 @@ impl SlopeReparam {
                     column: 0,
                 });
             }
-            for (j, &kept) in kept.iter().enumerate() {
-                if !kept {
+            for (j, &kept_j) in kept.iter().enumerate() {
+                if !kept_j {
                     unidentified.push(UnidentifiedDirection {
                         term,
                         level,
@@ -106,21 +89,17 @@ impl SlopeReparam {
             });
         }
 
-        // The whitened columns mix all raw columns, so materialize every
-        // output before writing any back. Whitened direction `k` lands in
-        // column slot `k`; slots past the level's rank stay exactly zero.
-        let mut outs = vec![vec![0.0; levels.len()]; v];
+        let mut u_cols = vec![vec![0.0; levels.len()]; v];
         for (i, &level) in levels.iter().enumerate() {
             let t = &transforms[level as usize];
             for ((zr, col), cj) in z_row.iter_mut().zip(&zs).zip(&*t.center) {
                 *zr = col[i] - cj;
             }
-            for (k, out) in outs.iter_mut().enumerate().take(t.w.len() / v) {
-                let row = &t.w[k * v..(k + 1) * v];
-                out[i] = row.iter().zip(&z_row).map(|(wj, zj)| wj * zj).sum();
+            for (w_row, out) in t.w.chunks_exact(v).zip(&mut u_cols) {
+                out[i] = dot(w_row, &z_row);
             }
         }
-        for (out, &c) in outs.into_iter().zip(&z_cols) {
+        for (out, &c) in u_cols.into_iter().zip(&z_cols) {
             design.frame.set_loading_column(c, out);
         }
 
@@ -137,43 +116,51 @@ impl SlopeReparam {
     /// Map solve-basis coefficients back to the user's parametrization.
     pub(crate) fn back_transform(&self, x: &mut [f64]) {
         let v = self.n_slopes;
-        let slope_base = self.offset + if self.intercept { self.n_levels } else { 0 };
         let mut b = vec![0.0; v];
         for (l, t) in self.transforms.iter().enumerate() {
-            let rank = t.w.len() / v;
-            // Fully dropped levels were never transformed; their slots are 0.
-            if rank == 0 {
+            if t.w.is_empty() {
                 continue;
             }
             b.fill(0.0);
-            for k in 0..rank {
-                let bw = x[slope_base + k * self.n_levels + l];
-                for (bj, wj) in b.iter_mut().zip(&t.w[k * v..(k + 1) * v]) {
-                    *bj += wj * bw;
+            for (k, w_row) in t.w.chunks_exact(v).enumerate() {
+                let bk = x[self.slope_slot(k, l)];
+                for (bj, wj) in b.iter_mut().zip(w_row) {
+                    *bj += wj * bk;
                 }
             }
             for (j, &bj) in b.iter().enumerate() {
-                x[slope_base + j * self.n_levels + l] = bj;
+                x[self.slope_slot(j, l)] = bj;
             }
             if self.intercept {
-                let shift: f64 = b.iter().zip(&*t.center).map(|(bj, cj)| bj * cj).sum();
-                x[self.offset + l] -= shift;
+                x[self.offset + l] -= dot(&b, &t.center);
             }
         }
     }
+
+    fn slope_slot(&self, j: usize, level: usize) -> usize {
+        self.offset + (usize::from(self.intercept) + j) * self.n_levels + level
+    }
 }
 
-/// Weighted within-level first and second moments of the slope loadings,
-/// accumulated in one pass (multivariate Welford) over positive-weight rows.
-/// A structurally constant column keeps an exactly-zero variance row, so
-/// exact rank drops survive a zero tolerance.
+/// One-pass weighted within-level moments (multivariate Welford); structural
+/// zeros stay exact, so rank drops survive a zero tolerance.
 struct LevelMoments {
     n_slopes: usize,
     w_sum: Vec<f64>,
     mean: Vec<f64>,
     /// Per level, `Σ w (z−μ)(z−μ)ᵀ` packed as a row-major lower triangle.
     comoment: Vec<f64>,
+    /// Scratch: deviations from the pre-update means.
     delta: Vec<f64>,
+}
+
+/// Index of `(j, k)`, `k ≤ j`, in a packed row-major lower triangle.
+fn tri_index(j: usize, k: usize) -> usize {
+    j * (j + 1) / 2 + k
+}
+
+fn tri_len(v: usize) -> usize {
+    v * (v + 1) / 2
 }
 
 impl LevelMoments {
@@ -182,109 +169,96 @@ impl LevelMoments {
             n_slopes,
             w_sum: vec![0.0; n_levels],
             mean: vec![0.0; n_levels * n_slopes],
-            comoment: vec![0.0; n_levels * n_slopes * (n_slopes + 1) / 2],
+            comoment: vec![0.0; n_levels * tri_len(n_slopes)],
             delta: vec![0.0; n_slopes],
         }
     }
 
     fn observe(&mut self, level: usize, z: &[f64], w: f64) {
-        // Zero-weight rows may carry arbitrary values; they must not affect
-        // identification or the whitening.
         if w <= 0.0 {
             return;
         }
         let v = self.n_slopes;
         self.w_sum[level] += w;
         let ratio = w / self.w_sum[level];
-        let mean = &mut self.mean[level * v..(level + 1) * v];
+        let mean = &mut self.mean[level * v..][..v];
         for (dj, (zj, mj)) in self.delta.iter_mut().zip(z.iter().zip(mean.iter_mut())) {
             *dj = zj - *mj;
             *mj += ratio * *dj;
         }
-        let tri = v * (v + 1) / 2;
-        let com = &mut self.comoment[level * tri..(level + 1) * tri];
-        let mut idx = 0;
+        let com = &mut self.comoment[level * tri_len(v)..][..tri_len(v)];
         for j in 0..v {
-            let wpost = w * (z[j] - mean[j]);
+            let dev = w * (z[j] - mean[j]);
             for k in 0..=j {
-                com[idx] += self.delta[k] * wpost;
-                idx += 1;
+                com[tri_index(j, k)] += self.delta[k] * dev;
             }
         }
     }
 
     fn mean(&self, level: usize) -> &[f64] {
-        &self.mean[level * self.n_slopes..(level + 1) * self.n_slopes]
+        &self.mean[level * self.n_slopes..][..self.n_slopes]
     }
 
-    /// The level's dense V×V slope Gram: centered against a pinned intercept,
-    /// raw (`Σwzzᵀ = M2 + w·μμᵀ`) for a slope-only term.
+    /// The level's V×V slope Gram: centered against a pinned intercept, raw
+    /// (`M2 + w·μμᵀ`) for a slope-only term.
     fn gram(&self, level: usize, intercept: bool, out: &mut [f64]) {
         let v = self.n_slopes;
-        let tri = v * (v + 1) / 2;
-        let com = &self.comoment[level * tri..(level + 1) * tri];
+        let com = &self.comoment[level * tri_len(v)..][..tri_len(v)];
         let mean = self.mean(level);
         let w = self.w_sum[level];
-        let mut idx = 0;
         for j in 0..v {
             for k in 0..=j {
-                let mut g = com[idx];
+                let mut g = com[tri_index(j, k)];
                 if !intercept {
                     g += w * mean[j] * mean[k];
                 }
                 out[j * v + k] = g;
                 out[k * v + j] = g;
-                idx += 1;
             }
         }
     }
 }
 
-/// Pivoted Cholesky whitening of one level's PSD slope Gram `g` (dense V×V,
-/// row-major): picks the largest-remaining-variance direction at each step
-/// and stops a column once its remaining variance is no longer above
-/// `tol` × its own initial variance (relative, hence scale-invariant per
-/// column). Returns the `rank × V` whitening rows `w` — `w·g·wᵀ = I` — and
-/// which columns were kept. Pivots are tracked through original column
-/// indices; nothing is swapped in place.
-fn whitening_rows(g: &[f64], v: usize, tol: f64) -> (Vec<f64>, Vec<bool>) {
-    let mut d: Vec<f64> = (0..v).map(|j| g[j * v + j]).collect();
-    let thresholds: Vec<f64> = d.iter().map(|&dj| tol * dj).collect();
-    // lfac[j][t]: weighted inner product of column j with whitened row t.
-    let mut lfac = vec![0.0; v * v];
-    let mut w: Vec<f64> = Vec::new();
+/// Pivoted Gram–Schmidt on the raw slope columns, run in coordinates:
+/// column `j` enters as `e_j` and all geometry goes through the dense
+/// row-major `v×v` level Gram, `⟨a, b⟩ = a·g·bᵀ`. Returns the `rank × v`
+/// orthonormal rows `w` — `w·g·wᵀ = I` — plus the kept-column mask. A column
+/// drops once its residual variance falls to `tol` × its initial variance;
+/// pivots keep their original column indices — nothing is swapped.
+fn pivoted_gram_schmidt(g: &[f64], v: usize, tol: f64) -> (Vec<f64>, Vec<bool>) {
+    let mut residual: Vec<f64> = (0..v).map(|j| g[j * v + j]).collect();
     let mut kept = vec![false; v];
-    for step in 0..v {
-        let pivot = (0..v)
-            .filter(|&j| !kept[j] && d[j].is_finite() && d[j] > thresholds[j])
-            .max_by(|&a, &b| d[a].total_cmp(&d[b]));
-        let Some(p) = pivot else { break };
+    let mut basis = Vec::new();
+    while let Some(p) = (0..v)
+        .filter(|&j| !kept[j] && residual[j].is_finite() && residual[j] > tol * g[j * v + j])
+        .max_by(|&a, &b| residual[a].total_cmp(&residual[b]))
+    {
         kept[p] = true;
-        let root = d[p].sqrt();
 
-        // Whitened row `step`: (e_p − Σ_t lfac[p][t]·w[t]) / root.
-        let row_base = step * v;
-        w.resize(row_base + v, 0.0);
-        w[row_base + p] = 1.0;
-        for t in 0..step {
-            let c = lfac[p * v + t];
-            for j in 0..v {
-                w[row_base + j] -= c * w[t * v + j];
+        // q = e_p − Σₜ ⟨e_p, qₜ⟩·qₜ, whose norm is already √residual[p].
+        let mut q = vec![0.0; v];
+        q[p] = 1.0;
+        for q_t in basis.chunks_exact(v) {
+            let c = dot(&g[p * v..][..v], q_t);
+            for (qj, &qtj) in q.iter_mut().zip(q_t) {
+                *qj -= c * qtj;
             }
         }
-        for wj in &mut w[row_base..row_base + v] {
-            *wj /= root;
+        let norm = residual[p].sqrt();
+        for qj in &mut q {
+            *qj /= norm;
         }
 
-        for j in (0..v).filter(|&j| !kept[j]) {
-            let mut val = g[j * v + p];
-            for t in 0..step {
-                val -= lfac[j * v + t] * lfac[p * v + t];
-            }
-            val /= root;
-            lfac[j * v + step] = val;
-            d[j] -= val * val;
+        // Pythagoras: projecting out q costs every column ⟨e_j, q⟩² of variance.
+        for (r, g_row) in residual.iter_mut().zip(g.chunks_exact(v)) {
+            let c = dot(g_row, &q);
+            *r -= c * c;
         }
+        basis.extend_from_slice(&q);
     }
-    (w, kept)
+    (basis, kept)
+}
+
+fn dot(a: &[f64], b: &[f64]) -> f64 {
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
 }

--- a/crates/within/src/solver/reparam.rs
+++ b/crates/within/src/solver/reparam.rs
@@ -4,79 +4,131 @@ use crate::domain::Design;
 
 use super::UnidentifiedDirection;
 
-/// Per-level affine change of basis for the design's sole slope column: the
-/// solve sees `(z - center) / scale`, which zeroes each level's
-/// intercept–slope cross-term and normalizes the slope block, leaving fitted
-/// values invariant. [`Self::back_transform`] returns coefficients to the
-/// user's parametrization.
+#[cfg(test)]
+mod tests;
+
+/// Relative rank tolerance: a slope direction is dropped once its remaining
+/// within-level variance is no longer above `RANK_TOL` × its own initial
+/// variance. Zero keeps every direction whose remaining variance stays
+/// positive, so only exact structural zeros drop.
+const RANK_TOL: f64 = 1e-10;
+
+/// Per-level change of basis for the design's sole slope term: the solve sees
+/// weighted-orthonormal slope directions that are uncorrelated with the
+/// level's intercept, leaving fitted values invariant while the per-level
+/// Gram becomes diagonal. [`Self::back_transform`] returns coefficients to
+/// the user's parametrization.
 pub(crate) struct SlopeReparam {
     offset: usize,
     n_levels: usize,
     intercept: bool,
-    /// Per-level `(center, scale)`; `None` at dropped and empty levels, whose
-    /// whitened column entries are zeroed and whose coefficients stay `0`.
-    transforms: Vec<Option<(f64, f64)>>,
+    n_slopes: usize,
+    transforms: Vec<LevelTransform>,
     /// Directions the data cannot identify, ascending in `(level, column)`.
     pub(crate) unidentified: Vec<UnidentifiedDirection>,
 }
 
+/// One level's whitening map `u = W·(z − center)` with `W` of shape
+/// `rank × V` (row-major). `Wᵀ` maps solved coefficients back to the user's
+/// basis; a dropped slope is a zero column of `W`, so its coefficient comes
+/// back as an exact `0`. An empty `w` marks a level whose every slope
+/// direction dropped (or an empty level).
+struct LevelTransform {
+    w: Box<[f64]>,
+    /// Within-level weighted means; all-zero for slope-only terms.
+    center: Box<[f64]>,
+}
+
 impl SlopeReparam {
-    /// Whiten the sole slope term's loading column in place and record how to
-    /// undo it. Returns `None` for slope-free designs.
+    /// Whiten the sole slope term's loading columns in place and record how
+    /// to undo it. Returns `None` for slope-free designs.
     ///
-    /// Identification is judged structurally over positive-weight rows so the
-    /// dropped set is deterministic: an empty level drops the term's every
-    /// column; a slope with no within-level variation (no nonzero value, for
-    /// a slope-only term) drops its slope column. Dropped slope entries are
-    /// materialized as exact zeros, so the minimal-norm LSMR solution leaves
-    /// an exact `0` in the coefficient slot.
+    /// Identification is judged over positive-weight rows: an empty level
+    /// drops the term's every column; within-level rank deficiency (constant
+    /// or collinear slopes, per [`RANK_TOL`]) drops the directions the pivot
+    /// order rejects, keeping the largest-remaining-variance direction at
+    /// each step. Dropped directions are materialized as exact zeros, so the
+    /// minimal-norm LSMR solution leaves an exact `0` in the coefficient
+    /// slot and the layout stays data-independent.
     pub(crate) fn build(design: &mut Design<'_>, weights: Option<&[f64]>) -> Option<Self> {
         let term = design.terms.iter().position(|t| !t.slopes.is_empty())?;
         let meta = &design.terms[term];
-        debug_assert_eq!(meta.slopes.len(), 1, "reparametrization is V=1-only");
         let (offset, n_levels, intercept) = (meta.offset, meta.n_levels, meta.intercept);
-        let z_col = meta.slopes[0];
+        let z_cols = meta.slopes.clone();
+        let v = z_cols.len();
         let levels = design.frame.level_column(term);
-        let z = design.frame.loading_column(z_col);
+        let zs: Vec<&[f64]> = z_cols
+            .iter()
+            .map(|&c| design.frame.loading_column(c))
+            .collect();
 
-        let mut stats = vec![LevelStats::default(); n_levels];
-        for (i, (&level, &zi)) in levels.iter().zip(z).enumerate() {
-            stats[level as usize].observe(zi, weights.map_or(1.0, |ws| ws[i]));
+        let mut moments = LevelMoments::new(n_levels, v);
+        let mut z_row = vec![0.0; v];
+        for (i, &level) in levels.iter().enumerate() {
+            for (zr, col) in z_row.iter_mut().zip(&zs) {
+                *zr = col[i];
+            }
+            moments.observe(level as usize, &z_row, weights.map_or(1.0, |ws| ws[i]));
         }
 
-        let slope_column = usize::from(intercept);
         let mut transforms = Vec::with_capacity(n_levels);
         let mut unidentified = Vec::new();
-        for (level, s) in stats.iter().enumerate() {
-            let transform = s.whitening(intercept);
-            if transform.is_none() {
-                // An empty level loses every column, a degenerate slope only its own.
-                let first = if s.is_empty() { 0 } else { slope_column };
-                for column in first..=slope_column {
+        let mut gram = vec![0.0; v * v];
+        for level in 0..n_levels {
+            moments.gram(level, intercept, &mut gram);
+            let (w, kept) = whitening_rows(&gram, v, RANK_TOL);
+            // An empty level loses its intercept column too; its every slope
+            // direction already drops through the all-zero Gram.
+            if intercept && moments.w_sum[level] == 0.0 {
+                unidentified.push(UnidentifiedDirection {
+                    term,
+                    level,
+                    column: 0,
+                });
+            }
+            for (j, &kept) in kept.iter().enumerate() {
+                if !kept {
                     unidentified.push(UnidentifiedDirection {
                         term,
                         level,
-                        column,
+                        column: usize::from(intercept) + j,
                     });
                 }
             }
-            transforms.push(transform);
+            let center = if intercept {
+                moments.mean(level).into()
+            } else {
+                vec![0.0; v].into()
+            };
+            transforms.push(LevelTransform {
+                w: w.into(),
+                center,
+            });
         }
 
-        let whitened: Vec<f64> = levels
-            .iter()
-            .zip(z)
-            .map(|(&level, &zi)| match transforms[level as usize] {
-                Some((center, scale)) => (zi - center) / scale,
-                None => 0.0,
-            })
-            .collect();
-        design.frame.set_loading_column(z_col, whitened);
+        // The whitened columns mix all raw columns, so materialize every
+        // output before writing any back. Whitened direction `k` lands in
+        // column slot `k`; slots past the level's rank stay exactly zero.
+        let mut outs = vec![vec![0.0; levels.len()]; v];
+        for (i, &level) in levels.iter().enumerate() {
+            let t = &transforms[level as usize];
+            for ((zr, col), cj) in z_row.iter_mut().zip(&zs).zip(&*t.center) {
+                *zr = col[i] - cj;
+            }
+            for (k, out) in outs.iter_mut().enumerate().take(t.w.len() / v) {
+                let row = &t.w[k * v..(k + 1) * v];
+                out[i] = row.iter().zip(&z_row).map(|(wj, zj)| wj * zj).sum();
+            }
+        }
+        for (out, &c) in outs.into_iter().zip(&z_cols) {
+            design.frame.set_loading_column(c, out);
+        }
 
         Some(Self {
             offset,
             n_levels,
             intercept,
+            n_slopes: v,
             transforms,
             unidentified,
         })
@@ -84,64 +136,155 @@ impl SlopeReparam {
 
     /// Map solve-basis coefficients back to the user's parametrization.
     pub(crate) fn back_transform(&self, x: &mut [f64]) {
+        let v = self.n_slopes;
         let slope_base = self.offset + if self.intercept { self.n_levels } else { 0 };
+        let mut b = vec![0.0; v];
         for (l, t) in self.transforms.iter().enumerate() {
-            // Dropped levels were never transformed; their coefficients are 0.
-            let Some((center, scale)) = *t else { continue };
-            let b = x[slope_base + l] / scale;
-            x[slope_base + l] = b;
+            let rank = t.w.len() / v;
+            // Fully dropped levels were never transformed; their slots are 0.
+            if rank == 0 {
+                continue;
+            }
+            b.fill(0.0);
+            for k in 0..rank {
+                let bw = x[slope_base + k * self.n_levels + l];
+                for (bj, wj) in b.iter_mut().zip(&t.w[k * v..(k + 1) * v]) {
+                    *bj += wj * bw;
+                }
+            }
+            for (j, &bj) in b.iter().enumerate() {
+                x[slope_base + j * self.n_levels + l] = bj;
+            }
             if self.intercept {
-                x[self.offset + l] -= b * center;
+                let shift: f64 = b.iter().zip(&*t.center).map(|(bj, cj)| bj * cj).sum();
+                x[self.offset + l] -= shift;
             }
         }
     }
 }
 
-/// Weighted running moments of `z` within one level (Welford), plus the
-/// structural variation flags, over positive-weight rows only.
-#[derive(Clone, Copy, Default)]
-struct LevelStats {
-    w_sum: f64,
-    mean: f64,
-    m2: f64,
-    first_z: f64,
-    varies: bool,
+/// Weighted within-level first and second moments of the slope loadings,
+/// accumulated in one pass (multivariate Welford) over positive-weight rows.
+/// A structurally constant column keeps an exactly-zero variance row, so
+/// exact rank drops survive a zero tolerance.
+struct LevelMoments {
+    n_slopes: usize,
+    w_sum: Vec<f64>,
+    mean: Vec<f64>,
+    /// Per level, `Σ w (z−μ)(z−μ)ᵀ` packed as a row-major lower triangle.
+    comoment: Vec<f64>,
+    delta: Vec<f64>,
 }
 
-impl LevelStats {
-    fn observe(&mut self, z: f64, w: f64) {
+impl LevelMoments {
+    fn new(n_levels: usize, n_slopes: usize) -> Self {
+        Self {
+            n_slopes,
+            w_sum: vec![0.0; n_levels],
+            mean: vec![0.0; n_levels * n_slopes],
+            comoment: vec![0.0; n_levels * n_slopes * (n_slopes + 1) / 2],
+            delta: vec![0.0; n_slopes],
+        }
+    }
+
+    fn observe(&mut self, level: usize, z: &[f64], w: f64) {
         // Zero-weight rows may carry arbitrary values; they must not affect
-        // identification or the scale.
+        // identification or the whitening.
         if w <= 0.0 {
             return;
         }
-        if self.w_sum == 0.0 {
-            self.first_z = z;
-        } else {
-            self.varies |= z != self.first_z;
+        let v = self.n_slopes;
+        self.w_sum[level] += w;
+        let ratio = w / self.w_sum[level];
+        let mean = &mut self.mean[level * v..(level + 1) * v];
+        for (dj, (zj, mj)) in self.delta.iter_mut().zip(z.iter().zip(mean.iter_mut())) {
+            *dj = zj - *mj;
+            *mj += ratio * *dj;
         }
-        self.w_sum += w;
-        let delta = z - self.mean;
-        self.mean += (w / self.w_sum) * delta;
-        self.m2 += w * delta * (z - self.mean);
+        let tri = v * (v + 1) / 2;
+        let com = &mut self.comoment[level * tri..(level + 1) * tri];
+        let mut idx = 0;
+        for j in 0..v {
+            let wpost = w * (z[j] - mean[j]);
+            for k in 0..=j {
+                com[idx] += self.delta[k] * wpost;
+                idx += 1;
+            }
+        }
     }
 
-    fn is_empty(&self) -> bool {
-        self.w_sum == 0.0
+    fn mean(&self, level: usize) -> &[f64] {
+        &self.mean[level * self.n_slopes..(level + 1) * self.n_slopes]
     }
 
-    /// The level's `(center, scale)`, or `None` when the slope direction is
-    /// structurally unidentifiable: `z` constant against a pinned intercept,
-    /// identically zero without one, or an empty level.
-    fn whitening(&self, intercept: bool) -> Option<(f64, f64)> {
-        let (identified, center, ssq) = if intercept {
-            (self.varies, self.mean, self.m2)
-        } else {
-            // Uncentered second moment: Σwz² = m2 + w·mean², both non-negative.
-            let ssq = self.m2 + self.w_sum * self.mean * self.mean;
-            (self.varies || self.first_z != 0.0, 0.0, ssq)
-        };
-        let scale = ssq.sqrt();
-        (identified && scale > 0.0 && scale.is_finite()).then_some((center, scale))
+    /// The level's dense V×V slope Gram: centered against a pinned intercept,
+    /// raw (`Σwzzᵀ = M2 + w·μμᵀ`) for a slope-only term.
+    fn gram(&self, level: usize, intercept: bool, out: &mut [f64]) {
+        let v = self.n_slopes;
+        let tri = v * (v + 1) / 2;
+        let com = &self.comoment[level * tri..(level + 1) * tri];
+        let mean = self.mean(level);
+        let w = self.w_sum[level];
+        let mut idx = 0;
+        for j in 0..v {
+            for k in 0..=j {
+                let mut g = com[idx];
+                if !intercept {
+                    g += w * mean[j] * mean[k];
+                }
+                out[j * v + k] = g;
+                out[k * v + j] = g;
+                idx += 1;
+            }
+        }
     }
+}
+
+/// Pivoted Cholesky whitening of one level's PSD slope Gram `g` (dense V×V,
+/// row-major): picks the largest-remaining-variance direction at each step
+/// and stops a column once its remaining variance is no longer above
+/// `tol` × its own initial variance (relative, hence scale-invariant per
+/// column). Returns the `rank × V` whitening rows `w` — `w·g·wᵀ = I` — and
+/// which columns were kept. Pivots are tracked through original column
+/// indices; nothing is swapped in place.
+fn whitening_rows(g: &[f64], v: usize, tol: f64) -> (Vec<f64>, Vec<bool>) {
+    let mut d: Vec<f64> = (0..v).map(|j| g[j * v + j]).collect();
+    let thresholds: Vec<f64> = d.iter().map(|&dj| tol * dj).collect();
+    // lfac[j][t]: weighted inner product of column j with whitened row t.
+    let mut lfac = vec![0.0; v * v];
+    let mut w: Vec<f64> = Vec::new();
+    let mut kept = vec![false; v];
+    for step in 0..v {
+        let pivot = (0..v)
+            .filter(|&j| !kept[j] && d[j].is_finite() && d[j] > thresholds[j])
+            .max_by(|&a, &b| d[a].total_cmp(&d[b]));
+        let Some(p) = pivot else { break };
+        kept[p] = true;
+        let root = d[p].sqrt();
+
+        // Whitened row `step`: (e_p − Σ_t lfac[p][t]·w[t]) / root.
+        let row_base = step * v;
+        w.resize(row_base + v, 0.0);
+        w[row_base + p] = 1.0;
+        for t in 0..step {
+            let c = lfac[p * v + t];
+            for j in 0..v {
+                w[row_base + j] -= c * w[t * v + j];
+            }
+        }
+        for wj in &mut w[row_base..row_base + v] {
+            *wj /= root;
+        }
+
+        for j in (0..v).filter(|&j| !kept[j]) {
+            let mut val = g[j * v + p];
+            for t in 0..step {
+                val -= lfac[j * v + t] * lfac[p * v + t];
+            }
+            val /= root;
+            lfac[j * v + step] = val;
+            d[j] -= val * val;
+        }
+    }
+    (w, kept)
 }

--- a/crates/within/src/solver/reparam/tests.rs
+++ b/crates/within/src/solver/reparam/tests.rs
@@ -1,17 +1,17 @@
-//! Seam tests for the per-level pivoted-Cholesky whitening: pivot
-//! bookkeeping through non-trivial pivot orders and the rank-tolerance
-//! contract, neither reachable through the public API (the tolerance is a
-//! crate-internal constant).
+//! Seam tests for the per-level pivoted Gram–Schmidt: pivot bookkeeping through
+//! non-trivial pivot orders and the rank-tolerance contract, neither
+//! reachable through the public API (the tolerance is a crate-internal
+//! constant).
 
 use super::*;
 
 #[test]
-fn whitening_rows_orthonormalize_under_a_non_monotonic_pivot_order() {
+fn gram_schmidt_orthonormalizes_under_a_non_monotonic_pivot_order() {
     // Diagonals [2, 5, 3] force the pivot sequence 1 → 2 → 0: any
     // bookkeeping that assumes natural or physically swapped order breaks
     // the W·G·Wᵀ = I identity below (the prototype's ≥3-slope cliff).
     let g = [2.0, 1.0, 0.5, 1.0, 5.0, 2.0, 0.5, 2.0, 3.0];
-    let (w, kept) = whitening_rows(&g, 3, RANK_TOL);
+    let (w, kept) = pivoted_gram_schmidt(&g, 3, RANK_TOL);
     assert_eq!(kept, [true; 3]);
     assert_eq!(w.len(), 9);
 
@@ -34,8 +34,8 @@ fn whitening_rows_orthonormalize_under_a_non_monotonic_pivot_order() {
 fn zero_tolerance_keeps_a_near_degenerate_direction_the_default_drops() {
     let eps = 1e-12;
     let g = [1.0, 1.0 - eps, 1.0 - eps, 1.0];
-    let (_, kept) = whitening_rows(&g, 2, RANK_TOL);
+    let (_, kept) = pivoted_gram_schmidt(&g, 2, RANK_TOL);
     assert_eq!(kept.iter().filter(|&&k| k).count(), 1);
-    let (_, kept) = whitening_rows(&g, 2, 0.0);
+    let (_, kept) = pivoted_gram_schmidt(&g, 2, 0.0);
     assert_eq!(kept, [true, true]);
 }

--- a/crates/within/src/solver/reparam/tests.rs
+++ b/crates/within/src/solver/reparam/tests.rs
@@ -1,0 +1,41 @@
+//! Seam tests for the per-level pivoted-Cholesky whitening: pivot
+//! bookkeeping through non-trivial pivot orders and the rank-tolerance
+//! contract, neither reachable through the public API (the tolerance is a
+//! crate-internal constant).
+
+use super::*;
+
+#[test]
+fn whitening_rows_orthonormalize_under_a_non_monotonic_pivot_order() {
+    // Diagonals [2, 5, 3] force the pivot sequence 1 → 2 → 0: any
+    // bookkeeping that assumes natural or physically swapped order breaks
+    // the W·G·Wᵀ = I identity below (the prototype's ≥3-slope cliff).
+    let g = [2.0, 1.0, 0.5, 1.0, 5.0, 2.0, 0.5, 2.0, 3.0];
+    let (w, kept) = whitening_rows(&g, 3, RANK_TOL);
+    assert_eq!(kept, [true; 3]);
+    assert_eq!(w.len(), 9);
+
+    for r in 0..3 {
+        for s in 0..3 {
+            let wgw: f64 = (0..3)
+                .flat_map(|j| (0..3).map(move |k| (j, k)))
+                .map(|(j, k)| w[r * 3 + j] * g[j * 3 + k] * w[s * 3 + k])
+                .sum();
+            let expected = if r == s { 1.0 } else { 0.0 };
+            assert!(
+                (wgw - expected).abs() < 1e-12,
+                "(W·G·Wᵀ)[{r}][{s}] = {wgw}, expected {expected}"
+            );
+        }
+    }
+}
+
+#[test]
+fn zero_tolerance_keeps_a_near_degenerate_direction_the_default_drops() {
+    let eps = 1e-12;
+    let g = [1.0, 1.0 - eps, 1.0 - eps, 1.0];
+    let (_, kept) = whitening_rows(&g, 2, RANK_TOL);
+    assert_eq!(kept.iter().filter(|&&k| k).count(), 1);
+    let (_, kept) = whitening_rows(&g, 2, 0.0);
+    assert_eq!(kept, [true, true]);
+}

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -282,26 +282,11 @@ fn test_solver_rejects_slope_bearing_design_naming_its_term() {
         within::Effect::new(&levels, true, [&slope[..]]).expect("slope effect"),
     ];
     // The design builds — the operator contract is exercisable — but solving
-    // is deferred to the transform slices (#59+).
+    // slopes alongside other terms is deferred to cross-factor routing (#61).
     let design = Design::new(effects).expect("slope design builds");
     let err = Solver::new(design, None, None).unwrap_err();
     match err {
         BuildError::SlopesNotYetSupported { effect: 1 } => {}
         other => panic!("Expected SlopesNotYetSupported for term 1, got: {other:?}"),
-    }
-}
-
-#[test]
-fn test_solver_rejects_multiple_slopes_on_one_factor() {
-    let levels = [0u32, 1, 0, 1];
-    let z1 = [1.0, 2.0, 3.0, 4.0];
-    let z2 = [0.5, -1.0, 2.0, 0.0];
-    let effects = vec![within::Effect::new(&levels, true, [&z1[..], &z2[..]]).expect("V=2 effect")];
-    // A sole V=1 term solves (#59); V≥2 waits on the rank-drop contract (#60).
-    let design = Design::new(effects).expect("V=2 design builds");
-    let err = Solver::new(design, None, None).unwrap_err();
-    match err {
-        BuildError::SlopesNotYetSupported { effect: 0 } => {}
-        other => panic!("Expected SlopesNotYetSupported for term 0, got: {other:?}"),
     }
 }

--- a/crates/within/tests/slopes.rs
+++ b/crates/within/tests/slopes.rs
@@ -1,4 +1,4 @@
-//! Single varying slope on one factor (#59): coefficient recovery in the
+//! Varying slopes on one factor (#59, #60): coefficient recovery in the
 //! user's parametrization, fitted-value invariance under the internal
 //! reparametrization, and deterministic rank-drop reporting.
 
@@ -274,4 +274,66 @@ fn batch_solve_shares_unidentified_and_back_transforms_each_rhs() {
     let n = single1.x.len();
     assert_eq!(&batch.x[..n], &single1.x[..]);
     assert_eq!(&batch.x[n..], &single2.x[..]);
+}
+
+#[test]
+fn three_slopes_solve_bounded_with_exact_rank_drops() {
+    // Strongly correlated slopes make the raw per-level Grams
+    // ill-conditioned (the ≥3-slope cliff scenario), and level 1's z2/z3
+    // are exactly collinear on top.
+    let n = 24;
+    let levels: Vec<u32> = (0..n).map(|i| (i % 3) as u32).collect();
+    let z1: Vec<f64> = (0..n).map(|i| (i as f64 * 0.37).sin() * 2.0).collect();
+    let z2: Vec<f64> = (0..n)
+        .map(|i| 0.95 * z1[i] + 0.1 * (i as f64 * 0.9 + 0.2).cos())
+        .collect();
+    let z3: Vec<f64> = (0..n)
+        .map(|i| {
+            if i % 3 == 1 {
+                2.0 * z2[i]
+            } else {
+                -0.8 * z1[i] + 0.15 * (i as f64 * 1.7).sin() + 0.1
+            }
+        })
+        .collect();
+    let y = synthetic_y(n);
+
+    let r = Solver::new(
+        vec![Effect::new(&levels, true, [&z1[..], &z2, &z3]).expect("effect")],
+        None,
+        PreconditionerConfig::default(),
+    )
+    .expect("solver")
+    .solve(&y, &LsmrOptions::default())
+    .expect("solve");
+    assert!(r.converged);
+    assert!(
+        r.iterations <= 30,
+        "conditioning cliff: {} iterations",
+        r.iterations
+    );
+
+    // Level 1 drops exactly one direction — the pivot keeps the
+    // larger-variance z3, so z2's coordinate (column 2) reads exactly 0.
+    assert_eq!(drops(&r), [(0, 1, 2)]);
+    assert_eq!(r.x[2 * 3 + 1], 0.0);
+
+    // The fit is the exact projection (residuals orthogonal to every design
+    // column within every level), and the reported user-basis coefficients
+    // reproduce it — together this pins the identified coefficients without
+    // an external solve.
+    for l in 0..3 {
+        for col in [None, Some(&z1), Some(&z2), Some(&z3)] {
+            let dot: f64 = (0..n)
+                .filter(|&i| levels[i] as usize == l)
+                .map(|i| r.demeaned[i] * col.map_or(1.0, |z| z[i]))
+                .sum();
+            assert!(dot.abs() < 1e-6, "level {l}: residual·column = {dot}");
+        }
+    }
+    for i in 0..n {
+        let l = levels[i] as usize;
+        let fitted = r.x[l] + r.x[3 + l] * z1[i] + r.x[6 + l] * z2[i] + r.x[9 + l] * z3[i];
+        assert_close(y[i] - r.demeaned[i], fitted, &format!("fitted value {i}"));
+    }
 }

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -86,10 +86,16 @@ class TestEffectErrors:
         with pytest.raises(ValueError, match="slope 0"):
             Effect(levels, intercept=True, slopes=[np.array([1.0, 2.0])])
 
-    def test_multi_slope_design_raises(self):
+    def test_slope_term_alongside_other_terms_raises(self):
         levels = np.array([0, 1, 0], dtype=np.uint32)
-        slopes = [np.array([1.0, 2.0, 3.0]), np.array([0.5, -1.0, 2.0])]
+        slope = [np.array([1.0, 2.0, 3.0])]
         y = np.array([1.0, 2.0, 3.0])
-        # A sole V=1 slope term solves (#59); V>=2 waits on #60.
-        with pytest.raises(ValueError, match="more than one slope"):
-            solve([Effect(levels, intercept=True, slopes=slopes)], y)
+        # A sole slope term solves (#59/#60); mixing waits on #61.
+        with pytest.raises(ValueError, match="alongside other effects"):
+            solve(
+                [
+                    Effect(levels, intercept=True, slopes=slope),
+                    Effect(levels, intercept=True),
+                ],
+                y,
+            )

--- a/tests/test_slopes.py
+++ b/tests/test_slopes.py
@@ -1,4 +1,4 @@
-"""Single varying slope on one factor (#59), cross-checked against pyfixest.
+"""Varying slopes on one factor (#59, #60), cross-checked against pyfixest.
 
 pyfixest has no native ``f[z]`` syntax; the reference is the explicit
 interaction parametrization ``y ~ C(f) + i(f, z) - 1``, which estimates the
@@ -93,3 +93,43 @@ def test_constant_slope_level_reports_drop_with_exact_zero():
     _assert_matches(
         res, _pyfixest_coef(f, z, y, "y ~ C(f) + i(f, z) - 1"), skip_slopes={1}
     )
+
+
+def _panel_multi(seed, v, n=400):
+    rng = np.random.default_rng(seed)
+    f = rng.integers(0, N_LEVELS, n).astype(np.uint32)
+    base = rng.normal(size=n)
+    # Correlated slopes so the raw per-level Grams are ill-conditioned.
+    zs = [base * (0.6 + 0.2 * j) + 0.15 * rng.normal(size=n) for j in range(v)]
+    a = rng.normal(size=N_LEVELS)
+    b = rng.normal(size=(v, N_LEVELS))
+    y = a[f] + sum(b[j][f] * zs[j] for j in range(v)) + rng.normal(scale=0.1, size=n)
+    return f, zs, y
+
+
+def _pyfixest_coef_multi(f, zs, y, w=None):
+    df = pd.DataFrame({"f": [f"L{v}" for v in f], "y": y})
+    for j, z in enumerate(zs):
+        df[f"z{j}"] = z
+    weights = None
+    if w is not None:
+        df["w"] = w
+        weights = "w"
+    terms = " + ".join(f"i(f, z{j})" for j in range(len(zs)))
+    return pf.feols(f"y ~ C(f) + {terms} - 1", data=df, weights=weights).coef()
+
+
+def test_three_correlated_weighted_slopes_match_pyfixest():
+    f, zs, y = _panel_multi(seed=19, v=3)
+    w = np.random.default_rng(29).uniform(0.2, 3.0, size=len(y))
+    res = within.solve([Effect(f, True, zs)], y, OPTS, weights=w)
+    assert res.converged
+    assert res.unidentified == []
+
+    coef = _pyfixest_coef_multi(f, zs, y, w=w)
+    for lvl in range(N_LEVELS):
+        assert res.x[lvl] == pytest.approx(coef[f"C(f)[L{lvl}]"], rel=1e-6, abs=1e-8)
+        for j in range(3):
+            assert res.x[N_LEVELS * (1 + j) + lvl] == pytest.approx(
+                coef[f"f::L{lvl}:z{j}"], rel=1e-6, abs=1e-8
+            )


### PR DESCRIPTION
Closes #60.

Generalizes the within-level reparametrization to any slope count on the sole factor: one-pass multivariate Welford moments per level, pivoted Gram–Schmidt on the centered slope Gram (raw for slope-only terms) taking the largest-remaining-variance direction each step, and a whitening map whose transpose back-transforms coefficients — dropped directions come back as exact zeros with a data-independent layout.

- Rank-drop contract: within-level collinear slopes drop exactly one direction (the pivot picks the survivor). The relative tolerance is crate-internal (1e-10, per-column so it is scale-invariant); a zero tolerance keeps near-degenerate directions, tested at the unit seam.
- Pivots are tracked through original column indices with no physical swapping, structurally excluding the prototype's ≥3-slope pivot-bookkeeping cliff; a property test forces a non-monotonic pivot order and asserts W·G·Wᵀ = I.
- The gate now rejects only slope terms alongside other terms (#61). V=1 behavior is unchanged.
- Tests (bare-minimum set): the two whitening-seam unit tests above, one consolidated V=3 integration test (bounded iterations, exact rank-drop reporting, residual-orthogonality + fitted-reconstruction oracle), and weighted V=3 pyfixest parity.
