### PR TITLE
Kernel-agnostic Schur reduction: sampled by default (#83)

### DIFF
--- a/crates/within/src/block_elim/elimination.rs
+++ b/crates/within/src/block_elim/elimination.rs
@@ -1,17 +1,17 @@
 //! Block-elimination metadata and star iteration for Schur complement assembly.
 //!
 //! For the bipartite SDDM `[D_q, -C; -C^T, D_r]`, eliminating the larger
-//! diagonal block (exact since it's diagonal) yields a reduced Laplacian-style
-//! system on the smaller block. This module owns the block-selection decision,
-//! precomputed inverse-diagonals, and zero-copy [`Star`] views used by both
-//! Schur complement strategies.
+//! diagonal block (exact since it's diagonal) yields a reduced SDDM system on
+//! the smaller block. This module owns the block-selection decision,
+//! precomputed inverse-diagonals, zero-copy [`Star`] views, and sampled fill
+//! edges on the explicit augmented graph.
 
 use approx_chol::low_level::{clique_tree_sample, clique_tree_sample_multi};
 use rayon::prelude::*;
 
 use crate::config::ApproxSchurConfig;
 use crate::csr_block::CsrBlock;
-use crate::domain::{BlockDiagonals, CrossTab};
+use crate::domain::{BlockDiagonals, CrossTab, GroundEdges, SolveSpace};
 use crate::BuildError;
 
 /// Undirected fill edge: `(lo_col, hi_col, weight)` with `lo_col < hi_col`.
@@ -23,9 +23,9 @@ pub(crate) type Edge = (u32, u32, f64);
 
 // Eliminating a diagonal vertex contributes a rank-1 clique (star) to the
 // Schur fill graph: every pair of its keep-block neighbors gets a fill edge.
-// `SampledCliqueEmitter` approximates high-degree stars with GKS 2023
-// clique-tree sampling — O(deg) edges instead of O(deg^2) — keeping the Schur
-// complement spectrally close to the exact (row-workspace) path.
+// `sample_star` approximates high-degree stars with GKS 2023 clique-tree
+// sampling — O(deg) edges instead of O(deg^2) — keeping the Schur complement
+// spectrally close to the exact (row-workspace) path.
 
 /// One eliminated vertex's neighbors in the keep-block.
 ///
@@ -45,31 +45,34 @@ impl Star<'_> {
     }
 }
 
-/// Emits sampled clique-tree fill edges for every star.
-pub(crate) struct SampledCliqueEmitter {
-    seed: u64,
-    split: u32,
-}
-
-impl SampledCliqueEmitter {
-    pub(crate) fn new(config: &ApproxSchurConfig) -> Self {
-        Self {
-            seed: config.seed,
-            split: config.split,
+/// Sample clique-tree fill edges for one eliminated star.
+///
+/// Ground surplus is one more incident edge, so the sampled star's capacity is
+/// exactly its eliminated diagonal.
+fn sample_star(
+    star: &Star,
+    ground: Option<(u32, f64)>,
+    config: &ApproxSchurConfig,
+    edges: &mut Vec<Edge>,
+    scratch: &mut Vec<(u32, f64)>,
+) {
+    scratch.clear();
+    for (&col, &w) in star.col_indices.iter().zip(star.weights) {
+        scratch.push((col, w));
+    }
+    if let Some((ground, surplus)) = ground {
+        if surplus > 0.0 {
+            scratch.push((ground, surplus));
         }
     }
-
-    fn emit(&self, star: &Star, edges: &mut Vec<Edge>, scratch: &mut Vec<(u32, f64)>) {
-        scratch.clear();
-        for (&col, &w) in star.col_indices.iter().zip(star.weights) {
-            scratch.push((col, w));
-        }
-        let seed = self.seed.wrapping_add(star.index as u64);
-        if self.split <= 1 {
-            clique_tree_sample(scratch, seed, edges);
-        } else {
-            clique_tree_sample_multi(scratch, self.split, seed, edges);
-        }
+    if scratch.len() <= 1 {
+        return;
+    }
+    let seed = config.seed.wrapping_add(star.index as u64);
+    if config.split <= 1 {
+        clique_tree_sample(scratch, seed, edges);
+    } else {
+        clique_tree_sample_multi(scratch, config.split, seed, edges);
     }
 }
 
@@ -87,6 +90,9 @@ pub(crate) struct Elimination<'a> {
     pub(crate) n_elim: usize,
     pub(crate) inv_diag_elim: Vec<f64>,
     pub(crate) diag_keep: &'a [f64],
+    pub(crate) surplus_keep: &'a [f64],
+    pub(crate) surplus_elim: &'a [f64],
+    pub(crate) solve_space: SolveSpace,
     pub(crate) keep_to_elim: &'a CsrBlock,
     pub(crate) elim_to_keep: &'a CsrBlock,
 }
@@ -100,6 +106,8 @@ impl<'a> Elimination<'a> {
     pub(crate) fn new(
         cross_tab: &'a CrossTab,
         diagonals: &'a BlockDiagonals,
+        ground_edges: &'a GroundEdges,
+        solve_space: SolveSpace,
     ) -> Result<Self, BuildError> {
         let n_q = cross_tab.n_q();
         let n_r = cross_tab.n_r();
@@ -132,6 +140,11 @@ impl<'a> Elimination<'a> {
         } else {
             &diagonals.q
         };
+        let (surplus_keep, surplus_elim) = if eliminate_q {
+            (&ground_edges.r[..], &ground_edges.q[..])
+        } else {
+            (&ground_edges.q[..], &ground_edges.r[..])
+        };
 
         let (keep_to_elim, elim_to_keep) = if eliminate_q {
             (&cross_tab.ct, &cross_tab.c)
@@ -145,6 +158,9 @@ impl<'a> Elimination<'a> {
             n_elim,
             inv_diag_elim,
             diag_keep,
+            surplus_keep,
+            surplus_elim,
+            solve_space,
             keep_to_elim,
             elim_to_keep,
         })
@@ -161,19 +177,22 @@ impl<'a> Elimination<'a> {
         }
     }
 
-    pub(crate) fn par_emit(&self, emitter: &SampledCliqueEmitter) -> Vec<Edge> {
+    pub(crate) fn par_emit(&self, config: &ApproxSchurConfig) -> Vec<Edge> {
         // Emit in parallel (one scratch buffer reused per fold chunk), concatenate,
         // then a single total-order `sort_and_dedup`. The total order fixes the
         // per-`(lo, hi)` weight summation order, so the result is independent of
         // thread scheduling (the concatenation order no longer matters).
+        let ground_vertex = (self.solve_space == SolveSpace::Grounded)
+            .then(|| u32::try_from(self.n_keep).expect("ground vertex exceeds u32::MAX"));
         let mut edges = (0..self.n_elim)
             .into_par_iter()
             .fold(
                 || (Vec::new(), Vec::<(u32, f64)>::new()),
                 |(mut edges, mut scratch), k| {
                     let star = self.star(k);
-                    if star.degree() > 1 {
-                        emitter.emit(&star, &mut edges, &mut scratch);
+                    if star.degree() > 0 {
+                        let ground = ground_vertex.map(|g| (g, self.surplus_elim[k]));
+                        sample_star(&star, ground, config, &mut edges, &mut scratch);
                     }
                     (edges, scratch)
                 },
@@ -183,6 +202,15 @@ impl<'a> Elimination<'a> {
                 a.append(&mut b);
                 a
             });
+        if let Some(ground) = ground_vertex {
+            edges.extend(
+                self.surplus_keep
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, surplus)| **surplus > 0.0)
+                    .map(|(i, &surplus)| (i as u32, ground, surplus)),
+            );
+        }
         Self::sort_and_dedup(&mut edges);
         edges
     }

--- a/crates/within/src/block_elim/factor.rs
+++ b/crates/within/src/block_elim/factor.rs
@@ -1,7 +1,7 @@
 //! Reduced-system factor backends for Schur-complement local solves.
 //!
 //! [`ReducedFactor`] wraps either approximate sparse Cholesky (from `approx-chol`)
-//! or dense Cholesky on an anchored principal minor ([`AnchoredDenseCholesky`]).
+//! or dense Cholesky on a principal minor ([`DenseCholesky`]).
 //! [`factor_sparse`] bridges to the `approx-chol` builder, surfacing build errors
 //! as [`BuildError::LocalSolverBuild`].
 
@@ -23,16 +23,23 @@ use crate::BuildError;
 pub(crate) enum ReducedFactor {
     /// Approximate sparse Cholesky on the reduced Schur CSR.
     Approx(Factor),
-    /// Exact dense Cholesky on an anchored principal minor of the Schur matrix.
-    Dense(AnchoredDenseCholesky),
+    /// Exact dense Cholesky on a principal minor of the Schur matrix.
+    Dense(DenseCholesky),
 }
 
 impl ReducedFactor {
-    pub(crate) fn try_dense_laplacian_minor(anchored_minor: Vec<f64>, n: usize) -> Option<Self> {
-        AnchoredDenseCholesky::try_from_dense_anchored_minor(anchored_minor, n).map(Self::Dense)
+    pub(crate) fn try_dense(minor: Vec<f64>, n: usize) -> Option<Self> {
+        DenseCholesky::try_factor(minor, n).map(Self::Dense)
     }
 
-    pub(crate) fn n(&self) -> usize {
+    pub(crate) fn input_dimension(&self) -> usize {
+        match self {
+            Self::Approx(f) => f.original_n(),
+            Self::Dense(f) => f.n(),
+        }
+    }
+
+    pub(crate) fn factor_dimension(&self) -> usize {
         match self {
             Self::Approx(f) => f.n(),
             Self::Dense(f) => f.n(),
@@ -59,36 +66,38 @@ impl ReducedFactor {
 }
 
 // ===========================================================================
-// AnchoredDenseCholesky — dense Cholesky on anchored principal minor
+// DenseCholesky — dense Cholesky on a principal minor
 // ===========================================================================
 
-/// Dense Cholesky on an anchored principal minor of a Laplacian-like matrix.
+/// Dense Cholesky on a principal `m × m` minor of the reduced Schur system.
+///
+/// `m == n` factors the full (nonsingular) complement; `m == n − 1` anchors
+/// the last node (`x = 0`) — the gauge for a floating Laplacian.
+/// `m` is recovered from the factor length, keeping the wire format unchanged.
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
-pub(crate) struct AnchoredDenseCholesky {
-    /// Lower-triangular factor of the `(n-1) x (n-1)` anchored minor.
+pub(crate) struct DenseCholesky {
+    /// Lower-triangular factor of the `m × m` minor, row-major.
     l_row_major: Vec<f64>,
-    /// Full Schur dimension before anchoring.
+    /// Full Schur dimension.
     n: usize,
 }
 
-impl AnchoredDenseCholesky {
-    fn try_from_dense_anchored_minor(dense_minor: Vec<f64>, n: usize) -> Option<Self> {
-        let m = n.saturating_sub(1);
+impl DenseCholesky {
+    fn try_factor(minor: Vec<f64>, n: usize) -> Option<Self> {
+        let anchored = n.saturating_sub(1);
+        let m = match minor.len() {
+            len if len == n * n => n,
+            len if len == anchored * anchored => anchored,
+            _ => return None,
+        };
         if m == 0 {
             return Some(Self {
                 l_row_major: Vec::new(),
                 n,
             });
         }
-        if dense_minor.len() != m * m {
-            return None;
-        }
-        Self::factor_dense_minor(dense_minor, n)
-    }
 
-    fn factor_dense_minor(dense_minor: Vec<f64>, n: usize) -> Option<Self> {
-        let m = n.saturating_sub(1);
-        let mat_ref = MatRef::from_row_major_slice(&dense_minor, m, m);
+        let mat_ref = MatRef::from_row_major_slice(&minor, m, m);
         let llt = mat_ref.llt(Side::Lower).ok()?;
         let l = llt.L();
 
@@ -106,24 +115,21 @@ impl AnchoredDenseCholesky {
         self.n
     }
 
-    /// Solve `L L^T x = b` on the anchored minor in-place.
+    /// Solve `L L^T x = b` on the factored minor in-place.
     ///
-    /// Expects `x.len() == n`; writes the anchored coordinate `x[n-1] = 0`.
+    /// Expects `x.len() == n`; coordinates past the minor (`x[m..]`) are the
+    /// anchored gauge and are written as zero.
     fn solve_in_place(&self, x: &mut [f64]) {
         debug_assert_eq!(x.len(), self.n);
-        if self.n == 0 {
-            return;
-        }
-        if self.n == 1 {
-            x[0] = 0.0;
-            return;
-        }
-
-        let m = self.n - 1;
         let l = &self.l_row_major;
+        let m = if l.len() == self.n * self.n {
+            self.n
+        } else {
+            self.n.saturating_sub(1)
+        };
         debug_assert_eq!(l.len(), m * m);
 
-        // Forward solve on anchored block: L y = b.
+        // Forward solve on the minor: L y = b.
         for i in 0..m {
             // SAFETY: i<m, row bounds and triangular-access bounds are validated by loop limits.
             let mut s = unsafe { *x.get_unchecked(i) };
@@ -139,7 +145,7 @@ impl AnchoredDenseCholesky {
             unsafe { *x.get_unchecked_mut(i) = s / lii };
         }
 
-        // Backward solve on anchored block: L^T x = y.
+        // Backward solve on the minor: L^T x = y.
         for i in (0..m).rev() {
             // SAFETY: i<m -> in bounds.
             let mut s = unsafe { *x.get_unchecked(i) };
@@ -155,7 +161,9 @@ impl AnchoredDenseCholesky {
             unsafe { *x.get_unchecked_mut(i) = s / lii };
         }
 
-        x[m] = 0.0;
+        for v in &mut x[m..] {
+            *v = 0.0;
+        }
     }
 }
 
@@ -189,8 +197,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_anchored_dense_cholesky_solve_n0() {
-        let chol = AnchoredDenseCholesky {
+    fn test_dense_cholesky_solve_n0() {
+        let chol = DenseCholesky {
             l_row_major: Vec::new(),
             n: 0,
         };
@@ -199,35 +207,44 @@ mod tests {
     }
 
     #[test]
-    fn test_anchored_dense_cholesky_solve_n1() {
-        let chol = AnchoredDenseCholesky {
+    fn test_dense_cholesky_solve_n1_anchored() {
+        let chol = DenseCholesky {
             l_row_major: Vec::new(),
             n: 1,
         };
         let mut x = vec![42.0];
         chol.solve_in_place(&mut x);
-        assert_eq!(x[0], 0.0); // n==1 -> x[0] = 0
+        assert_eq!(x[0], 0.0); // empty anchored minor -> x[0] = 0
     }
 
     #[test]
-    fn test_try_from_dense_anchored_minor_wrong_length() {
-        // n=3 -> m=2, expects 4 elements, give 3
-        let result = AnchoredDenseCholesky::try_from_dense_anchored_minor(vec![1.0, 2.0, 3.0], 3);
+    fn test_try_factor_wrong_length() {
+        // n=3 admits minors of 9 (full) or 4 (anchored) elements; give 3.
+        let result = DenseCholesky::try_factor(vec![1.0, 2.0, 3.0], 3);
         assert!(result.is_none());
     }
 
     #[test]
-    fn test_try_from_dense_anchored_minor_n1() {
-        // n=1 -> m=0, should return Some with empty
-        let result = AnchoredDenseCholesky::try_from_dense_anchored_minor(Vec::new(), 1);
+    fn test_try_factor_anchored_n1() {
+        // n=1, empty minor -> anchored m=0, Some with empty factor.
+        let result = DenseCholesky::try_factor(Vec::new(), 1);
         assert!(result.is_some());
         assert_eq!(result.unwrap().n(), 1);
     }
 
     #[test]
-    fn test_factor_dense_minor_singular() {
-        // Singular 2x2 matrix (both rows identical)
-        let result = AnchoredDenseCholesky::factor_dense_minor(vec![1.0, 1.0, 1.0, 1.0], 3);
+    fn test_try_factor_singular() {
+        // Singular 2x2 anchored minor of n=3 (both rows identical).
+        let result = DenseCholesky::try_factor(vec![1.0, 1.0, 1.0, 1.0], 3);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_full_minor_solves_directly() {
+        // Full 2x2 SPD minor (m == n): plain LLT solve, no anchored zero.
+        let chol = DenseCholesky::try_factor(vec![4.0, 0.0, 0.0, 9.0], 2).unwrap();
+        let mut x = vec![8.0, 18.0];
+        chol.solve_in_place(&mut x);
+        assert_eq!(x, vec![2.0, 2.0]);
     }
 }

--- a/crates/within/src/block_elim/schur.rs
+++ b/crates/within/src/block_elim/schur.rs
@@ -1,18 +1,17 @@
-//! Schur complement (a graph Laplacian on the kept factor levels) of an
-//! eliminated factor block in a bipartite SDDM system.
+//! Schur complement of the eliminated diagonal block in a bipartite SDDM
+//! system — SDDM in, SDDM on the kept levels out.
 //!
-//! Two [`SchurComplement`] impls share block-selection ([`Elimination`]) and
-//! emit a [`SchurLaplacian`]:
-//! - [`ExactSchurComplement`] — row-workspace accumulation.
-//! - [`ApproxSchurComplement`] — clique-tree sampling, keeping `S` sparse for
-//!   high-degree eliminated levels.
+//! [`exact`] accumulates the true reduced rows; [`sampled`] approximates each
+//! eliminated star's clique on the explicit augmented graph; [`dense_minor`]
+//! materializes the exact top-left `m × m` minor for the dense direct path.
 
+use super::compensated_sum;
 use super::csr_matrix::CsrMatrix;
 use rayon::prelude::*;
 
-use super::elimination::{Edge, Elimination, SampledCliqueEmitter};
+use super::elimination::{Edge, Elimination};
 use crate::config::ApproxSchurConfig;
-use crate::csr_block::CsrBlock;
+use crate::domain::SolveSpace;
 
 /// Checked `usize -> u32` for CSR indptr/index values. A silent `as u32`
 /// truncation above `u32::MAX` would corrupt the factorization with no
@@ -22,275 +21,270 @@ fn to_u32(x: usize) -> u32 {
     u32::try_from(x).expect("CSR index exceeds u32::MAX")
 }
 
-pub(crate) struct SchurLaplacian;
+/// Build the exact Schur complement via row-workspace accumulation.
+///
+/// Computes `S = D_keep − keep_to_elim · diag(inv_diag_elim) · elim_to_keep`
+/// directly, without materializing intermediate edges. Each keep-block row
+/// scatters into a dense workspace, then extracts non-zeros.
+pub(crate) fn exact(elim: &Elimination) -> CsrMatrix {
+    let n_keep = elim.n_keep;
 
-impl SchurLaplacian {
-    /// Build the Schur complement via row-workspace accumulation (exact path).
-    ///
-    /// Computes `S = D_keep − keep_to_elim · diag(inv_diag_elim) · elim_to_keep`
-    /// directly, without materializing intermediate edges. Each keep-block row
-    /// scatters into a dense workspace, then extracts non-zeros.
-    fn from_elimination(elim: &Elimination) -> CsrMatrix {
-        let n_keep = elim.n_keep;
-        let inv_diag_elim = &elim.inv_diag_elim;
-        let diag_keep = elim.diag_keep;
-        let keep_to_elim = elim.keep_to_elim;
-        let elim_to_keep = elim.elim_to_keep;
+    // Per-row Schur complement accumulation, parallelized via map_init.
+    // The (work, touched) pair is allocated once per rayon task and reused
+    // across rows assigned to that task.
+    let rows: Vec<(Vec<u32>, Vec<f64>)> = (0..n_keep)
+        .into_par_iter()
+        .map_init(
+            || (vec![0.0f64; n_keep], Vec::new()),
+            |(work, touched), i| {
+                compute_schur_row_dense(elim, i, work, touched);
+                let result = extract_sparse_row(i, work, touched);
+                touched.clear();
+                result
+            },
+        )
+        .collect();
 
-        // Per-row Schur complement accumulation, parallelized via map_init.
-        // The (work, touched) pair is allocated once per rayon task and reused
-        // across rows assigned to that task.
-        let rows: Vec<(Vec<u32>, Vec<f64>)> = (0..n_keep)
-            .into_par_iter()
-            .map_init(
-                || (vec![0.0f64; n_keep], Vec::new()),
-                |(work, touched), i| {
-                    Self::compute_schur_row_dense(
-                        i,
-                        diag_keep,
-                        keep_to_elim,
-                        elim_to_keep,
-                        inv_diag_elim,
-                        work,
-                        touched,
-                    );
-                    let result = Self::extract_sparse_row(i, work, touched);
-                    touched.clear();
-                    result
-                },
-            )
-            .collect();
+    assemble_schur_csr(rows, n_keep)
+}
 
-        Self::assemble_schur_csr(rows, n_keep)
+/// Build the sampled Schur complement as a Laplacian. Grounded systems retain
+/// the ground vertex as an ordinary final vertex.
+pub(crate) fn sampled(elim: &Elimination, config: &ApproxSchurConfig) -> CsrMatrix {
+    let edges = elim.par_emit(config);
+    let n = elim.n_keep + usize::from(elim.solve_space == SolveSpace::Grounded);
+    build_laplacian_csr(&edges, n)
+}
+
+pub(crate) fn exact_for_factor(elim: &Elimination) -> CsrMatrix {
+    let principal = exact(elim);
+    let surplus = reduced_surplus(elim);
+    build_explicit_laplacian(&principal, &surplus, elim.solve_space)
+}
+
+/// Build the exact top-left `m × m` Schur minor in row-major order.
+///
+/// `m == n_keep` is the full grounded complement; `m == n_keep − 1` anchors the
+/// last node of a floating Laplacian.
+pub(crate) fn dense_minor(elim: &Elimination, m: usize) -> Vec<f64> {
+    if m == 0 {
+        return Vec::new();
     }
 
-    /// Build the anchored top-left Schur minor `(n_keep-1) x (n_keep-1)` in row-major.
-    ///
-    /// This is the matrix actually factored by dense anchored Cholesky, so building
-    /// it directly avoids allocating a full `n_keep x n_keep` dense Schur matrix.
-    pub(crate) fn anchored_minor_from_elimination(elim: &Elimination) -> Vec<f64> {
-        let n_keep = elim.n_keep;
-        if n_keep <= 1 {
-            return Vec::new();
-        }
+    let mut minor = vec![0.0; m * m];
+    for i in 0..m {
+        minor[i * m + i] = elim.diag_keep[i];
+    }
 
-        let m = n_keep - 1;
-        let mut dense_minor = vec![0.0; m * m];
-
-        // Start with the kept diagonal block on anchored rows/cols.
-        for i in 0..m {
-            dense_minor[i * m + i] = elim.diag_keep[i];
-        }
-
-        let inv_diag_elim = &elim.inv_diag_elim;
-        let keep_to_elim = elim.keep_to_elim;
-        let elim_to_keep = elim.elim_to_keep;
-
-        // S_minor = D_keep_minor - keep_to_elim_minor * inv(D_elim) * elim_to_keep_minor
-        for i in 0..m {
-            let fwd_start = keep_to_elim.indptr[i] as usize;
-            let fwd_end = keep_to_elim.indptr[i + 1] as usize;
-            for fwd_idx in fwd_start..fwd_end {
-                let k = keep_to_elim.indices[fwd_idx] as usize;
-                let scale = keep_to_elim.data[fwd_idx] * inv_diag_elim[k];
-                let bwd_start = elim_to_keep.indptr[k] as usize;
-                let bwd_end = elim_to_keep.indptr[k + 1] as usize;
-                for bwd_idx in bwd_start..bwd_end {
-                    let j = elim_to_keep.indices[bwd_idx] as usize;
-                    if j < m {
-                        dense_minor[i * m + j] -= scale * elim_to_keep.data[bwd_idx];
-                    }
+    // S_minor = D_keep_minor - keep_to_elim_minor * inv(D_elim) * elim_to_keep_minor
+    for i in 0..m {
+        for (k, w) in elim.keep_to_elim.row(i) {
+            let scale = w * elim.inv_diag_elim[k];
+            for (j, v) in elim.elim_to_keep.row(k) {
+                if j < m {
+                    minor[i * m + j] -= scale * v;
                 }
             }
         }
-
-        dense_minor
     }
 
-    /// Scatter the Schur row `i` into a dense workspace.
-    ///
-    /// Computes `work[j] = D_keep[i] δ_{ij} - Σ_k (keep_to_elim[i,k] / D_elim[k]) * elim_to_keep[k,j]`
-    /// and records touched column indices.
-    fn compute_schur_row_dense(
-        i: usize,
-        diag_keep: &[f64],
-        keep_to_elim: &CsrBlock,
-        elim_to_keep: &CsrBlock,
-        inv_diag_elim: &[f64],
-        work: &mut [f64],
-        touched: &mut Vec<usize>,
-    ) {
-        work[i] = diag_keep[i];
-        touched.push(i);
+    minor
+}
 
-        let fwd_start = keep_to_elim.indptr[i] as usize;
-        let fwd_end = keep_to_elim.indptr[i + 1] as usize;
-        for fwd_idx in fwd_start..fwd_end {
-            let k = keep_to_elim.indices[fwd_idx] as usize;
-            let scale = keep_to_elim.data[fwd_idx] * inv_diag_elim[k];
-            let bwd_start = elim_to_keep.indptr[k] as usize;
-            let bwd_end = elim_to_keep.indptr[k + 1] as usize;
-            for bwd_idx in bwd_start..bwd_end {
-                let j = elim_to_keep.indices[bwd_idx] as usize;
-                if work[j] == 0.0 && j != i {
-                    touched.push(j);
-                }
-                work[j] -= scale * elim_to_keep.data[bwd_idx];
+/// Scatter the Schur row `i` into a dense workspace.
+///
+/// Computes `work[j] = D_keep[i] δ_{ij} - Σ_k (keep_to_elim[i,k] / D_elim[k]) * elim_to_keep[k,j]`
+/// and records touched column indices.
+fn compute_schur_row_dense(
+    elim: &Elimination,
+    i: usize,
+    work: &mut [f64],
+    touched: &mut Vec<usize>,
+) {
+    work[i] = elim.diag_keep[i];
+    touched.push(i);
+
+    for (k, w) in elim.keep_to_elim.row(i) {
+        let scale = w * elim.inv_diag_elim[k];
+        for (j, v) in elim.elim_to_keep.row(k) {
+            if work[j] == 0.0 && j != i {
+                touched.push(j);
+            }
+            work[j] -= scale * v;
+        }
+    }
+}
+
+/// Extract non-zero entries from the dense workspace into sparse row arrays.
+///
+/// Sorts touched columns, emits non-zero values (preserving the diagonal even
+/// if numerically zero for SDDM structure), and clears the workspace.
+fn extract_sparse_row(i: usize, work: &mut [f64], touched: &mut [usize]) -> (Vec<u32>, Vec<f64>) {
+    touched.sort_unstable();
+    // `touched.len()` is a tight upper bound on the emitted non-zeros
+    // (the diagonal plus every fill column), so size both buffers once.
+    let mut row_indices = Vec::with_capacity(touched.len());
+    let mut row_data = Vec::with_capacity(touched.len());
+    for &j in touched.iter() {
+        let v = work[j];
+        if v != 0.0 || j == i {
+            row_indices.push(to_u32(j));
+            row_data.push(v);
+        }
+        work[j] = 0.0;
+    }
+    (row_indices, row_data)
+}
+
+/// Assemble a CSR matrix from per-row sparse results.
+fn assemble_schur_csr(rows: Vec<(Vec<u32>, Vec<f64>)>, n_keep: usize) -> CsrMatrix {
+    let mut s_indptr = vec![0u32; n_keep + 1];
+    // Pre-count total NNZ so the value/index buffers allocate exactly once.
+    let total_nnz: usize = rows.iter().map(|(ri, _)| ri.len()).sum();
+    let mut s_indices = Vec::with_capacity(total_nnz);
+    let mut s_data = Vec::with_capacity(total_nnz);
+    for (i, (ri, rd)) in rows.into_iter().enumerate() {
+        s_indices.extend_from_slice(&ri);
+        s_data.extend_from_slice(&rd);
+        s_indptr[i + 1] = to_u32(s_indices.len());
+    }
+    CsrMatrix::new(s_indptr, s_indices, s_data, n_keep)
+}
+
+/// Build a symmetric Laplacian CSR from sorted upper-triangular edges.
+///
+/// Edges must be sorted by (lo, hi) with lo < hi, which lets lower-triangle,
+/// diagonal, and upper-triangle entries land in column order without per-row
+/// sorting.
+fn build_laplacian_csr(edges: &[Edge], n: usize) -> CsrMatrix {
+    debug_assert!(edges.iter().all(|&(lo, hi, _)| lo < hi));
+
+    // Count lower/upper entries per row and accumulate diagonal weights.
+    let mut lower_count = vec![0u32; n];
+    let mut upper_count = vec![0u32; n];
+    let mut diag = vec![0.0; n];
+    for &(lo, hi, w) in edges {
+        diag[lo as usize] += w;
+        upper_count[lo as usize] += 1; // row lo gets col hi (upper)
+        lower_count[hi as usize] += 1; // row hi gets col lo (lower)
+        diag[hi as usize] += w;
+    }
+
+    // Row layout: [lower entries | diagonal | upper entries]
+    let mut offsets = vec![0u32; n + 1];
+    for i in 0..n {
+        offsets[i + 1] = offsets[i] + lower_count[i] + 1 + upper_count[i];
+    }
+    let total_nnz = offsets[n] as usize;
+    let mut indices = vec![0u32; total_nnz];
+    let mut data = vec![0.0f64; total_nnz];
+
+    // Place diagonals and initialize cursors.
+    let mut lower_cursor: Vec<u32> = (0..n).map(|i| offsets[i]).collect();
+    let mut upper_cursor: Vec<u32> = (0..n).map(|i| offsets[i] + lower_count[i] + 1).collect();
+    for i in 0..n {
+        let pos = (offsets[i] + lower_count[i]) as usize;
+        indices[pos] = to_u32(i);
+        data[pos] = diag[i];
+    }
+
+    // Single pass: edges sorted by (lo, hi) guarantees both lower and
+    // upper entries arrive in column-sorted order per row.
+    for &(lo, hi, w) in edges {
+        let lo_idx = lo as usize;
+        let hi_idx = hi as usize;
+        // Upper triangle: row lo, column hi
+        let pos = upper_cursor[lo_idx] as usize;
+        indices[pos] = hi;
+        data[pos] = -w;
+        upper_cursor[lo_idx] += 1;
+        // Lower triangle: row hi, column lo
+        let pos = lower_cursor[hi_idx] as usize;
+        indices[pos] = lo;
+        data[pos] = -w;
+        lower_cursor[hi_idx] += 1;
+    }
+
+    CsrMatrix::new(offsets, indices, data, n)
+}
+
+fn reduced_surplus(elim: &Elimination) -> Vec<f64> {
+    if elim.solve_space == SolveSpace::Floating {
+        return vec![0.0; elim.n_keep];
+    }
+    let scaled: Vec<f64> = elim
+        .inv_diag_elim
+        .iter()
+        .zip(elim.surplus_elim)
+        .map(|(&inv_diag, &surplus)| inv_diag * surplus)
+        .collect();
+    let mut surplus = vec![0.0; elim.n_keep];
+    elim.keep_to_elim
+        .spmv_assign_add(&scaled, elim.surplus_keep, &mut surplus, false);
+    surplus
+}
+
+pub(super) fn build_explicit_laplacian(
+    principal: &CsrMatrix,
+    surplus: &[f64],
+    solve_space: SolveSpace,
+) -> CsrMatrix {
+    let n_keep = principal.n();
+    let ground = to_u32(n_keep);
+    let grounded = solve_space == SolveSpace::Grounded;
+    let n = n_keep + usize::from(grounded);
+    let mut indptr = Vec::with_capacity(n + 1);
+    let mut indices = Vec::new();
+    let mut data = Vec::new();
+    indptr.push(0);
+
+    for (i, &row_surplus) in surplus.iter().enumerate().take(n_keep) {
+        let start = principal.indptr()[i] as usize;
+        let end = principal.indptr()[i + 1] as usize;
+        let mut adjacency = 0.0;
+        let mut diagonal_position = None;
+        for (&j, &value) in principal.indices()[start..end]
+            .iter()
+            .zip(&principal.data()[start..end])
+        {
+            if j as usize == i {
+                diagonal_position = Some(indices.len());
+                indices.push(j);
+                data.push(0.0);
+            } else {
+                adjacency -= value;
+                indices.push(j);
+                data.push(value);
             }
         }
+        let diagonal_position = diagonal_position.expect("exact Schur row must contain a diagonal");
+        data[diagonal_position] = adjacency + row_surplus;
+        if grounded && row_surplus > 0.0 {
+            indices.push(ground);
+            data.push(-row_surplus);
+        }
+        indptr.push(to_u32(indices.len()));
     }
 
-    /// Extract non-zero entries from the dense workspace into sparse row arrays.
-    ///
-    /// Sorts touched columns, emits non-zero values (preserving the diagonal even
-    /// if numerically zero for SDDM structure), and clears the workspace.
-    fn extract_sparse_row(
-        i: usize,
-        work: &mut [f64],
-        touched: &mut [usize],
-    ) -> (Vec<u32>, Vec<f64>) {
-        touched.sort_unstable();
-        // `touched.len()` is a tight upper bound on the emitted non-zeros
-        // (the diagonal plus every fill column), so size both buffers once.
-        let mut row_indices = Vec::with_capacity(touched.len());
-        let mut row_data = Vec::with_capacity(touched.len());
-        for &j in touched.iter() {
-            let v = work[j];
-            if v != 0.0 || j == i {
-                row_indices.push(to_u32(j));
-                row_data.push(v);
+    if grounded {
+        for (i, &value) in surplus.iter().enumerate() {
+            if value > 0.0 {
+                indices.push(to_u32(i));
+                data.push(-value);
             }
-            work[j] = 0.0;
         }
-        (row_indices, row_data)
+        indices.push(ground);
+        data.push(compensated_sum(surplus));
+        indptr.push(to_u32(indices.len()));
     }
-
-    /// Assemble a CSR matrix from per-row sparse results.
-    fn assemble_schur_csr(rows: Vec<(Vec<u32>, Vec<f64>)>, n_keep: usize) -> CsrMatrix {
-        let mut s_indptr = vec![0u32; n_keep + 1];
-        // Pre-count total NNZ so the value/index buffers allocate exactly once.
-        let total_nnz: usize = rows.iter().map(|(ri, _)| ri.len()).sum();
-        let mut s_indices = Vec::with_capacity(total_nnz);
-        let mut s_data = Vec::with_capacity(total_nnz);
-        for (i, (ri, rd)) in rows.into_iter().enumerate() {
-            s_indices.extend_from_slice(&ri);
-            s_data.extend_from_slice(&rd);
-            s_indptr[i + 1] = to_u32(s_indices.len());
-        }
-        CsrMatrix::new(s_indptr, s_indices, s_data, n_keep)
-    }
-
-    /// Build symmetric CSR Laplacian from sorted upper-triangular edges.
-    ///
-    /// Edges must be sorted by (lo, hi) with lo < hi. This lets us place
-    /// lower-triangle, diagonal, and upper-triangle entries in correct column
-    /// order without any per-row sorting.
-    fn build_laplacian_csr(edges: &[Edge], n_keep: usize) -> CsrMatrix {
-        debug_assert!(edges.iter().all(|&(lo, hi, _)| lo < hi));
-
-        // Count lower/upper entries per row and accumulate diagonal weights.
-        let mut lower_count = vec![0u32; n_keep];
-        let mut upper_count = vec![0u32; n_keep];
-        let mut diag = vec![0.0f64; n_keep];
-        for &(lo, hi, w) in edges {
-            upper_count[lo as usize] += 1; // row lo gets col hi (upper)
-            lower_count[hi as usize] += 1; // row hi gets col lo (lower)
-            diag[lo as usize] += w;
-            diag[hi as usize] += w;
-        }
-
-        // Row layout: [lower entries | diagonal | upper entries]
-        let mut offsets = vec![0u32; n_keep + 1];
-        for i in 0..n_keep {
-            offsets[i + 1] = offsets[i] + lower_count[i] + 1 + upper_count[i];
-        }
-        let total_nnz = offsets[n_keep] as usize;
-        let mut indices = vec![0u32; total_nnz];
-        let mut data = vec![0.0f64; total_nnz];
-
-        // Place diagonals and initialize cursors.
-        let mut lower_cursor: Vec<u32> = (0..n_keep).map(|i| offsets[i]).collect();
-        let mut upper_cursor: Vec<u32> = (0..n_keep)
-            .map(|i| offsets[i] + lower_count[i] + 1)
-            .collect();
-        for i in 0..n_keep {
-            let pos = (offsets[i] + lower_count[i]) as usize;
-            indices[pos] = to_u32(i);
-            data[pos] = diag[i];
-        }
-
-        // Single pass: edges sorted by (lo, hi) guarantees both lower and
-        // upper entries arrive in column-sorted order per row.
-        for &(lo, hi, w) in edges {
-            let lo_idx = lo as usize;
-            let hi_idx = hi as usize;
-            // Upper triangle: row lo, column hi
-            let pos = upper_cursor[lo_idx] as usize;
-            indices[pos] = hi;
-            data[pos] = -w;
-            upper_cursor[lo_idx] += 1;
-            // Lower triangle: row hi, column lo
-            let pos = lower_cursor[hi_idx] as usize;
-            indices[pos] = lo;
-            data[pos] = -w;
-            lower_cursor[hi_idx] += 1;
-        }
-
-        CsrMatrix::new(offsets, indices, data, n_keep)
-    }
-}
-
-// ===========================================================================
-// Trait + implementations
-// ===========================================================================
-
-/// Strategy for computing the Schur complement from a prepared [`Elimination`].
-pub(crate) trait SchurComplement {
-    fn compute(&self, elim: &Elimination) -> CsrMatrix;
-}
-
-/// Exact Schur complement via block elimination.
-pub(crate) struct ExactSchurComplement;
-
-/// Approximate Schur complement via clique-tree sampling.
-pub(crate) struct ApproxSchurComplement {
-    config: ApproxSchurConfig,
-}
-
-impl ApproxSchurComplement {
-    pub(crate) fn new(config: ApproxSchurConfig) -> Self {
-        Self { config }
-    }
-}
-
-impl SchurComplement for ExactSchurComplement {
-    /// Compute the exact Schur complement using row-workspace accumulation.
-    ///
-    /// For the bipartite SDDM `[D_q, -C; -C^T, D_r]`, eliminates the larger
-    /// block (exact since it's diagonal) to get a reduced Laplacian on the
-    /// smaller block.
-    fn compute(&self, elim: &Elimination) -> CsrMatrix {
-        SchurLaplacian::from_elimination(elim)
-    }
-}
-
-impl SchurComplement for ApproxSchurComplement {
-    /// Compute an approximate Schur complement by sampling clique-trees.
-    ///
-    /// Each eliminated vertex produces at most deg-1 fill edges via the
-    /// GKS 2023 Algorithm 5 clique-tree approximation.
-    fn compute(&self, elim: &Elimination) -> CsrMatrix {
-        let emitter = SampledCliqueEmitter::new(&self.config);
-        let edges = elim.par_emit(&emitter);
-        SchurLaplacian::build_laplacian_csr(&edges, elim.n_keep)
-    }
+    CsrMatrix::new(indptr, indices, data, n)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::csr_block::CsrBlock;
-    use crate::domain::{BlockDiagonals, CrossTab};
+    use crate::domain::{BlockDiagonals, CrossTab, GroundEdges};
 
     fn make_cross_tab(
         c_dense: &[f64],
@@ -308,6 +302,18 @@ mod tests {
                 r: diag_r,
             },
         )
+    }
+
+    fn surplus_of(cross_tab: &CrossTab, diagonals: &BlockDiagonals) -> GroundEdges {
+        let row_surplus = |block: &CsrBlock, diagonal: &[f64]| {
+            (0..block.nrows)
+                .map(|i| (diagonal[i] - block.row(i).map(|(_, v)| v).sum::<f64>()).max(0.0))
+                .collect()
+        };
+        GroundEdges {
+            q: row_surplus(&cross_tab.c, &diagonals.q),
+            r: row_surplus(&cross_tab.ct, &diagonals.r),
+        }
     }
 
     fn sparse_to_dense(matrix: &CsrMatrix) -> Vec<Vec<f64>> {
@@ -397,7 +403,9 @@ mod tests {
         let diag_q = vec![5.0, 6.0, 8.0];
         let diag_r = vec![7.0, 9.0];
         let (cross_tab, diagonals) = make_cross_tab(&c_dense, 3, 2, diag_q.clone(), diag_r.clone());
-        let elim = Elimination::new(&cross_tab, &diagonals).unwrap();
+        let surplus = surplus_of(&cross_tab, &diagonals);
+        let elim =
+            Elimination::new(&cross_tab, &diagonals, &surplus, SolveSpace::Grounded).unwrap();
 
         assert!(elim.eliminate_q);
         assert_eq!(elim.inv_diag_elim.len(), 3);
@@ -409,7 +417,7 @@ mod tests {
             assert!((got - expected).abs() < 1e-12);
         }
 
-        let matrix = ExactSchurComplement.compute(&elim);
+        let matrix = exact(&elim);
         let expected = dense_exact_schur(&c_dense, 3, 2, &diag_q, &diag_r, true);
         let got = sparse_to_dense(&matrix);
         assert_dense_close(&got, &expected, 1e-12);
@@ -424,7 +432,8 @@ mod tests {
         let diag_r = vec![5.0, 6.0, 0.0];
         let (cross_tab, diagonals) = make_cross_tab(&c_dense, 2, 3, diag_q, diag_r);
 
-        let result = Elimination::new(&cross_tab, &diagonals);
+        let surplus = surplus_of(&cross_tab, &diagonals);
+        let result = Elimination::new(&cross_tab, &diagonals, &surplus, SolveSpace::Grounded);
         match result {
             Err(crate::BuildError::SingularDiagonal { index: 2, .. }) => {}
             Err(e) => panic!("expected SingularDiagonal at index 2, got: {e}"),
@@ -435,18 +444,23 @@ mod tests {
     #[test]
     fn approximate_schur_is_seed_deterministic_and_laplacian_like() {
         // Degree-3 star in eliminated block gives nontrivial sampled edges.
+        // Diagonals equal the adjacency row/column sums exactly, so the
+        // reduced system is a pure (zero-row-sum) Laplacian.
         let c_dense = vec![1.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
         let (cross_tab, diagonals) =
-            make_cross_tab(&c_dense, 3, 3, vec![10.0, 4.0, 5.0], vec![2.0, 3.0, 4.0]);
-        let elim_a = Elimination::new(&cross_tab, &diagonals).unwrap();
-        let elim_b = Elimination::new(&cross_tab, &diagonals).unwrap();
-        let approx = ApproxSchurComplement::new(crate::config::ApproxSchurConfig {
+            make_cross_tab(&c_dense, 3, 3, vec![6.0, 1.0, 1.0], vec![2.0, 3.0, 3.0]);
+        let surplus = surplus_of(&cross_tab, &diagonals);
+        let elim_a =
+            Elimination::new(&cross_tab, &diagonals, &surplus, SolveSpace::Floating).unwrap();
+        let elim_b =
+            Elimination::new(&cross_tab, &diagonals, &surplus, SolveSpace::Floating).unwrap();
+        let config = crate::config::ApproxSchurConfig {
             seed: 12345,
             ..Default::default()
-        });
+        };
 
-        let a = approx.compute(&elim_a);
-        let b = approx.compute(&elim_b);
+        let a = sampled(&elim_a, &config);
+        let b = sampled(&elim_b, &config);
 
         assert_eq!(elim_a.eliminate_q, elim_b.eliminate_q);
         assert_eq!(elim_a.inv_diag_elim, elim_b.inv_diag_elim);
@@ -469,6 +483,41 @@ mod tests {
             }
             assert!(row_sum.abs() <= 1e-10, "row {i} sum is not near zero");
             assert!(row[i] >= -1e-12, "diagonal should be non-negative");
+        }
+    }
+
+    #[test]
+    fn sampled_schur_carries_surplus_exactly_on_low_degree_stars() {
+        // Surplus on both blocks, geometry chosen so every eliminated star has
+        // at most two entries *including* its ground entry — clique-tree
+        // sampling of a 2-entry star is deterministic and exact, so the
+        // sampled reduction must equal the exact Schur complement:
+        //   q0: adjacency {r0: 1}, diag 3   -> star {(r0,1), (g,2)}
+        //   q1: adjacency {r0: 2, r1: 3}, diag 5 (no surplus)
+        //   q2: adjacency {r1: 4}, diag 6   -> star {(r1,4), (g,2)}
+        // Kept rows carry their own surplus: diag_r = col sums + [0.5, 0].
+        let c_dense = vec![1.0, 0.0, 2.0, 3.0, 0.0, 4.0];
+        let diag_q = vec![3.0, 5.0, 6.0];
+        let diag_r = vec![3.5, 7.0];
+        let (cross_tab, diagonals) = make_cross_tab(&c_dense, 3, 2, diag_q.clone(), diag_r.clone());
+        let surplus = surplus_of(&cross_tab, &diagonals);
+        let elim =
+            Elimination::new(&cross_tab, &diagonals, &surplus, SolveSpace::Grounded).unwrap();
+        assert!(elim.eliminate_q);
+
+        let sampled_dense = sparse_to_dense(&sampled(&elim, &Default::default()));
+        let expected = dense_exact_schur(&c_dense, 3, 2, &diag_q, &diag_r, true);
+        let sampled_principal: Vec<Vec<f64>> = sampled_dense[..expected.len()]
+            .iter()
+            .map(|row| row[..expected.len()].to_vec())
+            .collect();
+        assert_dense_close(&sampled_principal, &expected, 1e-12);
+
+        // Surplus is represented by an explicit ground vertex, so the augmented
+        // reduced matrix is an exact zero-row-sum Laplacian.
+        for (i, row) in sampled_dense.iter().enumerate() {
+            let row_sum: f64 = row.iter().sum();
+            assert!(row_sum.abs() < 1e-12, "row {i} sum is {row_sum}");
         }
     }
 }

--- a/crates/within/src/block_elim/solver.rs
+++ b/crates/within/src/block_elim/solver.rs
@@ -11,7 +11,7 @@ use crate::BuildError;
 use super::compensated_sum;
 use super::elimination::Elimination;
 use super::factor::{factor_sparse, ReducedFactor};
-use super::schur::{ApproxSchurComplement, ExactSchurComplement, SchurComplement, SchurLaplacian};
+use super::schur;
 
 // ===========================================================================
 // Solve helpers
@@ -155,6 +155,12 @@ impl BlockRoles<'_> {
 }
 
 impl BlockElimSolver {
+    fn explicit_ground_index(&self, n_keep: usize) -> Option<usize> {
+        (self.solve_space == SolveSpace::Grounded
+            && self.reduced_factor.input_dimension() == n_keep + 1)
+            .then_some(n_keep)
+    }
+
     pub(crate) fn new(
         cross_tab: impl Into<Arc<CrossTab>>,
         inv_diag_elim: Vec<f64>,
@@ -165,7 +171,7 @@ impl BlockElimSolver {
     ) -> Self {
         let cross_tab = cross_tab.into();
         let n_local = cross_tab.n_local();
-        let n_reduced = reduced_factor.n();
+        let n_reduced = reduced_factor.factor_dimension();
         Self {
             cross_tab,
             inv_diag_elim,
@@ -180,11 +186,14 @@ impl BlockElimSolver {
 
     /// Build a `BlockElimSolver` from a [`CrossTab`] and solver config.
     ///
-    /// Pipeline: build the [`Elimination`] once; attempt dense factorization on
-    /// the anchored minor when below `dense_threshold`; otherwise (or on dense
-    /// failure) assemble the sparse Schur complement and factor it via
-    /// `approx_chol`. The `Elimination` is consumed at the end to produce
-    /// `inv_diag_elim` and `eliminate_q`.
+    /// Pipeline: build the [`Elimination`] once; attempt dense factorization of
+    /// the exact Schur minor when below `dense_threshold`; otherwise (or on
+    /// dense failure) assemble the sparse Schur complement — sampled unless
+    /// configured exact — and factor it via `approx_chol`. The `Elimination` is
+    /// consumed at the end to produce `inv_diag_elim` and `eliminate_q`.
+    ///
+    /// `diagonals` are the build-time-only diagonal blocks; they are read by
+    /// [`Elimination::new`] and dropped once the factor is built.
     pub(crate) fn build(
         component: SddmComponent,
         config: &LocalSolverConfig,
@@ -192,26 +201,26 @@ impl BlockElimSolver {
         let SddmComponent {
             cross_tab,
             diagonals,
+            ground_edges,
             coordinates,
             solve_space,
         } = component;
-        let elim = Elimination::new(&cross_tab, &diagonals)?;
+        let elim = Elimination::new(&cross_tab, &diagonals, &ground_edges, solve_space)?;
         let n_keep = elim.n_keep;
-        // The dense factor anchors one node (`x_anchor = 0`) — a gauge choice
-        // valid only for the singular floating case.
-        let prefer_dense = solve_space == SolveSpace::Floating
-            && config.dense_threshold > 0
-            && n_keep <= config.dense_threshold;
 
-        // Below the dense threshold the reduced system is tiny — always use exact
-        // Schur complement (cheap at this size) and dense Cholesky factorization.
+        // Below the dense threshold the reduced system is tiny — factor the
+        // exact Schur minor densely. Floating systems anchor one node; grounded
+        // systems factor the full nonsingular complement.
         let dense_factor = if n_keep == 0 {
             // Trivial 1×1 component: nothing kept to reduce, so the solve
             // degenerates to `x = r/d`; never send an empty system to approx-chol.
-            ReducedFactor::try_dense_laplacian_minor(Vec::new(), 0)
-        } else if prefer_dense {
-            let anchored_minor = SchurLaplacian::anchored_minor_from_elimination(&elim);
-            ReducedFactor::try_dense_laplacian_minor(anchored_minor, n_keep)
+            ReducedFactor::try_dense(Vec::new(), 0)
+        } else if config.dense_threshold > 0 && n_keep <= config.dense_threshold {
+            let m = match solve_space {
+                SolveSpace::Floating => n_keep - 1,
+                SolveSpace::Grounded => n_keep,
+            };
+            ReducedFactor::try_dense(schur::dense_minor(&elim, m), n_keep)
         } else {
             None
         };
@@ -221,18 +230,19 @@ impl BlockElimSolver {
         let factor = match dense_factor {
             Some(f) => f,
             None => {
-                // Sampled Schur rebuilds the diagonal from edge weights alone,
-                // discarding the surplus that keeps a grounded component
-                // nonsingular — grounded components always take the exact path.
                 let schur_csr = match config.approx_schur {
-                    Some(cfg) if solve_space == SolveSpace::Floating => {
-                        ApproxSchurComplement::new(cfg).compute(&elim)
-                    }
-                    _ => ExactSchurComplement.compute(&elim),
+                    Some(cfg) => schur::sampled(&elim, &cfg),
+                    None => schur::exact_for_factor(&elim),
                 };
                 factor_sparse(&schur_csr, config.approx_chol)?
             }
         };
+        let reduced_input_dimension = factor.input_dimension();
+        debug_assert!(
+            reduced_input_dimension == n_keep
+                || (solve_space == SolveSpace::Grounded && reduced_input_dimension == n_keep + 1)
+        );
+        debug_assert!(factor.factor_dimension() >= reduced_input_dimension);
 
         let Elimination {
             inv_diag_elim,
@@ -263,6 +273,7 @@ impl BlockElimSolver {
     ) -> Result<(), LocalSolveError> {
         let n = self.n_local;
         let n_keep = roles.keep.len();
+        let explicit_ground = self.explicit_ground_index(n_keep);
 
         // Scale the eliminated block by its inverse diagonal.
         scale_by_diag_in_place(&mut rhs[roles.elim.clone()], &self.inv_diag_elim);
@@ -270,6 +281,7 @@ impl BlockElimSolver {
         // Apply `keep_to_elim` into the scratch tail to form the reduced RHS.
         {
             let (main, scratch) = rhs.split_at_mut(n);
+            scratch[n_keep..self.n_reduced].fill(0.0);
             roles.keep_to_elim.spmv_assign_add(
                 &main[roles.elim.clone()],
                 &main[roles.keep.clone()],
@@ -279,17 +291,14 @@ impl BlockElimSolver {
         }
         match self.solve_space {
             SolveSpace::Floating => {
-                if self.n_reduced > n_keep {
-                    rhs[n + n_keep] = 0.0;
-                }
                 subtract_mean(&mut rhs[n..], self.n_reduced);
             }
             // Grounded-Laplacian reduction of the nonsingular SDD reduced
             // system: the ground node absorbs the injected current, and its
             // potential is the gauge subtracted after the solve.
             SolveSpace::Grounded => {
-                if self.n_reduced > n_keep {
-                    rhs[n + n_keep] = -compensated_sum(&rhs[n..n + n_keep]);
+                if let Some(ground) = explicit_ground {
+                    rhs[n + ground] = -compensated_sum(&rhs[n..n + n_keep]);
                 }
             }
         }
@@ -298,8 +307,8 @@ impl BlockElimSolver {
         let reduced = roles.keep.start..roles.keep.start + self.n_reduced;
         sol[reduced.clone()].copy_from_slice(&rhs[n..n + self.n_reduced]);
         self.reduced_factor.solve_in_place(&mut sol[reduced])?;
-        if self.solve_space == SolveSpace::Grounded && self.n_reduced > n_keep {
-            let ground = sol[roles.keep.start + n_keep];
+        if let Some(ground) = explicit_ground {
+            let ground = sol[roles.keep.start + ground];
             for v in &mut sol[roles.keep.start..roles.keep.start + n_keep] {
                 *v -= ground;
             }

--- a/crates/within/src/block_elim/solver/tests.rs
+++ b/crates/within/src/block_elim/solver/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use crate::block_elim::csr_matrix::CsrMatrix;
 use crate::config::ApproxCholConfig;
 use crate::csr_block::CsrBlock;
 use crate::domain::BlockDiagonals;
@@ -119,6 +120,83 @@ fn trivial_singleton_component_solves_r_over_d() {
             .expect("trivial solve");
         assert_eq!(sol[0], 0.5, "n_q={n_q}, n_r={n_r}: expected r/d");
     }
+}
+
+#[test]
+fn sampled_sparse_preserves_barely_pd_direction() {
+    let surplus = 5e-10;
+    let c = CsrBlock::from_dense_table(&[1.0], 1, 1);
+    let ct = c.transpose();
+    let component = SddmComponent::general_for_test(
+        CrossTab { c, ct },
+        BlockDiagonals {
+            q: vec![1.0 + surplus],
+            r: vec![1.0],
+        },
+    );
+    let config = LocalSolverConfig {
+        approx_chol: ApproxCholConfig::default(),
+        approx_schur: Some(crate::config::ApproxSchurConfig::default()),
+        dense_threshold: 0,
+        scaling: Default::default(),
+    };
+    let solver = BlockElimSolver::build(component, &config).unwrap();
+    let mut rhs = vec![0.0; solver.scratch_size()];
+    rhs[..2].copy_from_slice(&[1.0, -1.0]);
+    let mut solution = vec![0.0; solver.scratch_size()];
+    solver.solve_local(&mut rhs, &mut solution, false).unwrap();
+
+    let ax = [
+        (1.0 + surplus) * solution[0] + solution[1],
+        solution[0] + solution[1],
+    ];
+    assert!((ax[0] - 1.0).abs() < 1e-6);
+    assert!((ax[1] + 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn grounded_backend_auxiliary_is_initialized_on_every_solve() {
+    let large = 1e7;
+    let small = 1e-9;
+    let principal = CsrMatrix::new(
+        vec![0, 2, 4],
+        vec![0, 1, 0, 1],
+        vec![large, -large, -large, large + small],
+        2,
+    );
+    let explicit_ground_laplacian =
+        schur::build_explicit_laplacian(&principal, &[0.0, small], SolveSpace::Grounded);
+    let factor = factor_sparse(&explicit_ground_laplacian, ApproxCholConfig::default())
+        .expect("factorization must succeed");
+    assert_eq!(factor.input_dimension(), 3);
+    assert_eq!(factor.factor_dimension(), 4);
+
+    let c = CsrBlock::from_dense_table(&[0.0; 6], 3, 2);
+    let cross_tab = CrossTab {
+        ct: c.transpose(),
+        c,
+    };
+    let solver = BlockElimSolver::new(
+        cross_tab,
+        vec![1.0; 3],
+        factor,
+        true,
+        CoordinateMap::default(),
+        SolveSpace::Grounded,
+    );
+
+    let solve_with_dirty_auxiliary = |dirty: f64| {
+        let mut rhs = vec![0.0; solver.scratch_size()];
+        rhs[3..5].copy_from_slice(&[1.0, -1.0]);
+        rhs[8] = dirty;
+        let mut solution = vec![0.0; solver.scratch_size()];
+        solver.solve_local(&mut rhs, &mut solution, false).unwrap();
+        solution
+    };
+
+    let first = solve_with_dirty_auxiliary(3.0);
+    let second = solve_with_dirty_auxiliary(-7.0);
+    assert_eq!(first[..solver.n_local], second[..solver.n_local]);
 }
 
 #[test]

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -9,7 +9,7 @@ pub(crate) use cross_tab::{find_all_active_levels, BlockDiagonals, CrossTab};
 pub use effect::Effect;
 
 pub(crate) use factor_pairs::{
-    build_local_domains, CoordinateMap, LocalDomain, SddmComponent, SolveSpace,
+    build_local_domains, CoordinateMap, GroundEdges, LocalDomain, SddmComponent, SolveSpace,
 };
 
 // ===========================================================================

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -15,7 +15,7 @@ use super::{find_all_active_levels, BlockDiagonals, Channel, ChannelPair, CrossT
 
 mod sddm;
 use sddm::{convert, ConversionError};
-pub(crate) use sddm::{CoordinateMap, SddmComponent, SolveSpace};
+pub(crate) use sddm::{CoordinateMap, GroundEdges, SddmComponent, SolveSpace};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ComponentClass {

--- a/crates/within/src/domain/factor_pairs/sddm.rs
+++ b/crates/within/src/domain/factor_pairs/sddm.rs
@@ -1,10 +1,10 @@
 //! Validated conversion from a signed bipartite Gram block to SDDM form.
 //!
 //! One signed diagonal coordinate map `S` makes `S A S` a Z-matrix and scales
-//! it to diagonal dominance. Diagonal surplus is classified once, here, so
-//! downstream reduction never has to infer rank or grounding from rounded
-//! diagonals. Plain components take a fast path: their Laplacian claim is
-//! validated and adopted without sign folding, scaling, or a data rewrite.
+//! it to diagonal dominance. Surplus is retained as explicit ground-edge
+//! weight, so downstream reduction never has to infer rank or grounding from
+//! rounded diagonals. Plain components take a fast path: their Laplacian claim
+//! is validated and adopted without sign folding, scaling, or a data rewrite.
 
 use super::ComponentClass;
 use crate::config::{ScalingConfig, ScalingFailure};
@@ -41,6 +41,12 @@ pub(crate) struct CoordinateMap {
     factors: Option<Box<[f64]>>,
 }
 
+#[derive(Clone)]
+pub(crate) struct GroundEdges {
+    pub(crate) q: Vec<f64>,
+    pub(crate) r: Vec<f64>,
+}
+
 impl CoordinateMap {
     pub(crate) fn apply(&self, values: &mut [f64], n_q: usize) {
         match &self.factors {
@@ -63,6 +69,7 @@ impl CoordinateMap {
 pub(crate) struct SddmComponent {
     pub(crate) cross_tab: CrossTab,
     pub(crate) diagonals: BlockDiagonals,
+    pub(crate) ground_edges: GroundEdges,
     pub(crate) coordinates: CoordinateMap,
     pub(crate) solve_space: SolveSpace,
 }
@@ -118,9 +125,14 @@ fn convert_known_laplacian(
     if total_mismatch > LAPLACIAN_VALIDATION_BUDGET.tolerance(cross_tab.n_local(), total_diagonal) {
         return Err(ConversionError::NotScalable);
     }
+    let ground_edges = GroundEdges {
+        q: vec![0.0; cross_tab.n_q()],
+        r: vec![0.0; cross_tab.n_r()],
+    };
     Ok(SddmComponent {
         cross_tab,
         diagonals: row_sums,
+        ground_edges,
         coordinates: CoordinateMap::default(),
         solve_space: SolveSpace::Floating,
     })
@@ -190,19 +202,25 @@ fn assemble(
             .collect(),
     };
     let row_sums = adjacency_sums(&cross_tab);
+    let mut ground_edges = GroundEdges {
+        q: vec![0.0; n_q],
+        r: vec![0.0; cross_tab.n_r()],
+    };
 
     let mut total_diagonal = 0.0;
     let mut total_surplus = 0.0;
     let mut clamped_deficit = 0.0f64;
-    for (diagonal, row_sum) in scaled_diagonals
+    for ((diagonal, row_sum), row_surplus) in scaled_diagonals
         .q
         .iter_mut()
         .zip(row_sums.q.iter().copied())
+        .zip(ground_edges.q.iter_mut())
         .chain(
             scaled_diagonals
                 .r
                 .iter_mut()
-                .zip(row_sums.r.iter().copied()),
+                .zip(row_sums.r.iter().copied())
+                .zip(ground_edges.r.iter_mut()),
         )
     {
         if !diagonal.is_finite() || *diagonal <= 0.0 {
@@ -216,13 +234,16 @@ fn assemble(
             clamped_deficit = clamped_deficit.max(deficit);
         }
         *diagonal = diagonal.max(row_sum);
+        *row_surplus = (*diagonal - row_sum).max(0.0);
         total_diagonal += *diagonal;
-        total_surplus += *diagonal - row_sum;
+        total_surplus += *row_surplus;
     }
 
     let solve_space =
         if total_surplus <= FLOATING_CLASSIFICATION_BUDGET.tolerance(n, total_diagonal) {
             scaled_diagonals = row_sums;
+            ground_edges.q.fill(0.0);
+            ground_edges.r.fill(0.0);
             SolveSpace::Floating
         } else {
             SolveSpace::Grounded
@@ -240,6 +261,7 @@ fn assemble(
         SddmComponent {
             cross_tab,
             diagonals: scaled_diagonals,
+            ground_edges,
             coordinates,
             solve_space,
         },

--- a/crates/within/src/domain/factor_pairs/sddm/tests.rs
+++ b/crates/within/src/domain/factor_pairs/sddm/tests.rs
@@ -52,14 +52,23 @@ fn cross_tab(table: &[f64], n_q: usize, n_r: usize) -> CrossTab {
 fn assert_sddm(component: &SddmComponent) {
     assert!(component.cross_tab.c.data.iter().all(|value| *value >= 0.0));
     let sums = adjacency_sums(&component.cross_tab);
-    for (&diagonal, &row_sum) in component
+    for ((&diagonal, &row_sum), &surplus) in component
         .diagonals
         .q
         .iter()
         .zip(sums.q.iter())
-        .chain(component.diagonals.r.iter().zip(sums.r.iter()))
+        .zip(component.ground_edges.q.iter())
+        .chain(
+            component
+                .diagonals
+                .r
+                .iter()
+                .zip(sums.r.iter())
+                .zip(component.ground_edges.r.iter()),
+        )
     {
         assert!(diagonal >= row_sum);
+        assert!((diagonal - row_sum - surplus).abs() <= 1e-12 * diagonal);
     }
 }
 
@@ -246,6 +255,7 @@ fn barely_pd_surplus_is_structural() {
     )
     .unwrap();
     assert_eq!(component.solve_space, SolveSpace::Grounded);
+    assert!((component.ground_edges.q[0] - surplus).abs() < 1e-15);
     assert_sddm(&component);
 }
 

--- a/crates/within/tests/slopes_routing.rs
+++ b/crates/within/tests/slopes_routing.rs
@@ -143,3 +143,69 @@ fn near_collinear_cross_term_direction_survives_routing() {
         rnorm / ynorm
     );
 }
+
+#[test]
+fn surplus_component_sampled_matches_exact_reduction() {
+    // DGP in lockstep with `positive_slope_only_pair_grounds_beyond_dense_threshold`
+    // (src/solver/tests.rs), which pins that this design grounds a surplus-carrying
+    // component whose kept side exceeds the dense threshold: the default arm below
+    // exercises the sparse SAMPLED reduction on it; `approx_schur: None` is the
+    // exact-reduction reference (#83).
+    let n = 8000usize;
+    let f: Vec<u32> = (0..n).map(|i| (i % 80) as u32).collect();
+    let g: Vec<u32> = (0..n).map(|i| ((i / 80) % 40) as u32).collect();
+    let z: Vec<f64> = (0..n)
+        .map(|i| 0.5 + ((i * 13) % 100) as f64 / 100.0)
+        .collect();
+    let y: Vec<f64> = (0..n)
+        .map(|i| {
+            let fl = f[i] as f64;
+            (0.5 + (fl * 0.037).cos()) * z[i]
+                + 0.8 * (g[i] as f64 * 0.11).sin()
+                + (i as f64 * 0.61).sin() * 0.3
+        })
+        .collect();
+
+    let solve = |approx_schur| {
+        let effects = vec![
+            Effect::new(&f, false, [&z[..]]).expect("slope effect"),
+            Effect::new(&g, true, []).expect("plain effect"),
+        ];
+        let config = PreconditionerConfig::Additive {
+            local_solver: within::config::LocalSolverConfig {
+                approx_schur,
+                ..Default::default()
+            },
+            reduction: Default::default(),
+        };
+        Solver::new(effects, None, config)
+            .expect("build")
+            .solve(&y, &LsmrOptions::default())
+            .expect("solve")
+    };
+
+    let sampled = solve(Some(within::config::ApproxSchurConfig::default()));
+    let exact = solve(None);
+    assert!(sampled.converged, "sampled arm did not converge");
+    assert!(exact.converged, "exact arm did not converge");
+    assert!(sampled.unidentified.is_empty());
+    assert!(
+        sampled.iterations <= 30,
+        "iterations = {}",
+        sampled.iterations
+    );
+    // The demeaned response is the kernel-invariant deliverable; both arms
+    // must land on the same one.
+    for (i, ((&s, &e), &yi)) in sampled
+        .demeaned
+        .iter()
+        .zip(&exact.demeaned)
+        .zip(&y)
+        .enumerate()
+    {
+        assert!(
+            (s - e).abs() <= 1e-6 * (1.0 + yi.abs()),
+            "demeaned[{i}]: sampled {s} vs exact {e}"
+        );
+    }
+}


### PR DESCRIPTION
Diagonal surplus becomes explicit ground-edge weight on the reduced graph: the sampled clique-tree and dense Cholesky paths now cover grounded components too (previously exact-sparse only). The ground vertex is an ordinary member of each eliminated star; the gauge is subtracted after the solve. Sampled-vs-exact parity is pinned on a grounded fixture.

Stacked on #86 (eager SDDM conversion); the state-model docs follow in a third PR.