### PR TITLE
feat(within): Gremban double cover for frustrated signed components

### DIFF
--- a/benchmarks/slopes_fixest.py
+++ b/benchmarks/slopes_fixest.py
@@ -1,12 +1,11 @@
 """Varying-slopes reference benchmark: R fixest vs within (#65).
 
 On-demand perf comparison for the varying-slopes epic (#64): times slope
-estimation on shared synthetic DGPs and prints R fixest's fit time + iteration
-counts. within's slope solver (#58/#59) doesn't exist yet — ``run_within`` is
-the stub seam to fill once it lands. The point is reference numbers before
-within can produce its own.
+estimation on shared synthetic DGPs and prints fit time + iteration counts
+per tool. The R arm needs a provisioned R; the within arm always runs.
 
     pixi run -e fixest bench-slopes     # provisions R + fixest, runs the catalog
+    pixi run bench-slopes               # within arm only
 
 Edit ``SIZES`` to sweep scale.
 """
@@ -17,6 +16,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -254,35 +254,60 @@ def run_fixest(case: Case) -> dict:
 
 
 def run_within(case: Case) -> dict:
-    # === #65 within hook ===
-    # within's varying-slopes solver does not exist in the live tree yet
-    # (#58/#59). Once it lands, build the design from case.fe_terms (factor
-    # codes + their slope columns out of case.columns) plus case.regressors,
-    # time the solve median-of-REPEAT, and return a run_fixest-shaped dict.
-    raise NotImplementedError(
-        "within varying-slopes solver not implemented yet (#58/#59); "
-        "this hook returns a result once the slope API lands."
-    )
+    """Time within on ``case``: one solver build per fit, then a demeaning
+    solve for the response and each regressor (matching feols's per-variable
+    iteration report)."""
+    import within
+
+    effects = [
+        within.Effect(
+            case.columns[factor].astype(np.uint32),
+            True,
+            [case.columns[s].astype(np.float64) for s in slopes],
+        )
+        for factor, slopes in case.fe_terms
+    ]
+    targets = [case.response, *case.regressors]
+
+    times: list[float] = []
+    iters: list[str] = []
+    for _ in range(REPEAT):
+        start = time.perf_counter()
+        solver = within.Solver(effects)
+        results = [solver.solve(case.columns[t].astype(np.float64)) for t in targets]
+        times.append(time.perf_counter() - start)
+        iters = [f"{r.iterations}{'' if r.converged else '!'}" for r in results]
+    return {
+        "tool": "within",
+        "case": case.name,
+        "n_obs": case.n_obs,
+        "time_s": float(np.median(times)),
+        "iters": "/".join(iters),
+    }
 
 
 def main() -> int:
-    if not _r_available():
+    r_available = _r_available()
+    if not r_available:
         print(
             "R fixest: skipped (Rscript/fixest not found) — "
             "run `pixi run -e fixest bench-slopes` to provision R."
         )
-        return 0
 
     rows: list[dict] = []
     for size in SIZES:
         for builder in CASES:
             case = builder(size)
             print(f"  {case.name}  n_obs={case.n_obs:,}  feols: {case.formula()}")
+            if r_available:
+                try:
+                    rows.append(run_fixest(case))
+                except Exception as exc:  # noqa: BLE001 - report and continue the sweep
+                    print(f"    R fixest failed: {exc}")
             try:
-                rows.append(run_fixest(case))
+                rows.append(run_within(case))
             except Exception as exc:  # noqa: BLE001 - report and continue the sweep
-                print(f"    R fixest failed: {exc}")
-    # within arm plugs in here once #58/#59 land — see run_within.
+                print(f"    within failed: {exc}")
 
     print(f"\n{'tool':<10}{'case':<22}{'n_obs':>10}{'time_s':>9}   iters")
     for r in rows:

--- a/benchmarks/slopes_fixest.py
+++ b/benchmarks/slopes_fixest.py
@@ -270,19 +270,19 @@ def run_within(case: Case) -> dict:
     targets = [case.response, *case.regressors]
 
     times: list[float] = []
-    iters: list[str] = []
     for _ in range(REPEAT):
         start = time.perf_counter()
         solver = within.Solver(effects)
         results = [solver.solve(case.columns[t].astype(np.float64)) for t in targets]
         times.append(time.perf_counter() - start)
-        iters = [f"{r.iterations}{'' if r.converged else '!'}" for r in results]
     return {
         "tool": "within",
         "case": case.name,
         "n_obs": case.n_obs,
         "time_s": float(np.median(times)),
-        "iters": "/".join(iters),
+        "iters": "/".join(
+            f"{r.iterations}{'' if r.converged else '!'}" for r in results
+        ),
     }
 
 

--- a/crates/within/src/block_elim/solver.rs
+++ b/crates/within/src/block_elim/solver.rs
@@ -100,8 +100,8 @@ pub struct BlockElimSolver {
     pub(crate) reduced_factor: ReducedFactor,
     /// True if the q-block was eliminated (n_q >= n_r).
     eliminate_q: bool,
-    /// Total DOF count (`n_q + n_r`).
-    n_local: usize,
+    /// Internal DOF count (`n_q + n_r`); twice the external count for covers.
+    n_internal: usize,
     /// Internal factor dimension, including backend-added auxiliary vertices.
     n_reduced: usize,
     /// Original-to-SDDM coordinate map; in-memory only until the wire-format bump.
@@ -170,14 +170,14 @@ impl BlockElimSolver {
         solve_space: SolveSpace,
     ) -> Self {
         let cross_tab = cross_tab.into();
-        let n_local = cross_tab.n_local();
+        let n_internal = cross_tab.n_local();
         let n_reduced = reduced_factor.factor_dimension();
         Self {
             cross_tab,
             inv_diag_elim,
             reduced_factor,
             eliminate_q,
-            n_local,
+            n_internal,
             n_reduced,
             coordinates,
             solve_space,
@@ -271,7 +271,7 @@ impl BlockElimSolver {
         sol: &mut [f64],
         allow_inner_parallelism: bool,
     ) -> Result<(), LocalSolveError> {
-        let n = self.n_local;
+        let n = self.n_internal;
         let n_keep = roles.keep.len();
         let explicit_ground = self.explicit_ground_index(n_keep);
 
@@ -330,11 +330,11 @@ impl BlockElimSolver {
 
 impl LocalSolver for BlockElimSolver {
     fn n_local(&self) -> usize {
-        self.n_local
+        self.coordinates.n_external(self.n_internal)
     }
 
     fn scratch_size(&self) -> usize {
-        self.n_local + self.n_reduced
+        self.n_internal + self.n_reduced
     }
 
     fn inner_parallelism_work_estimate(&self) -> usize {
@@ -344,7 +344,7 @@ impl LocalSolver for BlockElimSolver {
         }
 
         let cross_nnz = self.cross_tab.c.nnz();
-        (2 * cross_nnz) + self.n_local
+        (2 * cross_nnz) + self.n_internal
     }
 
     fn solve_local(
@@ -353,11 +353,11 @@ impl LocalSolver for BlockElimSolver {
         sol: &mut [f64],
         allow_inner_parallelism: bool,
     ) -> Result<(), LocalSolveError> {
-        let n = self.n_local;
+        let n = self.n_internal;
         let n_q = self.cross_tab.n_q();
         let ct = &self.cross_tab;
 
-        self.coordinates.apply(&mut rhs[..n], n_q);
+        self.coordinates.fold(&mut rhs[..n], n_q);
         if self.solve_space == SolveSpace::Floating {
             subtract_mean(rhs, n);
         }
@@ -383,7 +383,7 @@ impl LocalSolver for BlockElimSolver {
         if self.solve_space == SolveSpace::Floating {
             subtract_mean(sol, n);
         }
-        self.coordinates.apply(&mut sol[..n], n_q);
+        self.coordinates.unfold(&mut sol[..n], n_q);
         Ok(())
     }
 }

--- a/crates/within/src/block_elim/solver/tests.rs
+++ b/crates/within/src/block_elim/solver/tests.rs
@@ -196,7 +196,7 @@ fn grounded_backend_auxiliary_is_initialized_on_every_solve() {
 
     let first = solve_with_dirty_auxiliary(3.0);
     let second = solve_with_dirty_auxiliary(-7.0);
-    assert_eq!(first[..solver.n_local], second[..solver.n_local]);
+    assert_eq!(first[..solver.n_local()], second[..solver.n_local()]);
 }
 
 #[test]
@@ -287,5 +287,62 @@ fn signed_component_realizes_congruence_transformed_solve() {
                 r[i]
             );
         }
+    }
+}
+
+#[test]
+fn frustrated_component_solves_exactly_through_cover() {
+    // Frustrated 2×2 component (negative 4-cycle), weakly dominant with
+    // strict surplus on the kept side (Grounded cover). Dense reduction only:
+    // it is the one arm whose factor is exact, so the oracle A·x = r is sharp
+    // (A is irreducibly dominant, hence nonsingular, and the cover acts as
+    // the exact inverse on the antisymmetric subspace). The sparse arms'
+    // approx-chol factor is inexact on the cover's degree-3 reduced graph;
+    // they are exercised end-to-end in slopes_routing.rs, where factor error
+    // only costs LSMR iterations.
+    let (n_q, n_r) = (2usize, 2usize);
+    let c_raw = [1.0, 1.5, 2.0, -1.0];
+    let a = [
+        [2.5, 0.0, 1.0, 1.5],
+        [0.0, 3.0, 2.0, -1.0],
+        [1.0, 2.0, 3.4, 0.0],
+        [1.5, -1.0, 0.0, 2.9],
+    ];
+
+    let c = CsrBlock::from_dense_table(&c_raw, n_q, n_r);
+    let ct = c.transpose();
+    let component = SddmComponent::general_for_test(
+        CrossTab { c, ct },
+        BlockDiagonals {
+            q: vec![a[0][0], a[1][1]],
+            r: vec![a[2][2], a[3][3]],
+        },
+    );
+    let config = LocalSolverConfig {
+        approx_chol: ApproxCholConfig::default(),
+        approx_schur: None,
+        dense_threshold: 8,
+        scaling: Default::default(),
+    };
+    let solver =
+        BlockElimSolver::build(component, &config).expect("covered block-elim build failed");
+    let n = n_q + n_r;
+    assert_eq!(solver.n_local(), n, "cover reports external size");
+
+    let r = [1.0, -2.0, 0.5, 3.0];
+    let mut rhs = vec![0.0; solver.scratch_size()];
+    rhs[..n].copy_from_slice(&r);
+    let mut sol = vec![0.0; solver.scratch_size()];
+    solver
+        .solve_local(&mut rhs, &mut sol, false)
+        .expect("solve_local failed");
+
+    for i in 0..n {
+        let ax: f64 = (0..n).map(|j| a[i][j] * sol[j]).sum();
+        assert!(
+            (ax - r[i]).abs() < 1e-9,
+            "row {i}: A·x = {ax}, expected {}",
+            r[i]
+        );
     }
 }

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -14,7 +14,7 @@ use crate::{BuildError, BuildWarning, SignedPair};
 use super::{find_all_active_levels, BlockDiagonals, Channel, ChannelPair, CrossTab, Design};
 
 mod sddm;
-use sddm::{convert, ConversionError};
+use sddm::{convert, NotScalable};
 pub(crate) use sddm::{CoordinateMap, GroundEdges, SddmComponent, SolveSpace};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -141,15 +141,8 @@ fn split_into_subdomains(
             term_r: pair.r.term,
             column_r: pair.r.column,
         };
-        let (component, uncertified) =
-            convert(comp_ct, comp_diag, class, scaling).map_err(|error| match error {
-                ConversionError::Frustrated => {
-                    BuildError::FrustratedComponent { pair: signed_pair }
-                }
-                ConversionError::NotScalable => {
-                    BuildError::UnscalableComponent { pair: signed_pair }
-                }
-            })?;
+        let (component, uncertified) = convert(comp_ct, comp_diag, class, scaling)
+            .map_err(|NotScalable| BuildError::UnscalableComponent { pair: signed_pair })?;
         if let Some(uncertified) = uncertified {
             warnings.push(BuildWarning::UnscalableComponent {
                 pair: signed_pair,

--- a/crates/within/src/domain/factor_pairs/sddm.rs
+++ b/crates/within/src/domain/factor_pairs/sddm.rs
@@ -340,7 +340,7 @@ fn assemble_cover(
             .zip(scales.iter())
             .map(|(&diagonal, &scale)| diagonal * scale * scale)
             .collect();
-        [scaled.as_slice(), scaled.as_slice()].concat()
+        scaled.repeat(2)
     };
     let scaled_diagonals = BlockDiagonals {
         q: doubled(&diagonals.q, &scales[..n_q]),

--- a/crates/within/src/domain/factor_pairs/sddm.rs
+++ b/crates/within/src/domain/factor_pairs/sddm.rs
@@ -5,9 +5,13 @@
 //! weight, so downstream reduction never has to infer rank or grounding from
 //! rounded diagonals. Plain components take a fast path: their Laplacian claim
 //! is validated and adopted without sign folding, scaling, or a data rewrite.
+//! Frustrated components — where no signature exists — convert through their
+//! Gremban double cover, which is SDDM under the same dominance scaling and
+//! acts on the antisymmetric subspace as the scaled original.
 
 use super::ComponentClass;
 use crate::config::{ScalingConfig, ScalingFailure};
+use crate::csr_block::CsrBlock;
 use crate::domain::{BlockDiagonals, CrossTab};
 
 #[derive(Clone, Copy)]
@@ -33,12 +37,20 @@ pub(crate) enum SolveSpace {
     Grounded,
 }
 
-/// Diagonal map between original and SDDM coordinates, applied to vectors at
-/// the solve boundary. `None` is the canonical bipartite map (negate the `r`
-/// block) — not the identity.
+/// Map between original and SDDM coordinates, applied to vectors at the
+/// solve boundary. `Canonical` is the bipartite map (negate the `r` block) —
+/// not the identity.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct CoordinateMap {
-    factors: Option<Box<[f64]>>,
+pub(crate) enum CoordinateMap {
+    #[default]
+    Canonical,
+    /// Diagonal congruence factors (sign · scale) of a balanced component.
+    Scaled(Box<[f64]>),
+    /// Gremban double cover of a frustrated component: `factors` (canonical
+    /// sign · scale, external length) map the original coordinates, and
+    /// vectors pass through the doubled system via the antisymmetric
+    /// embedding `[z, -z]` and read-back `(x⁺ - x⁻) / 2`.
+    Cover(Box<[f64]>),
 }
 
 #[derive(Clone)]
@@ -48,17 +60,69 @@ pub(crate) struct GroundEdges {
 }
 
 impl CoordinateMap {
-    pub(crate) fn apply(&self, values: &mut [f64], n_q: usize) {
-        match &self.factors {
-            Some(factors) => {
+    /// DOF count exposed to gather/scatter; a cover solves an internally
+    /// doubled system.
+    pub(crate) fn n_external(&self, n_internal: usize) -> usize {
+        match self {
+            CoordinateMap::Cover(_) => n_internal / 2,
+            _ => n_internal,
+        }
+    }
+
+    /// Map an original-coordinate RHS into SDDM coordinates. `values` spans
+    /// the internal system and `n_q` is its internal q-size; for covers only
+    /// the first `n_external` entries hold data on entry.
+    pub(crate) fn fold(&self, values: &mut [f64], n_q: usize) {
+        match self {
+            CoordinateMap::Canonical => {
+                for value in &mut values[n_q..] {
+                    *value = -*value;
+                }
+            }
+            CoordinateMap::Scaled(factors) => {
                 debug_assert_eq!(values.len(), factors.len());
                 for (value, &factor) in values.iter_mut().zip(factors.iter()) {
                     *value *= factor;
                 }
             }
-            None => {
-                for value in &mut values[n_q..] {
+            CoordinateMap::Cover(factors) => {
+                let (n_ext, n_q) = (values.len() / 2, n_q / 2);
+                let n_r = n_ext - n_q;
+                debug_assert_eq!(n_ext, factors.len());
+                for (value, &factor) in values[..n_ext].iter_mut().zip(factors.iter()) {
+                    *value *= factor;
+                }
+                // Expand [z_q | z_r] into [z_q | -z_q | z_r | -z_r]; block
+                // moves ordered so no source is clobbered before its copy.
+                values.copy_within(n_q..n_ext, 2 * n_q + n_r);
+                values.copy_within(n_q..n_ext, 2 * n_q);
+                values.copy_within(..n_q, n_q);
+                for value in &mut values[n_q..2 * n_q] {
                     *value = -*value;
+                }
+                for value in &mut values[2 * n_q + n_r..] {
+                    *value = -*value;
+                }
+            }
+        }
+    }
+
+    /// Map an SDDM-coordinate solution back to original coordinates; the
+    /// diagonal maps are involutions up to scale, so they re-apply `fold`.
+    pub(crate) fn unfold(&self, values: &mut [f64], n_q: usize) {
+        match self {
+            CoordinateMap::Canonical | CoordinateMap::Scaled(_) => self.fold(values, n_q),
+            CoordinateMap::Cover(factors) => {
+                let (n_ext, n_q) = (values.len() / 2, n_q / 2);
+                let n_r = n_ext - n_q;
+                for i in 0..n_q {
+                    values[i] = 0.5 * (values[i] - values[n_q + i]);
+                }
+                for i in 0..n_r {
+                    values[n_q + i] = 0.5 * (values[2 * n_q + i] - values[2 * n_q + n_r + i]);
+                }
+                for (value, &factor) in values[..n_ext].iter_mut().zip(factors.iter()) {
+                    *value *= factor;
                 }
             }
         }
@@ -74,11 +138,10 @@ pub(crate) struct SddmComponent {
     pub(crate) solve_space: SolveSpace,
 }
 
+/// The component admits no diagonal scaling to weak dominance (Boman); its
+/// comparison matrix is not PSD, so no SDDM form — direct or covered — exists.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum ConversionError {
-    Frustrated,
-    NotScalable,
-}
+pub(super) struct NotScalable;
 
 /// Evidence that a component's dominance scaling exceeded tolerance or budget
 /// under [`ScalingFailure::Warn`]; the caller attaches pair context and
@@ -94,7 +157,7 @@ pub(super) fn convert(
     diagonals: BlockDiagonals,
     class: ComponentClass,
     scaling: &ScalingConfig,
-) -> Result<(SddmComponent, Option<UncertifiedScaling>), ConversionError> {
+) -> Result<(SddmComponent, Option<UncertifiedScaling>), NotScalable> {
     match class {
         ComponentClass::KnownLaplacian => {
             convert_known_laplacian(cross_tab, diagonals).map(|component| (component, None))
@@ -109,7 +172,7 @@ pub(super) fn convert(
 fn convert_known_laplacian(
     cross_tab: CrossTab,
     diagonals: BlockDiagonals,
-) -> Result<SddmComponent, ConversionError> {
+) -> Result<SddmComponent, NotScalable> {
     let row_sums = adjacency_sums(&cross_tab);
     let mut total_diagonal = 0.0;
     let mut total_mismatch = 0.0;
@@ -123,7 +186,7 @@ fn convert_known_laplacian(
         total_mismatch += (diagonal - row_sum).abs();
     }
     if total_mismatch > LAPLACIAN_VALIDATION_BUDGET.tolerance(cross_tab.n_local(), total_diagonal) {
-        return Err(ConversionError::NotScalable);
+        return Err(NotScalable);
     }
     let ground_edges = GroundEdges {
         q: vec![0.0; cross_tab.n_q()],
@@ -142,18 +205,23 @@ fn convert_general(
     cross_tab: CrossTab,
     diagonals: BlockDiagonals,
     scaling: &ScalingConfig,
-) -> Result<(SddmComponent, Option<UncertifiedScaling>), ConversionError> {
-    let signs = folding_signs(&cross_tab)?;
+) -> Result<(SddmComponent, Option<UncertifiedScaling>), NotScalable> {
+    let signs = folding_signs(&cross_tab);
     let relaxation = dominance_scaling(&cross_tab, &diagonals, scaling)?;
     if !relaxation.certified && scaling.on_failure == ScalingFailure::Error {
-        return Err(ConversionError::NotScalable);
+        return Err(NotScalable);
     }
-    let factors: Vec<f64> = signs
-        .iter()
-        .zip(relaxation.scales.iter())
-        .map(|(&sign, &scale)| sign * scale)
-        .collect();
-    let (component, clamped_deficit) = assemble(cross_tab, diagonals, factors, scaling)?;
+    let (component, clamped_deficit) = match signs {
+        Some(signs) => {
+            let factors: Vec<f64> = signs
+                .iter()
+                .zip(relaxation.scales.iter())
+                .map(|(&sign, &scale)| sign * scale)
+                .collect();
+            assemble(cross_tab, diagonals, factors, scaling)?
+        }
+        None => assemble_cover(cross_tab, diagonals, relaxation.scales, scaling)?,
+    };
     let violation = relaxation.violation.max(clamped_deficit);
     let uncertified = (violation > scaling.tolerance).then_some(UncertifiedScaling {
         sweeps: relaxation.sweeps,
@@ -170,9 +238,8 @@ fn assemble(
     diagonals: BlockDiagonals,
     factors: Vec<f64>,
     scaling: &ScalingConfig,
-) -> Result<(SddmComponent, f64), ConversionError> {
+) -> Result<(SddmComponent, f64), NotScalable> {
     let n_q = cross_tab.n_q();
-    let n = cross_tab.n_local();
     for i in 0..n_q {
         let start = cross_tab.c.indptr[i] as usize;
         let end = cross_tab.c.indptr[i + 1] as usize;
@@ -180,14 +247,14 @@ fn assemble(
         for (&j, value) in columns.iter().zip(&mut cross_tab.c.data[start..end]) {
             let folded = -factors[i] * factors[n_q + j as usize] * *value;
             if !folded.is_finite() || folded < 0.0 {
-                return Err(ConversionError::NotScalable);
+                return Err(NotScalable);
             }
             *value = folded;
         }
     }
     cross_tab.ct = cross_tab.c.transpose();
 
-    let mut scaled_diagonals = BlockDiagonals {
+    let scaled_diagonals = BlockDiagonals {
         q: diagonals
             .q
             .iter()
@@ -201,9 +268,111 @@ fn assemble(
             .map(|(&diagonal, &factor)| diagonal * factor * factor)
             .collect(),
     };
+
+    let canonical = factors
+        .iter()
+        .enumerate()
+        .all(|(i, &factor)| factor == if i < n_q { 1.0 } else { -1.0 });
+    let coordinates = if canonical {
+        CoordinateMap::Canonical
+    } else {
+        CoordinateMap::Scaled(factors.into_boxed_slice())
+    };
+    finalize(cross_tab, scaled_diagonals, coordinates, scaling)
+}
+
+/// Assemble the Gremban double cover of a frustrated component: scaled cell
+/// magnitudes, raw-nonnegative cells within each copy, raw-negative cells
+/// across copies. The cover is SDDM exactly when `scales` certifies dominance
+/// of the magnitudes, and acts on the antisymmetric subspace as the scaled
+/// original.
+fn assemble_cover(
+    cross_tab: CrossTab,
+    diagonals: BlockDiagonals,
+    scales: Vec<f64>,
+    scaling: &ScalingConfig,
+) -> Result<(SddmComponent, f64), NotScalable> {
+    let n_q = cross_tab.n_q();
+    let n_r = cross_tab.n_r();
+
+    let mut indptr = Vec::with_capacity(2 * n_q + 1);
+    let mut indices = Vec::with_capacity(2 * cross_tab.c.nnz());
+    let mut data = Vec::with_capacity(2 * cross_tab.c.nnz());
+    indptr.push(0u32);
+    for copy_shifted in [false, true] {
+        for i in 0..n_q {
+            let start = cross_tab.c.indptr[i] as usize;
+            let end = cross_tab.c.indptr[i + 1] as usize;
+            // Emit the unshifted column block before the shifted one so each
+            // row's columns stay sorted.
+            for column_shifted in [false, true] {
+                let column_base = if column_shifted { n_r as u32 } else { 0 };
+                let select_negative = column_shifted != copy_shifted;
+                for idx in start..end {
+                    let value = cross_tab.c.data[idx];
+                    if (value < 0.0) != select_negative {
+                        continue;
+                    }
+                    let scaled =
+                        scales[i] * value * scales[n_q + cross_tab.c.indices[idx] as usize];
+                    if !scaled.is_finite() {
+                        return Err(NotScalable);
+                    }
+                    indices.push(cross_tab.c.indices[idx] + column_base);
+                    data.push(scaled.abs());
+                }
+            }
+            indptr.push(indices.len() as u32);
+        }
+    }
+    let c = CsrBlock {
+        indptr,
+        indices,
+        data,
+        nrows: 2 * n_q,
+        ncols: 2 * n_r,
+    };
+    let ct = c.transpose();
+
+    let doubled = |diagonal: &[f64], scales: &[f64]| -> Vec<f64> {
+        let scaled: Vec<f64> = diagonal
+            .iter()
+            .zip(scales.iter())
+            .map(|(&diagonal, &scale)| diagonal * scale * scale)
+            .collect();
+        [scaled.as_slice(), scaled.as_slice()].concat()
+    };
+    let scaled_diagonals = BlockDiagonals {
+        q: doubled(&diagonals.q, &scales[..n_q]),
+        r: doubled(&diagonals.r, &scales[n_q..]),
+    };
+
+    let mut factors = scales;
+    for factor in &mut factors[n_q..] {
+        *factor = -*factor;
+    }
+    finalize(
+        CrossTab { c, ct },
+        scaled_diagonals,
+        CoordinateMap::Cover(factors.into_boxed_slice()),
+        scaling,
+    )
+}
+
+/// Validate weak dominance of an assembled SDDM form: clamp roundoff
+/// deficits, retain surplus as ground edges, and classify the solve space.
+/// Returns the largest relative deficit that was clamped; deficits beyond
+/// tolerance are errors under [`ScalingFailure::Error`].
+fn finalize(
+    cross_tab: CrossTab,
+    mut scaled_diagonals: BlockDiagonals,
+    coordinates: CoordinateMap,
+    scaling: &ScalingConfig,
+) -> Result<(SddmComponent, f64), NotScalable> {
+    let n = cross_tab.n_local();
     let row_sums = adjacency_sums(&cross_tab);
     let mut ground_edges = GroundEdges {
-        q: vec![0.0; n_q],
+        q: vec![0.0; cross_tab.n_q()],
         r: vec![0.0; cross_tab.n_r()],
     };
 
@@ -224,12 +393,12 @@ fn assemble(
         )
     {
         if !diagonal.is_finite() || *diagonal <= 0.0 {
-            return Err(ConversionError::NotScalable);
+            return Err(NotScalable);
         }
         let deficit = (row_sum - *diagonal) / diagonal.max(row_sum);
         if deficit > scaling.tolerance {
             if scaling.on_failure == ScalingFailure::Error {
-                return Err(ConversionError::NotScalable);
+                return Err(NotScalable);
             }
             clamped_deficit = clamped_deficit.max(deficit);
         }
@@ -249,14 +418,6 @@ fn assemble(
             SolveSpace::Grounded
         };
 
-    let canonical = factors
-        .iter()
-        .enumerate()
-        .all(|(i, &factor)| factor == if i < n_q { 1.0 } else { -1.0 });
-    let coordinates = CoordinateMap {
-        factors: (!canonical).then(|| factors.into_boxed_slice()),
-    };
-
     Ok((
         SddmComponent {
             cross_tab,
@@ -269,11 +430,13 @@ fn assemble(
     ))
 }
 
-fn folding_signs(cross_tab: &CrossTab) -> Result<Vec<f64>, ConversionError> {
+/// A per-node signature folding every off-diagonal nonpositive, or `None`
+/// when the component is frustrated (a negative cycle admits no signature).
+fn folding_signs(cross_tab: &CrossTab) -> Option<Vec<f64>> {
     let n = cross_tab.n_local();
     let mut signs = vec![0.0; n];
     if n == 0 {
-        return Ok(signs);
+        return Some(signs);
     }
     for root in 0..n {
         if signs[root] != 0.0 {
@@ -288,12 +451,12 @@ fn folding_signs(cross_tab: &CrossTab) -> Result<Vec<f64>, ConversionError> {
                     signs[j] = expected;
                     stack.push(j);
                 } else if signs[j] != expected {
-                    return Err(ConversionError::Frustrated);
+                    return None;
                 }
             }
         }
     }
-    Ok(signs)
+    Some(signs)
 }
 
 struct DominanceScaling {
@@ -308,7 +471,7 @@ fn dominance_scaling(
     cross_tab: &CrossTab,
     diagonals: &BlockDiagonals,
     scaling: &ScalingConfig,
-) -> Result<DominanceScaling, ConversionError> {
+) -> Result<DominanceScaling, NotScalable> {
     let n_q = cross_tab.n_q();
     let n = cross_tab.n_local();
     let diagonal = |i: usize| {
@@ -319,7 +482,7 @@ fn dominance_scaling(
         }
     };
     if (0..n).any(|i| !diagonal(i).is_finite() || diagonal(i) <= 0.0) {
-        return Err(ConversionError::NotScalable);
+        return Err(NotScalable);
     }
 
     let already_dominant = (0..n).all(|i| {
@@ -366,7 +529,7 @@ fn dominance_scaling(
         // exhaustion hands over a usable best-effort scaling.
         let peak = mu.iter().copied().fold(0.0f64, f64::max);
         if !peak.is_finite() {
-            return Err(ConversionError::NotScalable);
+            return Err(NotScalable);
         }
         for value in &mut mu {
             *value /= peak;
@@ -381,7 +544,7 @@ fn dominance_scaling(
         .map(|(&value, &normalizer)| value * normalizer)
         .collect();
     if !scales.iter().all(|value| value.is_finite() && *value > 0.0) {
-        return Err(ConversionError::NotScalable);
+        return Err(NotScalable);
     }
     Ok(DominanceScaling {
         scales,
@@ -392,7 +555,7 @@ fn dominance_scaling(
 }
 
 fn adjacency_sums(cross_tab: &CrossTab) -> BlockDiagonals {
-    let sum_rows = |block: &crate::csr_block::CsrBlock| {
+    let sum_rows = |block: &CsrBlock| {
         (0..block.nrows)
             .map(|i| block.row(i).map(|(_, v)| v).sum())
             .collect()

--- a/crates/within/src/domain/factor_pairs/sddm/tests.rs
+++ b/crates/within/src/domain/factor_pairs/sddm/tests.rs
@@ -85,7 +85,7 @@ fn known_laplacian_has_canonical_coordinates_and_no_ground() {
     )
     .unwrap();
     assert_eq!(component.solve_space, SolveSpace::Floating);
-    assert!(component.coordinates.factors.is_none());
+    assert!(matches!(component.coordinates, CoordinateMap::Canonical));
     assert!(uncertified.is_none());
     assert_sddm(&component);
 }
@@ -103,12 +103,12 @@ fn known_laplacian_claim_is_checked() {
         ComponentClass::KnownLaplacian,
         &ScalingConfig::default(),
     );
-    assert!(matches!(result, Err(ConversionError::NotScalable)));
+    assert!(matches!(result, Err(NotScalable)));
 }
 
 #[test]
-fn negative_cycle_is_rejected() {
-    let result = convert(
+fn frustrated_component_converts_to_gremban_cover() {
+    let (component, uncertified) = convert(
         cross_tab(&[1.0, 1.0, 1.0, -1.0], 2, 2),
         BlockDiagonals {
             q: vec![2.0, 2.0],
@@ -116,8 +116,34 @@ fn negative_cycle_is_rejected() {
         },
         ComponentClass::General,
         &ScalingConfig::default(),
-    );
-    assert!(matches!(result, Err(ConversionError::Frustrated)));
+    )
+    .unwrap();
+    assert!(uncertified.is_none());
+    assert_sddm(&component);
+    // Doubled bipartite cover: raw-positive cells within each copy,
+    // raw-negative cells across copies, magnitudes preserved.
+    assert_eq!(component.cross_tab.c.nrows, 4);
+    assert_eq!(component.cross_tab.c.ncols, 4);
+    let mut dense = [[0.0; 4]; 4];
+    for (i, row) in dense.iter_mut().enumerate() {
+        for (j, value) in component.cross_tab.c.row(i) {
+            row[j] = value;
+        }
+    }
+    let expected = [
+        [1.0, 1.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0, 1.0],
+        [0.0, 1.0, 1.0, 0.0],
+    ];
+    assert_eq!(dense, expected);
+    // Weak dominance with zero surplus: the cover floats, and vectors pass
+    // through canonical-sign unit factors.
+    assert_eq!(component.solve_space, SolveSpace::Floating);
+    match &component.coordinates {
+        CoordinateMap::Cover(factors) => assert_eq!(factors.as_ref(), [1.0, 1.0, -1.0, -1.0]),
+        other => panic!("expected cover coordinates, got {other:?}"),
+    }
 }
 
 #[test]
@@ -214,7 +240,7 @@ fn non_scalable_component_errors_under_error_mode() {
             ..Default::default()
         },
     );
-    assert!(matches!(result, Err(ConversionError::NotScalable)));
+    assert!(matches!(result, Err(NotScalable)));
 }
 
 #[test]

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -52,16 +52,6 @@ pub enum BuildError {
         /// The offending value.
         value: f64,
     },
-    /// A signed cross-factor component contains a negative-sign cycle, so no
-    /// balancing signature exists.
-    #[error(
-        "frustrated signed component between {pair}: a negative-sign cycle cannot \
-         be balanced (support tracked in #62)"
-    )]
-    FrustratedComponent {
-        /// The offending channel pair.
-        pair: SignedPair,
-    },
     /// A signed component could not be certified as diagonally scalable to an
     /// SDDM operator.
     #[error("signed component between {pair} is not diagonally scalable to SDDM form")]

--- a/crates/within/tests/slopes_routing.rs
+++ b/crates/within/tests/slopes_routing.rs
@@ -1,8 +1,8 @@
 //! Cross-factor signed routing (#61): slope terms solving alongside other
-//! factors through balanced/scaled signed subdomains, plus the frustration
-//! error path (lifted by #62).
+//! factors through balanced/scaled signed subdomains, with frustrated
+//! components solving through their Gremban double cover (#62).
 
-use within::{BuildError, Effect, LsmrOptions, PreconditionerConfig, SignedPair, Solver};
+use within::{Effect, LsmrOptions, PreconditionerConfig, Solver};
 
 fn lcg(seed: &mut u64) -> u64 {
     *seed = seed
@@ -83,32 +83,88 @@ fn unit_trends_plus_time_effects_boundary() {
 }
 
 #[test]
-fn frustrated_component_errors_cleanly() {
+fn frustrated_component_solves_via_cover() {
     // Per-level means are exactly 0, so whitening keeps the cell signs:
-    // rows (−,+,+) / (−,−,+) contain a negative 4-cycle. Exactly one signed
-    // component exists, so the reported pair is deterministic.
+    // rows (−,+,+) / (−,−,+) contain a negative 4-cycle — the minimal
+    // frustrated component. The cover path must reproduce the exact
+    // least-squares projection: residuals orthogonal to every design column,
+    // and the reported coefficients reconstruct the fit.
     let f = [0u32, 0, 0, 1, 1, 1];
     let g = [0u32, 1, 2, 0, 1, 2];
     let z = [-2.0, 1.0, 1.0, -1.0, -1.0, 2.0];
+    let y = [1.0, -2.0, 0.5, 3.0, -1.5, 2.5];
     let effects = vec![
         Effect::new(&f, true, [&z[..]]).expect("slope effect"),
         Effect::new(&g, true, []).expect("plain effect"),
     ];
 
-    let err = Solver::new(effects, None, PreconditionerConfig::default()).unwrap_err();
-    assert!(err.to_string().contains("frustrated"));
-    match err {
-        BuildError::FrustratedComponent {
-            pair:
-                SignedPair {
-                    term_q: 0,
-                    column_q: 1,
-                    term_r: 1,
-                    column_r: 0,
-                },
-        } => {}
-        other => panic!("expected FrustratedComponent for (f-slope, g-int), got: {other:?}"),
+    let r = Solver::new(effects, None, PreconditionerConfig::default())
+        .expect("frustrated component builds via its Gremban cover")
+        .solve(&y, &LsmrOptions::default())
+        .expect("solve");
+    assert!(r.converged);
+    assert!(r.unidentified.is_empty());
+
+    for level in 0..2u32 {
+        for slope in [None, Some(&z)] {
+            let dot: f64 = (0..y.len())
+                .filter(|&i| f[i] == level)
+                .map(|i| r.demeaned[i] * slope.map_or(1.0, |z| z[i]))
+                .sum();
+            assert!(dot.abs() < 1e-6, "f level {level}: residual·column = {dot}");
+        }
     }
+    for level in 0..3u32 {
+        let dot: f64 = (0..y.len())
+            .filter(|&i| g[i] == level)
+            .map(|i| r.demeaned[i])
+            .sum();
+        assert!(dot.abs() < 1e-6, "g level {level}: residual·column = {dot}");
+    }
+    for i in 0..y.len() {
+        let fitted = r.x[f[i] as usize] + r.x[2 + f[i] as usize] * z[i] + r.x[4 + g[i] as usize];
+        assert!(
+            (y[i] - r.demeaned[i] - fitted).abs() < 1e-6,
+            "fitted value {i}"
+        );
+    }
+}
+
+#[test]
+fn frustrated_two_factor_slope_solves_with_bounded_iterations() {
+    // Same shape as the balanced two-factor case, but g has five levels:
+    // whitened slope rows are zero-sum, so a ≥3-level partner generically
+    // closes negative cycles — the realistic frustrated regime.
+    let n = 50_000;
+    let n_f = 200u64;
+    let mut seed = 47u64;
+    let f: Vec<u32> = (0..n).map(|_| (lcg(&mut seed) % n_f) as u32).collect();
+    let g: Vec<u32> = (0..n).map(|_| (lcg(&mut seed) % 5) as u32).collect();
+    let z: Vec<f64> = (0..n)
+        .map(|_| (lcg(&mut seed) % 2001) as f64 / 1000.0 - 1.0)
+        .collect();
+    let y: Vec<f64> = (0..n)
+        .map(|i| {
+            let fl = f[i] as f64;
+            (fl * 0.013).sin()
+                + (0.5 + (fl * 0.037).cos()) * z[i]
+                + 0.4 * g[i] as f64
+                + (i as f64 * 0.61).sin() * 0.3
+        })
+        .collect();
+
+    let effects = vec![
+        Effect::new(&f, true, [&z[..]]).expect("slope effect"),
+        Effect::new(&g, true, []).expect("plain effect"),
+    ];
+    let r = Solver::new(effects, None, PreconditionerConfig::default())
+        .expect("frustrated routing builds")
+        .solve(&y, &LsmrOptions::default())
+        .expect("solve");
+
+    assert!(r.converged);
+    assert!(r.iterations <= 80, "iterations = {}", r.iterations);
+    assert!(r.unidentified.is_empty());
 }
 
 #[test]

--- a/docs/4_sddm_state_model.md
+++ b/docs/4_sddm_state_model.md
@@ -4,7 +4,7 @@ States = matrix classes (invariants). Edges = transforms (domain, exactness,
 pullback). Code is audited against the model: a code path with no legal edge is
 a bug or a missing theorem. Tags: **[exact]**, **[quality]** (costs iterations,
 never correctness), **[def]** (definitional boundary), **[open]** (missing
-mathematics), **[planned]** (see Status).
+mathematics).
 
 ## Problem
 
@@ -106,7 +106,7 @@ it).
 | scale | dominant B → S± | $A \mapsto SAS$, $S$ certified by monotone fixed point | exact | $x = S\hat x$ |
 | clamp | ¬dominant B → S± | diagonal lift $d_i \mapsto \max\bigl(d_i, \sum_j \lvert a_{ij}\rvert\bigr)$ — operator perturbation | quality | — |
 | switch | balanced S± → L₊ | $A \mapsto \sigma A \sigma$, fused with scale; surplus → ground edges; floating ⟺ total surplus ≤ roundoff | exact | $x = \sigma \circ \hat x$ |
-| cover | frustrated S± → L₊ ($2n$) | Gremban double cover; balanced ⟺ cover disconnects | exact, planned | $x = (x^+ - x^-)/2$ |
+| cover | frustrated S± → L₊ ($2n$) | Gremban double cover; balanced ⟺ cover disconnects | exact | $x = (x^+ - x^-)/2$ |
 | eliminate | L₊ → L₊ | Schur on the larger bipartite side: independent set ⇒ pivots = original diagonals; ground kept; eliminated surplus joins its star (capacity = pivot) | exact rows / sampled per-star clique-tree (unbiased, kernel sure, no spectral guarantee; exact on ≤ 2-entry stars) | back-substitution |
 | factor | L₊ → 𝓛 | clique-tree to completion (ground ordinary) / dense Cholesky (floating: anchored minor = grounding, benign) | sampled / exact | substitution |
 | pseudo-solve | 𝓛 → B⁺ | compose pullbacks in reverse; floating: mean-project RHS and solution; grounded: gauge $(b, -\mathbf{1}^\top b)$, $x = \hat x - \hat x_g$ | — | is the pullback |
@@ -261,7 +261,5 @@ which problem is solved, invisibly.
   grounding isomorphism; exact Schur closure and clique decomposition
   (AC(k) §3.1); Gremban cover exactness; additive-Schwarz symmetry/PSD-ness
   under two-sided PoU weights.
-- **Planned** — cover; until it lands, frustrated components — generic for
-  slope pairs — have no path through the model.
 - **Open** — elimination theory for rank-1-block matrix-weighted Laplacians
   (state P); connection-Laplacian theory needs scaled-unitary weights.

--- a/tests/test_slopes.py
+++ b/tests/test_slopes.py
@@ -1,4 +1,4 @@
-"""Varying slopes (#59, #60) and cross-factor routing (#61), cross-checked
+"""Varying slopes (#59, #60) and cross-factor routing (#61, #62), cross-checked
 against pyfixest.
 
 pyfixest has no native ``f[z]`` syntax; the reference is the explicit
@@ -205,10 +205,32 @@ def test_unit_trends_time_effects_boundary_matches_pyfixest():
         )
 
 
-def test_frustrated_two_factor_raises():
-    f = np.array([0, 0, 0, 1, 1, 1], dtype=np.uint32)
-    g = np.array([0, 1, 2, 0, 1, 2], dtype=np.uint32)
-    z = np.array([-2.0, 1.0, 1.0, -1.0, -1.0, 2.0])
-    y = np.zeros(6)
-    with pytest.raises(ValueError, match="frustrated"):
-        within.solve([Effect(f, True, [z]), Effect(g, True)], y, OPTS)
+def test_frustrated_two_factor_slope_matches_pyfixest():
+    # A partner factor with three or more levels generically frustrates the
+    # (f-slope, g) pair — whitened slope rows are zero-sum, so cycles close
+    # with negative sign. Solved through the Gremban double cover; the fit
+    # must still match the reference exactly.
+    rng = np.random.default_rng(303)
+    n = 500
+    f = rng.integers(0, N_LEVELS, n).astype(np.uint32)
+    g = rng.integers(0, 5, n).astype(np.uint32)
+    z = rng.normal(size=n)
+    a = rng.normal(size=N_LEVELS)
+    b = rng.normal(size=N_LEVELS)
+    c = rng.normal(size=5)
+    y = a[f] + b[f] * z + c[g] + rng.normal(scale=0.1, size=n)
+
+    res = within.solve([Effect(f, True, [z]), Effect(g, True)], y, OPTS)
+    assert res.converged
+    assert res.unidentified == []
+
+    df = pd.DataFrame(
+        {"f": [f"L{v}" for v in f], "g": [f"G{v}" for v in g], "z": z, "y": y}
+    )
+    fit = pf.feols("y ~ C(f) + i(f, z) + C(g) - 1", data=df)
+    coef = fit.coef()
+    for lvl in range(N_LEVELS):
+        assert res.x[N_LEVELS + lvl] == pytest.approx(
+            coef[f"f::L{lvl}:z"], rel=1e-6, abs=1e-8
+        )
+    assert np.allclose(res.demeaned, fit.resid(), rtol=1e-6, atol=1e-8)


### PR DESCRIPTION
Closes #62.

Frustrated components — generic for slope pairs — now solve instead of erroring. The cover is built at SDDM conversion, before elimination: scaled cell magnitudes double into a bipartite SDDM system (raw-positive cells within-copy, raw-negative across copies) that the existing elimination/reduction pipeline consumes unchanged. Vectors pass through the antisymmetric embedding `[z; -z]` and read-back `(x⁺ − x⁻)/2` at the solve boundary; `BuildError::FrustratedComponent` is deleted.

Verification: covered block-elim solve pinned exact against the raw signed operator; the minimal negative-cycle model pins the exact least-squares projection; frustrated pyfixest parity added (5-level partner). AKM smoke via `bench-slopes` (within arm now wired into the #65 script): all cases converge — `akm_both` 277/276 iterations, 0.65 s vs fixest 6.97 s at 100 k obs.