### PR TITLE
Batch solve for term designs: free-function binding + parity pins (#63)

### DIFF
--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -57,44 +57,57 @@ pub fn solve<'py>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (categories, Y, options=None, weights=None, preconditioner=None))]
+#[pyo3(signature = (design, Y, options=None, weights=None, preconditioner=None))]
 pub fn solve_batch<'py>(
     py: Python<'py>,
-    categories: PyReadonlyArray2<'py, u32>,
+    design: &Bound<'py, PyAny>,
     #[allow(non_snake_case)] Y: PyReadonlyArray2<'py, f64>,
     options: Option<&Bound<'py, PyAny>>,
     weights: Option<PyReadonlyArray1<'py, f64>>,
     preconditioner: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<PyBatchSolveResult> {
-    let cats = categories.as_array();
-    warn_c_contiguous(py, &cats)?;
-
-    let y_arr = Y.as_array();
-
-    // Validate Y row count against the design up front. Without this, an empty
-    // batch (Y.shape[1] == 0) would silently skip the per-column length check
-    // inside `Solver::solve`.
-    if y_arr.nrows() != cats.nrows() {
-        return Err(value_err(format!(
-            "Y has {} rows but categories has {} observations",
-            y_arr.nrows(),
-            cats.nrows()
-        )));
-    }
-
-    // Defer column extraction and weight coercion into the GIL-released closure
-    // below: F-contiguous columns and contiguous weights are borrowed directly,
-    // only strided input is copied (off-GIL).
-    let w_view = weights.as_ref().map(|w| w.as_array());
     let params = resolve_lsmr_config(options)?;
     let precond = resolve_precond_input(py, preconditioner)?;
 
-    run_batch(py, move || -> Result<_, WithinError> {
-        let columns = extract_columns(&y_arr);
-        let col_refs = column_refs(&columns);
-        let w_cow = w_view.as_ref().map(coerce_to_slice);
-        solve_batch_native(cats, &col_refs, w_cow.as_deref(), &params, precond)
-    })
+    let y_arr = Y.as_array();
+    let w_view = weights.as_ref().map(|w| w.as_array());
+
+    match extract_design(py, design)? {
+        DesignSource::Categories(categories) => {
+            let cats = categories.as_array();
+            warn_c_contiguous(py, &cats)?;
+            validate_batch_rows(y_arr.nrows(), cats.nrows())?;
+            run_batch(py, move || -> Result<_, WithinError> {
+                let columns = extract_columns(&y_arr);
+                let col_refs = column_refs(&columns);
+                let w_cow = w_view.as_ref().map(coerce_to_slice);
+                solve_batch_native(cats, &col_refs, w_cow.as_deref(), &params, precond)
+            })
+        }
+        DesignSource::Effects(terms) => {
+            if let Some(first) = terms.first() {
+                validate_batch_rows(y_arr.nrows(), first.levels.len())?;
+            }
+            run_batch(py, move || -> Result<_, WithinError> {
+                let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
+                let columns = extract_columns(&y_arr);
+                let col_refs = column_refs(&columns);
+                let w_cow = w_view.as_ref().map(coerce_to_slice);
+                solve_batch_native(effects, &col_refs, w_cow.as_deref(), &params, precond)
+            })
+        }
+    }
+}
+
+/// Validate `Y`'s row count up front: an empty batch (`Y.shape[1] == 0`) would
+/// otherwise silently skip the per-column length check inside `Solver::solve`.
+fn validate_batch_rows(y_rows: usize, n_obs: usize) -> PyResult<()> {
+    if y_rows != n_obs {
+        return Err(value_err(format!(
+            "Y has {y_rows} rows but the design has {n_obs} observations"
+        )));
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -1,5 +1,5 @@
 use ndarray::array;
-use within::{solve, LsmrOptions, Preconditioner, PreconditionerConfig, Solver};
+use within::{solve, Effect, LsmrOptions, Preconditioner, PreconditionerConfig, Solver};
 
 #[path = "common/orchestrate_helpers.rs"]
 mod common;
@@ -131,6 +131,41 @@ fn test_solver_batch() {
 
     assert_eq!(batch.converged.len(), 3);
     assert!(batch.converged.iter().all(|&c| c));
+}
+
+#[test]
+fn test_solver_batch_term_design_shares_drop_report() {
+    // Level 0's z is constant, so its whitened slope column drops; each batch
+    // column must reproduce the single solve and share the drop report.
+    let f = [0u32, 0, 0, 1, 1, 1];
+    let g = [0u32, 1, 2, 0, 1, 2];
+    let z = [3.0, 3.0, 3.0, -1.0, -1.0, 2.0];
+    let ys = [
+        [1.0, -2.0, 0.5, 3.0, -1.5, 2.5],
+        [0.3, 1.1, -0.7, 2.2, 0.9, -1.4],
+    ];
+    let effects = vec![
+        Effect::new(&f, true, [&z[..]]).expect("slope effect"),
+        Effect::new(&g, true, []).expect("plain effect"),
+    ];
+    let params = default_params();
+
+    let solver = Solver::new(effects, None, additive_precond()).expect("solver build");
+    let batch = solver
+        .solve_batch(&[&ys[0], &ys[1]], &params)
+        .expect("solve batch");
+    assert!(!batch.unidentified.is_empty(), "level 0 slope should drop");
+
+    for (i, y) in ys.iter().enumerate() {
+        let single = solver.solve(y, &params).expect("single solve");
+        assert_eq!(batch.unidentified, single.unidentified);
+        for (a, b) in batch.x(i).iter().zip(single.x.iter()) {
+            assert!((a - b).abs() < 1e-12, "batch x mismatch");
+        }
+        for (a, b) in batch.demeaned(i).iter().zip(single.demeaned.iter()) {
+            assert!((a - b).abs() < 1e-12, "batch demeaned mismatch");
+        }
+    }
 }
 
 #[test]

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -210,7 +210,7 @@ def solve(
     ...
 
 def solve_batch(
-    categories: NDArray[np.uint32],
+    design: NDArray[np.uint32] | list[Effect],
     Y: NDArray[np.float64],
     options: LsmrOptions | None = None,
     weights: NDArray[np.float64] | None = None,
@@ -224,7 +224,9 @@ def solve_batch(
     the setup phase (preconditioner construction).
 
     Args:
-        categories: Factor assignments, shape ``(n_obs, n_factors)``, dtype ``uint32``.
+        design: Either a ``(n_obs, n_factors)`` ``uint32`` array of factor
+            assignments (F-contiguous for best performance; a ``UserWarning``
+            is emitted otherwise), or a list of :class:`Effect` terms.
         Y: Response matrix, shape ``(n_obs, k)``, dtype ``float64``. Each column
             is a separate response vector.
         options: LSMR solver tuning. Default: ``LsmrOptions(tol=1e-8, maxiter=1000)``.

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -381,6 +381,27 @@ class TestSolveBatchFreeFunction:
         np.testing.assert_allclose(batch.x[:, 0], r1.x, atol=1e-10)
         np.testing.assert_allclose(batch.x[:, 1], r2.x, atol=1e-10)
 
+    def test_solve_batch_effect_terms_match_individual(self):
+        f = np.array([0, 0, 0, 1, 1, 1], dtype=np.uint32)
+        g = np.array([0, 1, 2, 0, 1, 2], dtype=np.uint32)
+        z = np.array([-2.0, 1.0, 1.0, -1.0, -1.0, 2.0])
+        Y = np.column_stack(
+            [
+                np.array([1.0, -2.0, 0.5, 3.0, -1.5, 2.5]),
+                np.array([0.3, 1.1, -0.7, 2.2, 0.9, -1.4]),
+            ]
+        )
+        from within import Effect, solve_batch
+
+        effects = [Effect(f, True, [z]), Effect(g, True)]
+        batch = solve_batch(effects, Y)
+        for j in range(Y.shape[1]):
+            single = solve(effects, Y[:, j].copy())
+            np.testing.assert_allclose(batch.x[:, j], single.x, atol=1e-10)
+            np.testing.assert_allclose(
+                batch.demeaned[:, j], single.demeaned, atol=1e-10
+            )
+
     def test_solve_batch_result_shapes(self, problem):
         cats, y = problem
         categories = as_solver_categories(cats)


### PR DESCRIPTION
Implements #63.

`Solver::solve_batch` already carried term designs by construction (it delegates per RHS to `solve`, sharing the design-determined drop report); the one gap was the Python free function `solve_batch`, whose binding only accepted a categories matrix. It now dispatches on the design argument exactly like free `solve` — the native function was already generic.

- `within.solve_batch(effects, Y)` works; parameter renamed `categories` → `design` (all existing callers are positional), stub updated.
- Rust test: batch vs single parity for a term design with a dropped slope column, drop report shared across columns.
- Python test: free-function batch with effect terms matches per-column `solve`.

The serialization half of #63's done-when landed in #92 (`signed_route_preconditioner_round_trips`).

`cargo test --workspace` and `pixi run test` (114 py tests) green.