### PR TITLE
feat(within): expose CoefficientLayout for solve results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 - **Varying slopes:** factor effects can carry continuous slope covariates via the new `Effect` term type (level codes, an intercept flag, and zero or more slope columns), accepted anywhere a categories matrix is — Rust `Solver::new` / `solve` / `solve_batch` and the Python first argument (#58–#63).
 - `SolveResult` / `BatchSolveResult` report unidentified directions as `UnidentifiedDirection` records (`term`, `level`, `column`) in both Rust and Python; those coefficient slots hold `0`, never NaN (#69).
+- `CoefficientLayout` (Rust and Python), reached via `SolveResult.layout` / `BatchSolveResult.layout`, translates a `(term, level, column)` address to its flat `x` index and back, so callers need not reconstruct term offsets by hand (#99).
 - `SolveResult.x` is term-major — coefficient column `c` of `level` sits at `term_offset + c * n_levels + level`; intercept-only designs keep the 0.2.0 ordering (#71).
 - `ScalingConfig` (in `within.config`) tunes certification of signed-component scaling; `Solver::warnings()` returns non-fatal `BuildWarning`s from the build (#61).
 - New `BuildError` variants `EmptyEffect` and `SlopeLengthMismatch` for malformed effect terms (#58).
@@ -21,7 +22,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 - **BREAKING:** The Python `solve` / `solve_batch` / `Solver` first parameter is renamed `categories` → `design` and now accepts a `list[Effect]` as well as a `uint32` array; positional calls are unaffected, `categories=` keyword calls break (#58).
 - **BREAKING:** The serialized `Preconditioner` wire format changed (v3 → v6); `Preconditioner` bytes from 0.2.0 no longer decode (#72, #98).
-- **BREAKING:** `SolveResult` / `BatchSolveResult` gain a public `unidentified` field and are not `#[non_exhaustive]`, so exhaustive Rust destructuring must account for it (#69).
+- **BREAKING:** `SolveResult` / `BatchSolveResult` gain public `unidentified` and `layout` fields and are not `#[non_exhaustive]`, so exhaustive Rust destructuring must account for them (#69, #99).
 - **BREAKING:** `Design` / `Solver` trade their storage type parameter for a lifetime — `Design<'a>` / `Solver<'a>` — borrowing caller columns until a locality sort or `into_owned()` (#68).
 - **BREAKING:** `Design::from_store` → `Design::from_frame`, taking an `ObservationFrame` (#68).
 - **BREAKING:** `BuildError::ObservationCountMismatch` reports the offending `column` index (#68).

--- a/crates/within-py/src/lib.rs
+++ b/crates/within-py/src/lib.rs
@@ -18,7 +18,7 @@ use config::{
     PyAdditiveSchwarz, PyApproxCholConfig, PyApproxSchurConfig, PyLocalSolverConfig, PyLsmrOptions,
     PyPreconditioner, PyPreconditionerConfig, PyReductionStrategy, PyScalingConfig,
 };
-use results::{PyBatchSolveResult, PySolveResult, PyUnidentifiedDirection};
+use results::{PyBatchSolveResult, PyCoefficientLayout, PySolveResult, PyUnidentifiedDirection};
 
 // ---------------------------------------------------------------------------
 // Module
@@ -29,6 +29,7 @@ fn _within(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySolveResult>()?;
     m.add_class::<PyBatchSolveResult>()?;
     m.add_class::<PyUnidentifiedDirection>()?;
+    m.add_class::<PyCoefficientLayout>()?;
     m.add_class::<PyLsmrOptions>()?;
     m.add_class::<PyAdditiveSchwarz>()?;
     m.add_class::<PyReductionStrategy>()?;

--- a/crates/within-py/src/results.rs
+++ b/crates/within-py/src/results.rs
@@ -2,9 +2,10 @@
 
 use numpy::ndarray::{Array2, ShapeBuilder};
 use numpy::IntoPyArray;
+use pyo3::exceptions::PyIndexError;
 use pyo3::prelude::*;
 
-use within::{BatchSolveResult, SolveResult};
+use within::{BatchSolveResult, CoefficientLayout, SolveResult};
 
 use crate::convert::value_err;
 
@@ -19,6 +20,8 @@ pub struct PySolveResult {
     pub x: Py<numpy::PyArray1<f64>>,
     #[pyo3(get)]
     pub unidentified: Vec<PyUnidentifiedDirection>,
+    #[pyo3(get)]
+    pub layout: PyCoefficientLayout,
     #[pyo3(get)]
     pub demeaned: Py<numpy::PyArray1<f64>>,
     #[pyo3(get)]
@@ -42,6 +45,8 @@ pub struct PyBatchSolveResult {
     pub x: Py<numpy::PyArray2<f64>>,
     #[pyo3(get)]
     pub unidentified: Vec<PyUnidentifiedDirection>,
+    #[pyo3(get)]
+    pub layout: PyCoefficientLayout,
     #[pyo3(get)]
     pub demeaned: Py<numpy::PyArray2<f64>>,
     #[pyo3(get)]
@@ -79,6 +84,70 @@ impl PyUnidentifiedDirection {
     }
 }
 
+/// Translates a ``(term, level, column)`` coefficient address to its flat
+/// index in ``SolveResult.x`` and back.
+#[pyclass(frozen, module = "within._within")]
+#[pyo3(name = "CoefficientLayout")]
+#[derive(Clone)]
+pub struct PyCoefficientLayout {
+    inner: CoefficientLayout,
+}
+
+#[pymethods]
+impl PyCoefficientLayout {
+    fn n_dofs(&self) -> usize {
+        self.inner.n_dofs()
+    }
+
+    fn n_terms(&self) -> usize {
+        self.inner.n_terms()
+    }
+
+    fn n_levels(&self, term: usize) -> PyResult<usize> {
+        self.inner.n_levels(term).ok_or_else(|| self.term_oob(term))
+    }
+
+    fn n_columns(&self, term: usize) -> PyResult<usize> {
+        self.inner
+            .n_columns(term)
+            .ok_or_else(|| self.term_oob(term))
+    }
+
+    fn index(&self, term: usize, level: usize, column: usize) -> PyResult<usize> {
+        self.inner.index(term, level, column).ok_or_else(|| {
+            PyIndexError::new_err(format!(
+                "coefficient address (term={term}, level={level}, column={column}) out of range"
+            ))
+        })
+    }
+
+    fn address(&self, index: usize) -> PyResult<(usize, usize, usize)> {
+        self.inner.address(index).ok_or_else(|| {
+            PyIndexError::new_err(format!(
+                "x index {index} out of range (n_dofs={})",
+                self.inner.n_dofs()
+            ))
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "CoefficientLayout(n_terms={}, n_dofs={})",
+            self.inner.n_terms(),
+            self.inner.n_dofs()
+        )
+    }
+}
+
+impl PyCoefficientLayout {
+    fn term_oob(&self, term: usize) -> PyErr {
+        PyIndexError::new_err(format!(
+            "term {term} out of range (n_terms={})",
+            self.inner.n_terms()
+        ))
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Result conversion helpers
 // ---------------------------------------------------------------------------
@@ -95,6 +164,9 @@ pub(crate) fn into_py_result(py: Python<'_>, result: SolveResult) -> PySolveResu
                 column: u.column,
             })
             .collect(),
+        layout: PyCoefficientLayout {
+            inner: result.layout,
+        },
         demeaned: result.demeaned.into_pyarray(py).unbind(),
         converged: result.converged,
         iterations: result.iterations,
@@ -128,6 +200,9 @@ pub(crate) fn into_py_batch_result(
                 column: u.column,
             })
             .collect(),
+        layout: PyCoefficientLayout {
+            inner: result.layout,
+        },
         demeaned: demeaned.into_pyarray(py).unbind(),
         converged: result.converged,
         iterations: result.iterations,

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -37,8 +37,14 @@ pub(crate) struct TermMeta {
 }
 
 impl TermMeta {
+    /// Coefficient-column count (`intercept? + slopes`), ordered
+    /// `[intercept?, slopes…]`.
+    pub fn n_columns(&self) -> usize {
+        usize::from(self.intercept) + self.slopes.len()
+    }
+
     pub fn n_dofs(&self) -> usize {
-        (usize::from(self.intercept) + self.slopes.len()) * self.n_levels
+        self.n_columns() * self.n_levels
     }
 
     /// Global DOF base of coefficient column `column`.

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -28,6 +28,6 @@ pub use domain::{Design, Effect};
 pub use error::{BuildError, BuildWarning, SignedPair, SolveError, WithinError};
 pub use operator::schwarz::Preconditioner;
 pub use solver::{
-    solve, solve_batch, BatchSolveResult, IntoDesign, PreconditionerInput, SolveResult, Solver,
-    UnidentifiedDirection,
+    solve, solve_batch, BatchSolveResult, CoefficientLayout, IntoDesign, PreconditionerInput,
+    SolveResult, Solver, UnidentifiedDirection,
 };

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -125,6 +125,82 @@ pub struct UnidentifiedDirection {
     pub column: usize,
 }
 
+/// Translates a `(term, level, column)` coefficient address to its flat index
+/// in [`SolveResult::x`] and back, so callers need not reconstruct the
+/// term-major offset formula (`offset + column * n_levels + level`) by hand.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoefficientLayout {
+    terms: Vec<TermLayout>,
+    n_dofs: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TermLayout {
+    offset: usize,
+    n_levels: usize,
+    n_columns: usize,
+}
+
+impl CoefficientLayout {
+    pub(crate) fn from_design(design: &Design) -> Self {
+        let terms = design
+            .terms
+            .iter()
+            .map(|t| TermLayout {
+                offset: t.offset,
+                n_levels: t.n_levels,
+                n_columns: usize::from(t.intercept) + t.slopes.len(),
+            })
+            .collect();
+        Self {
+            terms,
+            n_dofs: design.n_dofs,
+        }
+    }
+
+    /// Total number of coefficients (the length of [`SolveResult::x`]).
+    pub fn n_dofs(&self) -> usize {
+        self.n_dofs
+    }
+
+    /// Number of terms in the design.
+    pub fn n_terms(&self) -> usize {
+        self.terms.len()
+    }
+
+    /// Level count of `term`, or `None` if `term` is out of range.
+    pub fn n_levels(&self, term: usize) -> Option<usize> {
+        self.terms.get(term).map(|t| t.n_levels)
+    }
+
+    /// Coefficient-column count of `term` (`intercept? + slopes`, ordered
+    /// `[intercept?, slopes…]`), or `None` if `term` is out of range.
+    pub fn n_columns(&self, term: usize) -> Option<usize> {
+        self.terms.get(term).map(|t| t.n_columns)
+    }
+
+    /// Flat [`SolveResult::x`] index of coefficient `column` of `level` within
+    /// `term`, or `None` if any coordinate is out of range.
+    pub fn index(&self, term: usize, level: usize, column: usize) -> Option<usize> {
+        let t = self.terms.get(term)?;
+        (level < t.n_levels && column < t.n_columns).then(|| t.offset + column * t.n_levels + level)
+    }
+
+    /// The `(term, level, column)` address of flat index `i`, or `None` if
+    /// `i >= n_dofs`.
+    pub fn address(&self, i: usize) -> Option<(usize, usize, usize)> {
+        if i >= self.n_dofs {
+            return None;
+        }
+        // Term blocks are contiguous in ascending offset order, so the owning
+        // term is the last one whose offset does not exceed `i`.
+        let term = self.terms.partition_point(|t| t.offset <= i) - 1;
+        let t = &self.terms[term];
+        let within = i - t.offset;
+        Some((term, within % t.n_levels, within / t.n_levels))
+    }
+}
+
 /// Common solve output for all orchestration entry points.
 #[derive(Debug, Clone)]
 #[must_use]
@@ -138,6 +214,8 @@ pub struct SolveResult {
     pub x: Vec<f64>,
     /// Per-level directions the data cannot identify.
     pub unidentified: Vec<UnidentifiedDirection>,
+    /// Address ↔ flat-`x`-index translation for this design's coefficients.
+    pub layout: CoefficientLayout,
     /// Demeaned response: `y - D x` (length = n_obs), in caller order.
     ///
     /// Invariant: any per-observation field added here must be translated
@@ -170,6 +248,8 @@ pub struct BatchSolveResult {
     /// Per-level directions the data cannot identify, shared across all RHS:
     /// identification depends only on the design and weights, never on `y`.
     pub unidentified: Vec<UnidentifiedDirection>,
+    /// Address ↔ flat-`x`-index translation for this design's coefficients.
+    pub layout: CoefficientLayout,
     /// All demeaned responses concatenated (length = n_obs * n_rhs).
     pub demeaned: Vec<f64>,
     /// Per-RHS convergence flags.
@@ -374,6 +454,7 @@ impl<'a> Solver<'a> {
         Ok(SolveResult {
             x,
             unidentified,
+            layout: CoefficientLayout::from_design(&self.design),
             // Back to the caller's observation order (no-op if not reordered).
             demeaned: self.design.permute_obs_out(demeaned),
             converged: r.converged,
@@ -427,6 +508,7 @@ impl<'a> Solver<'a> {
         Ok(BatchSolveResult {
             x,
             unidentified,
+            layout: CoefficientLayout::from_design(&self.design),
             demeaned,
             converged,
             iterations,

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -149,7 +149,7 @@ impl CoefficientLayout {
             .map(|t| TermLayout {
                 offset: t.offset,
                 n_levels: t.n_levels,
-                n_columns: usize::from(t.intercept) + t.slopes.len(),
+                n_columns: t.n_columns(),
             })
             .collect();
         Self {

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -1,4 +1,5 @@
 use super::reparam::SlopeReparam;
+use super::CoefficientLayout;
 use crate::config::{ScalingConfig, DEFAULT_DENSE_SCHUR_THRESHOLD};
 use crate::domain::{build_local_domains, Design, SolveSpace};
 use crate::Effect;
@@ -36,4 +37,48 @@ fn positive_slope_only_pair_grounds_beyond_dense_threshold() {
         }),
         "fixture must ground a component past the dense threshold (warnings: {warnings:?})"
     );
+}
+
+#[test]
+fn coefficient_layout_translates_addresses_both_ways() {
+    // term 0: plain 3-level factor (1 column); term 1: 2-level factor with an
+    // intercept and one slope (2 columns).
+    let f = [0u32, 1, 2, 0, 1, 2];
+    let g = [0u32, 0, 1, 1, 0, 1];
+    let z = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let design = Design::new(vec![
+        Effect::new(&f, true, []).expect("plain effect"),
+        Effect::new(&g, true, [&z[..]]).expect("slope effect"),
+    ])
+    .expect("design");
+    let layout = CoefficientLayout::from_design(&design);
+
+    assert_eq!(layout.n_terms(), 2);
+    assert_eq!(
+        (layout.n_levels(0), layout.n_columns(0)),
+        (Some(3), Some(1))
+    );
+    assert_eq!(
+        (layout.n_levels(1), layout.n_columns(1)),
+        (Some(2), Some(2))
+    );
+    assert_eq!(layout.n_levels(2), None);
+
+    // Forward matches the documented `offset + column * n_levels + level`.
+    assert_eq!(layout.index(0, 2, 0), Some(2));
+    assert_eq!(layout.index(1, 0, 0), Some(3)); // term-1 intercept, level 0
+    assert_eq!(layout.index(1, 1, 1), Some(6)); // term-1 slope, level 1
+    assert_eq!(layout.n_dofs(), 7);
+
+    // Out-of-range coordinates are rejected, not silently wrapped.
+    assert_eq!(layout.index(1, 2, 0), None); // level past n_levels
+    assert_eq!(layout.index(1, 0, 2), None); // column past n_columns
+    assert_eq!(layout.index(2, 0, 0), None); // term past n_terms
+    assert_eq!(layout.address(7), None);
+
+    // `address` inverts `index` for every flat slot.
+    for i in 0..layout.n_dofs() {
+        let (term, level, column) = layout.address(i).expect("address in range");
+        assert_eq!(layout.index(term, level, column), Some(i));
+    }
 }

--- a/python/within/__init__.py
+++ b/python/within/__init__.py
@@ -45,6 +45,7 @@ For Rust-level internals, build the API docs with ``cargo doc --open``.
 
 from within._within import (
     BatchSolveResult,
+    CoefficientLayout,
     Effect,
     LsmrOptions,
     Preconditioner,
@@ -59,6 +60,7 @@ from within import config  # noqa: F401 — expose submodule on `within.config`
 
 __all__ = [
     "BatchSolveResult",
+    "CoefficientLayout",
     "Effect",
     "LsmrOptions",
     "Preconditioner",

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -85,6 +85,22 @@ class UnidentifiedDirection:
     @property
     def column(self) -> int: ...
 
+class CoefficientLayout:
+    """Translate a ``(term, level, column)`` coefficient address to its flat
+    ``SolveResult.x`` index and back, so callers need not reconstruct the
+    term-major offset formula.
+
+    ``n_levels``, ``n_columns``, ``index``, and ``address`` raise ``IndexError``
+    on an out-of-range coordinate rather than returning a wrong value.
+    """
+
+    def n_dofs(self) -> int: ...
+    def n_terms(self) -> int: ...
+    def n_levels(self, term: int) -> int: ...
+    def n_columns(self, term: int) -> int: ...
+    def index(self, term: int, level: int, column: int) -> int: ...
+    def address(self, index: int) -> tuple[int, int, int]: ...
+
 class SolveResult:
     """Result of a single fixed-effects solve.
 
@@ -97,6 +113,7 @@ class SolveResult:
             directions hold the minimal-norm value ``0``, never NaN.
         unidentified: Per-level directions the data cannot identify, as
             :class:`UnidentifiedDirection` records.
+        layout: Address <-> flat-``x``-index translation for the coefficients.
         demeaned: Response vector after subtracting estimated fixed effects,
             shape ``(n_obs,)``.
         converged: Whether the LSMR solver met the convergence tolerance.
@@ -112,6 +129,8 @@ class SolveResult:
     def x(self) -> NDArray[np.float64]: ...
     @property
     def unidentified(self) -> list[UnidentifiedDirection]: ...
+    @property
+    def layout(self) -> CoefficientLayout: ...
     @property
     def demeaned(self) -> NDArray[np.float64]: ...
     @property
@@ -138,6 +157,7 @@ class BatchSolveResult:
             ``0``, never NaN.
         unidentified: Per-level directions the data cannot identify, as
             :class:`UnidentifiedDirection` records; shared across all RHS.
+        layout: Address <-> flat-``x``-index translation for the coefficients.
         demeaned: Demeaned responses, shape ``(n_obs, k)`` (column-major).
         converged: Whether each RHS converged.
         iterations: Total LSMR iterations for each RHS.
@@ -151,6 +171,8 @@ class BatchSolveResult:
     def x(self) -> NDArray[np.float64]: ...
     @property
     def unidentified(self) -> list[UnidentifiedDirection]: ...
+    @property
+    def layout(self) -> CoefficientLayout: ...
     @property
     def demeaned(self) -> NDArray[np.float64]: ...
     @property

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -7,6 +7,7 @@ import pytest
 
 from within import (
     BatchSolveResult,
+    CoefficientLayout,
     Effect,
     LsmrOptions,
     Preconditioner,
@@ -21,6 +22,40 @@ from conftest import generate_synthetic_data
 
 def as_solver_categories(cats):
     return np.asfortranarray(np.column_stack(cats).astype(np.uint32))
+
+
+def test_coefficient_layout_locates_unidentified_and_round_trips():
+    # firm level 2 is a singleton in the (non-first) slope term, so its slope
+    # direction is unidentified.
+    worker = np.array([0, 0, 1, 1, 2, 2], np.uint32)
+    firm = np.array([2, 0, 0, 1, 1, 0], np.uint32)
+    x = np.array([0.5, -1.0, 0.3, 2.0, -0.7, 1.1])
+    y = np.array([1.0, 2.0, 3.0, 1.5, 0.4, -0.2])
+
+    res = solve([Effect(worker, True), Effect(firm, True, [x])], y)
+    layout = res.layout
+    assert isinstance(layout, CoefficientLayout)
+    assert layout.n_dofs() == len(res.x)
+    assert [
+        (layout.n_levels(t), layout.n_columns(t)) for t in range(layout.n_terms())
+    ] == [
+        (3, 1),
+        (3, 2),
+    ]
+
+    # The reported unidentified direction resolves to a zero coefficient slot.
+    (u,) = res.unidentified
+    assert res.x[layout.index(u.term, u.level, u.column)] == 0.0
+
+    # index and address are mutual inverses over the whole vector.
+    for i in range(layout.n_dofs()):
+        assert layout.index(*layout.address(i)) == i
+
+    # Out-of-range coordinates raise instead of reading the wrong coefficient.
+    with pytest.raises(IndexError):
+        layout.index(u.term, u.level, layout.n_columns(u.term))
+    with pytest.raises(IndexError):
+        layout.address(layout.n_dofs())
 
 
 @pytest.fixture()


### PR DESCRIPTION
Resolves #99 (close manually on merge — base is `feature/slopes`, not the default branch).

`SolveResult` / `BatchSolveResult` now carry a `CoefficientLayout` (`.layout`) that maps a `(term, level, column)` address to its flat `x` index and back, so callers no longer re-derive `offset + column * n_levels + level` by hand — an off-by-one there silently reads the wrong coefficient.

Surface (Rust + Python):
- `layout.index(term, level, column)` → flat `x` index
- `layout.address(i)` → `(term, level, column)`
- `n_terms()`, `n_levels(term)`, `n_columns(term)`, `n_dofs()`
- out-of-range coordinates return `None` (Rust) / raise `IndexError` (Python)

Primary use: cross-reference `unidentified` records against `x`.