### PR TITLE
Public-API consistency sweep (#100–#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - **BREAKING:** The Python `solve` / `solve_batch` / `Solver` first parameter is renamed `categories` → `design` and now accepts a `list[Effect]` as well as a `uint32` array; positional calls are unaffected, `categories=` keyword calls break (#58).
+- **BREAKING:** The Python free `solve` / `solve_batch` take `weights` before `options` — `(design, y, weights, options, preconditioner)` — matching the `Solver` constructor and the Rust core. Callers passing `options` positionally must switch to the `options=` keyword (#101).
 - **BREAKING:** The serialized `Preconditioner` wire format changed (v3 → v6); `Preconditioner` bytes from 0.2.0 no longer decode (#72, #98).
 - **BREAKING:** `LocalSolverConfig.approx_schur: Option<ApproxSchurConfig>` becomes `schur: SchurMode` (Rust) / `schur: Schur | None` (Python). Omitted/`None` now uniformly means the library default (approximate); "exact Schur" is `SchurMode::Exact` / `Schur.exact()` (was `approx_schur=None`). The `within.config.LocalSolverConfig` compatibility subclass is removed (#104).
 - **BREAKING:** `SolveResult` / `BatchSolveResult` gain public `unidentified` and `layout` fields and are not `#[non_exhaustive]`, so exhaustive Rust destructuring must account for them (#69, #99).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - Rust `solve` / `solve_batch` / `Solver::solve` / `Solver::solve_batch` take LSMR options as `impl Into<Option<&LsmrOptions>>`, so `None` selects the default (a bare `&LsmrOptions` still works). The crate root now also re-exports `LocalSolverConfig`, `ReductionStrategy`, `ApproxCholConfig`, and `ApproxSchurConfig`, so a tuned `Additive` is constructible from crate-root imports alone (#105).
 - Python `Preconditioner.apply` raises `ValueError` (was `RuntimeError`) on a solve-time failure, matching the `solve` paths (#105).
 - The one-shot Python `solve` / `solve_batch` re-emit build warnings as `UserWarning`s (e.g. uncertified signed-component scaling), matching the persistent `Solver`; previously they were discarded (#103).
+- Wrong-dtype input arrays raise a `TypeError` naming the expected dtype (design → `uint32`, response and weights → `float64`) and the dtype received, instead of an opaque PyO3 conversion error (#100).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - **BREAKING:** `BuildError::ObservationCountMismatch` reports the offending `column` index (#68).
 - `approx-chol` bumped 0.2.0 → 0.3.1, speeding up local-solver setup.
 - The locality reorder changes summation order, so unsorted-input results match 0.2.0 within solver tolerance, not bitwise.
+- Rust `solve` / `solve_batch` / `Solver::solve` / `Solver::solve_batch` take LSMR options as `impl Into<Option<&LsmrOptions>>`, so `None` selects the default (a bare `&LsmrOptions` still works). The crate root now also re-exports `LocalSolverConfig`, `ReductionStrategy`, `ApproxCholConfig`, and `ApproxSchurConfig`, so a tuned `Additive` is constructible from crate-root imports alone (#105).
+- Python `Preconditioner.apply` raises `ValueError` (was `RuntimeError`) on a solve-time failure, matching the `solve` paths (#105).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - `CoefficientLayout` (Rust and Python), reached via `SolveResult.layout` / `BatchSolveResult.layout`, translates a `(term, level, column)` address to its flat `x` index and back, so callers need not reconstruct term offsets by hand (#99).
 - `SolveResult.x` is term-major — coefficient column `c` of `level` sits at `term_offset + c * n_levels + level`; intercept-only designs keep the 0.2.0 ordering (#71).
 - `ScalingConfig` (in `within.config`) tunes certification of signed-component scaling; `Solver::warnings()` returns non-fatal `BuildWarning`s from the build (#61).
+- `SchurMode` (Rust) / `Schur` (Python, `Schur.approximate(...)` / `Schur.exact()`) names the local solver's Schur-reduction mode explicitly (#104).
 - New `BuildError` variants `EmptyEffect` and `SlopeLengthMismatch` for malformed effect terms (#58).
 - **`ObservationFrame`:** columnar observation storage — one `u32` level-code column per factor plus `f64` loading columns, each independently borrowed or owned (#68).
 - **Locality sort:** `Design` reorders observations by the highest-cardinality factor when unsorted, copying columns once; results still return in caller row order (#68).
@@ -22,6 +23,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 - **BREAKING:** The Python `solve` / `solve_batch` / `Solver` first parameter is renamed `categories` → `design` and now accepts a `list[Effect]` as well as a `uint32` array; positional calls are unaffected, `categories=` keyword calls break (#58).
 - **BREAKING:** The serialized `Preconditioner` wire format changed (v3 → v6); `Preconditioner` bytes from 0.2.0 no longer decode (#72, #98).
+- **BREAKING:** `LocalSolverConfig.approx_schur: Option<ApproxSchurConfig>` becomes `schur: SchurMode` (Rust) / `schur: Schur | None` (Python). Omitted/`None` now uniformly means the library default (approximate); "exact Schur" is `SchurMode::Exact` / `Schur.exact()` (was `approx_schur=None`). The `within.config.LocalSolverConfig` compatibility subclass is removed (#104).
 - **BREAKING:** `SolveResult` / `BatchSolveResult` gain public `unidentified` and `layout` fields and are not `#[non_exhaustive]`, so exhaustive Rust destructuring must account for them (#69, #99).
 - **BREAKING:** `Design` / `Solver` trade their storage type parameter for a lifetime — `Design<'a>` / `Solver<'a>` — borrowing caller columns until a locality sort or `into_owned()` (#68).
 - **BREAKING:** `Design::from_store` → `Design::from_frame`, taking an `ObservationFrame` (#68).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - Python `Preconditioner.apply` raises `ValueError` (was `RuntimeError`) on a solve-time failure, matching the `solve` paths (#105).
 - The one-shot Python `solve` / `solve_batch` re-emit build warnings as `UserWarning`s (e.g. uncertified signed-component scaling), matching the persistent `Solver`; previously they were discarded (#103).
 - Wrong-dtype input arrays raise a `TypeError` naming the expected dtype (design → `uint32`, response and weights → `float64`) and the dtype received, instead of an opaque PyO3 conversion error (#100).
+- Corrected published examples and type stubs: `PreconditionerConfig` / `ReductionStrategy` are documented as (non-iterable) attribute holders rather than `IntEnum`, examples use the current argument order and `Schur` / `split_merge` spellings, and the varying-slopes workflow and minimal-norm normalization convention are documented (#102).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - The locality reorder changes summation order, so unsorted-input results match 0.2.0 within solver tolerance, not bitwise.
 - Rust `solve` / `solve_batch` / `Solver::solve` / `Solver::solve_batch` take LSMR options as `impl Into<Option<&LsmrOptions>>`, so `None` selects the default (a bare `&LsmrOptions` still works). The crate root now also re-exports `LocalSolverConfig`, `ReductionStrategy`, `ApproxCholConfig`, and `ApproxSchurConfig`, so a tuned `Additive` is constructible from crate-root imports alone (#105).
 - Python `Preconditioner.apply` raises `ValueError` (was `RuntimeError`) on a solve-time failure, matching the `solve` paths (#105).
+- The one-shot Python `solve` / `solve_batch` re-emit build warnings as `UserWarning`s (e.g. uncertified signed-component scaling), matching the persistent `Solver`; previously they were discarded (#103).
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -56,16 +56,42 @@ beta_hat = np.linalg.lstsq(X_tilde, y_tilde, rcond=None)[0]
 print(np.round(beta_hat, 4))  # [ 0.9982 -2.006   0.5005]
 ```
 
+### Varying slopes
+
+Pass a list of `Effect` terms instead of a categories array. Each term is a
+factor's level codes plus an optional intercept and zero or more slope
+covariates (per-level slopes, as in fixest's `f[z]` notation).
+
+```python
+from within import solve, Effect
+
+firm = np.random.randint(0, 500, n).astype(np.uint32)
+year = np.random.randint(0, 20, n).astype(np.uint32)
+x = np.random.randn(n)  # covariate whose slope varies by firm
+
+result = solve(
+    [
+        Effect(firm, intercept=True, slopes=[x]),  # firm intercept + firm-specific x slope
+        Effect(year, intercept=True),              # year intercept
+    ],
+    y,
+)
+
+# Read firm level 3's x-slope via the layout map (column 0 = intercept, 1 = first slope):
+i = result.layout.index(0, 3, 1)
+print(result.x[i])
+```
+
 ## Python API
 
 ### High-level functions
 
 | Function | Description |
 |---|---|
-| `solve(categories, y, options?, weights?, preconditioner?)` | Solve a single right-hand side. Returns `SolveResult`. |
-| `solve_batch(categories, Y, options?, weights?, preconditioner?)` | Solve multiple RHS vectors in parallel. `Y` has shape `(n_obs, k)`. Returns `BatchSolveResult`. |
+| `solve(design, y, weights?, options?, preconditioner?)` | Solve a single right-hand side. Returns `SolveResult`. |
+| `solve_batch(design, Y, weights?, options?, preconditioner?)` | Solve multiple RHS vectors in parallel. `Y` has shape `(n_obs, k)`. Returns `BatchSolveResult`. |
 
-`categories` is a 2-D `uint32` array of shape `(n_obs, n_factors)`. A `UserWarning` is emitted when a C-contiguous array is passed — use `np.asfortranarray(categories)` for best performance.
+`design` is either a 2-D `uint32` array of shape `(n_obs, n_factors)` or a list of `Effect` terms (see [Varying slopes](#varying-slopes)). A `UserWarning` is emitted when a C-contiguous categories array is passed — use `np.asfortranarray(design)` for best performance.
 
 ### Persistent solver
 
@@ -84,7 +110,7 @@ solver2 = Solver(fe, preconditioner=precond)   # skip re-factorization
 
 | Property / Method | Description |
 |---|---|
-| `Solver(categories, weights?, preconditioner?)` | Build solver. Factorizes the preconditioner at construction. |
+| `Solver(design, weights?, preconditioner?)` | Build solver. Factorizes the preconditioner at construction. |
 | `.solve(y, options?)` | Solve a single RHS with the given LSMR tuning. Returns `SolveResult`. |
 | `.solve_batch(Y, options?)` | Solve multiple RHS columns in parallel. Returns `BatchSolveResult`. |
 | `.preconditioner` | Return the built `Preconditioner` (picklable), or `None`. Reuse via `Solver(fe, preconditioner=p)`. |
@@ -113,16 +139,19 @@ The `preconditioner` argument accepts any of:
 
 | Class | Description |
 |---|---|
-| `LocalSolverConfig(approx_chol?, approx_schur?, dense_threshold=24)` | Schur reduction + approximate Cholesky. Omit `approx_schur` for the library-default approximate variant; pass `approx_schur=None` to request an exact Schur (slower, used for validation). |
-| `ApproxCholConfig(seed=0, split=1)` | Approximate Cholesky parameters. |
+| `LocalSolverConfig(approx_chol?, schur?, dense_threshold=24, scaling?)` | Schur reduction + approximate Cholesky. Omit `schur` for the library-default approximate variant; pass `schur=Schur.exact()` to request an exact Schur (slower, used for validation). |
+| `Schur.approximate(config?)` / `Schur.exact()` | Schur-reduction mode passed as `LocalSolverConfig(schur=...)`. |
+| `ApproxCholConfig(seed=0, split_merge=None)` | Approximate Cholesky parameters. |
 | `ApproxSchurConfig(seed=0, split=1)` | Approximate Schur complement sampling parameters. |
-| `ReductionStrategy` enum | `Auto` (default), `AtomicScatter`, `ParallelReduction`. |
+| `ReductionStrategy` | `Auto` (default), `AtomicScatter`, `ParallelReduction` (class attributes, not an `Enum`). |
 
 ### Result types
 
-**`SolveResult`**: `x` (coefficients), `demeaned` (residuals), `converged`, `iterations`, `residual`, `time_total`, `time_setup`, `time_solve`.
+**`SolveResult`**: `x` (coefficients), `unidentified` (directions the data cannot identify, as `UnidentifiedDirection(term, level, column)` records), `layout` (a `CoefficientLayout` mapping a `(term, level, column)` address to its flat `x` index and back), `demeaned` (residuals), `converged`, `iterations`, `residual`, `time_total`, `time_setup`, `time_solve`.
 
 **`BatchSolveResult`**: Same fields, with `converged`, `iterations`, `residual`, and `time_solve` as lists (one entry per RHS).
+
+Coefficients for unidentified directions are pinned to the **minimal-norm** value `0` (never NaN). This is why `x` can differ from reference tools that instead drop a reference level; the identified fit — `demeaned` — is unaffected by the choice.
 
 ## Rust API
 
@@ -161,23 +190,26 @@ let r1 = solver.solve(&y, &LsmrOptions::default())?;
 let r2 = solver.solve(&another_y, &LsmrOptions::default())?;  // reuses preconditioner
 ```
 
-Two-channel preconditioner signaling: `Option<&PreconditionerConfig>` where
-`None` is the library default and `Some(PreconditionerConfig::Off)` is the
-explicit identity preconditioner.
+`solve` and `Solver::new` take the preconditioner as `impl Into<PreconditionerInput>`:
+`None` (library default), a `&PreconditionerConfig` or owned `PreconditionerConfig`
+(e.g. `PreconditionerConfig::Off` for the identity), or an owned/borrowed
+`Preconditioner` for reuse. LSMR options are `impl Into<Option<&LsmrOptions>>`, so
+`None` accepts the defaults and `&opts` overrides them.
 
 | Type | Variants / Fields |
 |---|---|
 | `LsmrOptions` | `{ tol: f64, maxiter: usize, local_size: Option<usize> }` |
 | `PreconditionerConfig` | `Off` \| `Additive { local_solver: LocalSolverConfig, reduction: ReductionStrategy }` \| `Diagonal` (`#[non_exhaustive]`) |
-| `LocalSolverConfig` | `{ approx_chol, approx_schur, dense_threshold }` |
+| `LocalSolverConfig` | `{ approx_chol, schur: SchurMode, dense_threshold, scaling }` |
+| `SchurMode` | `Approximate(ApproxSchurConfig)` \| `Exact` |
 | `Preconditioner` | Opaque built handle — reuse via `Solver::new(.., precond)` (owned or `&`) |
 
 ### Lower-level access
 
 | Module | Visibility | Key types |
 |---|---|---|
-| `within::config` | public | `LsmrOptions`, `PreconditionerConfig`, `LocalSolverConfig`, `ApproxCholConfig`, `ApproxSchurConfig`, `ReductionStrategy` |
-| `within::observation` | public | `Store` trait, `FactorMajorStore`, `ArrayStore`, `FactorMeta` |
+| `within::config` | public | `LsmrOptions`, `PreconditionerConfig`, `LocalSolverConfig`, `SchurMode`, `ApproxCholConfig`, `ApproxSchurConfig`, `ScalingConfig`, `ReductionStrategy` |
+| `within::observation` | public | `ObservationFrame` (columnar level-code + loading columns) |
 | `within::error` | public | `WithinError`, `BuildError`, `SolveError` |
 | `domain` / `operator` / `solver` / `orchestrate` | `pub(crate)` | implementation layers — public items are re-exported at the crate root |
 

--- a/benchmarks/_framework.py
+++ b/benchmarks/_framework.py
@@ -108,7 +108,7 @@ def _solve_once(
     result = solve(
         np.asfortranarray(np.column_stack(categories).astype(np.uint32)),
         y,
-        config.config,
+        options=config.config,
         preconditioner=config.preconditioner,
     )
 

--- a/benchmarks/_framework.py
+++ b/benchmarks/_framework.py
@@ -26,6 +26,7 @@ from within._within import (
     AdditiveSchwarz,
     ApproxCholConfig,
     ApproxSchurConfig,
+    Schur,
     ReductionStrategy,
     LocalSolverConfig,
 )
@@ -202,13 +203,13 @@ def standard_solver_configs(
     """
     schur = LocalSolverConfig(
         approx_chol=ApproxCholConfig(seed=opts.seed),
-        approx_schur=ApproxSchurConfig(seed=opts.seed),
+        schur=Schur.approximate(ApproxSchurConfig(seed=opts.seed)),
     )
     # "2-2": both densification knobs on — split_merge=2 (AC2 reduced-system
     # factorization) and split=2 (denser Schur clique-tree sampling).
     schur_2_2 = LocalSolverConfig(
         approx_chol=ApproxCholConfig(seed=opts.seed, split_merge=2),
-        approx_schur=ApproxSchurConfig(seed=opts.seed, split=2),
+        schur=Schur.approximate(ApproxSchurConfig(seed=opts.seed, split=2)),
     )
     return [
         SolverConfig(

--- a/benchmarks/suites/ac_comparison.py
+++ b/benchmarks/suites/ac_comparison.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from within._within import (
     ApproxCholConfig,
     ApproxSchurConfig,
+    Schur,
     LocalSolverConfig,
 )
 from .._framework import (
@@ -35,7 +36,7 @@ from .._table import print_pivot, print_table
 def _schur(seed: int, split_merge: int | None) -> LocalSolverConfig:
     return LocalSolverConfig(
         approx_chol=ApproxCholConfig(seed=seed, split_merge=split_merge),
-        approx_schur=ApproxSchurConfig(seed=seed),
+        schur=Schur.approximate(ApproxSchurConfig(seed=seed)),
     )
 
 

--- a/benchmarks/suites/fixest_comparison.py
+++ b/benchmarks/suites/fixest_comparison.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from within._within import (
     ApproxCholConfig,
     ApproxSchurConfig,
+    Schur,
     LocalSolverConfig,
 )
 from .._framework import (
@@ -52,17 +53,17 @@ def run_fixest_comparison(opts: SuiteOptions) -> list[BenchmarkResult]:
 
     exact_schur = LocalSolverConfig(
         approx_chol=ApproxCholConfig(seed=0, split_merge=8),
-        approx_schur=None,
+        schur=Schur.exact(),
     )
     approx_schur = LocalSolverConfig(
         approx_chol=ApproxCholConfig(seed=0, split_merge=8),
-        approx_schur=ApproxSchurConfig(seed=0),
+        schur=Schur.approximate(ApproxSchurConfig(seed=0)),
     )
     # "2-2": both densification knobs on — split_merge=2 (AC2 factorization)
     # and split=2 (denser Schur clique-tree sampling).
     schur_2_2 = LocalSolverConfig(
         approx_chol=ApproxCholConfig(seed=0, split_merge=2),
-        approx_schur=ApproxSchurConfig(seed=0, split=2),
+        schur=Schur.approximate(ApproxSchurConfig(seed=0, split=2)),
     )
 
     solver_configs = [

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -12,7 +12,10 @@ use within::{
 };
 
 use crate::config::{resolve_lsmr_config, resolve_precond_input, PyPreconditioner};
-use crate::convert::{coerce_to_slice, column_refs, extract_columns, value_err, warn_c_contiguous};
+use crate::convert::{
+    coerce_to_slice, column_refs, extract_columns, readonly_f64_1d, readonly_f64_2d,
+    readonly_u32_2d, value_err, warn_c_contiguous,
+};
 use crate::results::{
     emit_build_warnings, run_batch, run_batch_with_warnings, run_solve, run_solve_with_warnings,
     PyBatchSolveResult, PySolveResult,
@@ -60,13 +63,15 @@ fn build_and_solve_batch<'a>(
 pub fn solve<'py>(
     py: Python<'py>,
     design: &Bound<'py, PyAny>,
-    y: PyReadonlyArray1<'py, f64>,
-    weights: Option<PyReadonlyArray1<'py, f64>>,
+    y: &Bound<'py, PyAny>,
+    weights: Option<&Bound<'py, PyAny>>,
     options: Option<&Bound<'py, PyAny>>,
     preconditioner: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<PySolveResult> {
     let params = resolve_lsmr_config(options)?;
     let precond = resolve_precond_input(py, preconditioner)?;
+    let y = readonly_f64_1d("y", y)?;
+    let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
 
     // Borrow the array views while the GIL is held (`PyReadonlyArray` needs the
     // token), but defer slice coercion -- and any copy of strided input -- into
@@ -97,15 +102,17 @@ pub fn solve<'py>(
 pub fn solve_batch<'py>(
     py: Python<'py>,
     design: &Bound<'py, PyAny>,
-    #[allow(non_snake_case)] Y: PyReadonlyArray2<'py, f64>,
-    weights: Option<PyReadonlyArray1<'py, f64>>,
+    #[allow(non_snake_case)] Y: &Bound<'py, PyAny>,
+    weights: Option<&Bound<'py, PyAny>>,
     options: Option<&Bound<'py, PyAny>>,
     preconditioner: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<PyBatchSolveResult> {
     let params = resolve_lsmr_config(options)?;
     let precond = resolve_precond_input(py, preconditioner)?;
+    let y = readonly_f64_2d("Y", Y)?;
+    let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
 
-    let y_arr = Y.as_array();
+    let y_arr = y.as_array();
     let w_view = weights.as_ref().map(|w| w.as_array());
 
     match extract_design(py, design)? {
@@ -213,7 +220,7 @@ enum DesignSource<'py> {
 /// (borrowed) or a list of [`Effect`] terms (cloned out of Python).
 fn extract_design<'py>(py: Python<'_>, design: &Bound<'py, PyAny>) -> PyResult<DesignSource<'py>> {
     if design.downcast::<PyUntypedArray>().is_ok() {
-        let categories = design.extract::<PyReadonlyArray2<u32>>()?;
+        let categories = readonly_u32_2d("design", design)?;
         warn_c_contiguous(py, &categories.as_array())?;
         return Ok(DesignSource::Categories(categories));
     }
@@ -250,9 +257,10 @@ impl PySolver {
     fn new<'py>(
         py: Python<'py>,
         design: &Bound<'py, PyAny>,
-        weights: Option<PyReadonlyArray1<'py, f64>>,
+        weights: Option<&Bound<'py, PyAny>>,
         preconditioner: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Self> {
+        let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
         let weights_vec: Option<Vec<f64>> = weights.as_ref().map(|w| w.as_array().to_vec());
         let precond = resolve_precond_input(py, preconditioner)?;
 
@@ -287,9 +295,10 @@ impl PySolver {
     fn solve_py<'py>(
         &self,
         py: Python<'py>,
-        y: PyReadonlyArray1<'py, f64>,
+        y: &Bound<'py, PyAny>,
         options: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<PySolveResult> {
+        let y = readonly_f64_1d("y", y)?;
         let y_arr = y.as_array();
         let y_cow = coerce_to_slice(&y_arr);
         let params = resolve_lsmr_config(options)?;
@@ -305,10 +314,11 @@ impl PySolver {
     fn solve_batch_py<'py>(
         &self,
         py: Python<'py>,
-        #[allow(non_snake_case)] Y: PyReadonlyArray2<'py, f64>,
+        #[allow(non_snake_case)] Y: &Bound<'py, PyAny>,
         options: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<PyBatchSolveResult> {
-        let y_arr = Y.as_array();
+        let y = readonly_f64_2d("Y", Y)?;
+        let y_arr = y.as_array();
 
         let n_obs = self.solver.n_obs();
         if y_arr.nrows() != n_obs {

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -1,17 +1,55 @@
 //! Free `#[pyfunction]`s exposed via `within._within`: [`solve`] and
 //! [`solve_batch`].
 
+use std::time::Instant;
+
 use numpy::{PyReadonlyArray1, PyReadonlyArray2, PyUntypedArray};
 use pyo3::prelude::*;
 
 use within::{
-    solve as solve_native, solve_batch as solve_batch_native, BuildError, Design, Effect,
-    IntoDesign, SolveResult, Solver, WithinError,
+    BatchSolveResult, BuildError, BuildWarning, Design, Effect, IntoDesign, LsmrOptions,
+    PreconditionerInput, SolveResult, Solver, WithinError,
 };
 
 use crate::config::{resolve_lsmr_config, resolve_precond_input, PyPreconditioner};
 use crate::convert::{coerce_to_slice, column_refs, extract_columns, value_err, warn_c_contiguous};
-use crate::results::{run_batch, run_solve, PyBatchSolveResult, PySolveResult};
+use crate::results::{
+    emit_build_warnings, run_batch, run_batch_with_warnings, run_solve, run_solve_with_warnings,
+    PyBatchSolveResult, PySolveResult,
+};
+
+/// Build a one-shot solver, run the solve (mirroring [`within::solve`]'s
+/// timing), and hand back the build warnings so the caller can re-emit them.
+fn build_and_solve<'a>(
+    design: impl IntoDesign<'a>,
+    y: &[f64],
+    weights: Option<&[f64]>,
+    lsmr: &LsmrOptions,
+    precond: impl Into<PreconditionerInput>,
+) -> Result<(SolveResult, Vec<BuildWarning>), WithinError> {
+    let t_start = Instant::now();
+    let solver = Solver::new(design, weights.map(|w| w.to_vec()), precond)?;
+    let time_setup = t_start.elapsed().as_secs_f64();
+    let mut result = solver.solve(y, lsmr)?;
+    result.time_setup += time_setup;
+    result.time_total = t_start.elapsed().as_secs_f64();
+    Ok((result, solver.warnings().to_vec()))
+}
+
+/// Batch counterpart to [`build_and_solve`], mirroring [`within::solve_batch`].
+fn build_and_solve_batch<'a>(
+    design: impl IntoDesign<'a>,
+    ys: &[&[f64]],
+    weights: Option<&[f64]>,
+    lsmr: &LsmrOptions,
+    precond: impl Into<PreconditionerInput>,
+) -> Result<(BatchSolveResult, Vec<BuildWarning>), WithinError> {
+    let t_start = Instant::now();
+    let solver = Solver::new(design, weights.map(|w| w.to_vec()), precond)?;
+    let mut result = solver.solve_batch(ys, lsmr)?;
+    result.time_total = t_start.elapsed().as_secs_f64();
+    Ok((result, solver.warnings().to_vec()))
+}
 
 // ---------------------------------------------------------------------------
 // Public solve functions
@@ -39,20 +77,18 @@ pub fn solve<'py>(
     match extract_design(py, design)? {
         DesignSource::Categories(categories) => {
             let cats = categories.as_array();
-            run_solve(py, move || -> Result<SolveResult, WithinError> {
+            run_solve_with_warnings(py, move || {
                 let y_cow = coerce_to_slice(&y_arr);
                 let w_cow = w_view.as_ref().map(coerce_to_slice);
-                solve_native(cats, &y_cow, w_cow.as_deref(), &params, precond)
+                build_and_solve(cats, &y_cow, w_cow.as_deref(), &params, precond)
             })
         }
-        DesignSource::Effects(terms) => {
-            run_solve(py, move || -> Result<SolveResult, WithinError> {
-                let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
-                let y_cow = coerce_to_slice(&y_arr);
-                let w_cow = w_view.as_ref().map(coerce_to_slice);
-                solve_native(effects, &y_cow, w_cow.as_deref(), &params, precond)
-            })
-        }
+        DesignSource::Effects(terms) => run_solve_with_warnings(py, move || {
+            let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
+            let y_cow = coerce_to_slice(&y_arr);
+            let w_cow = w_view.as_ref().map(coerce_to_slice);
+            build_and_solve(effects, &y_cow, w_cow.as_deref(), &params, precond)
+        }),
     }
 }
 
@@ -77,23 +113,23 @@ pub fn solve_batch<'py>(
             let cats = categories.as_array();
             warn_c_contiguous(py, &cats)?;
             validate_batch_rows(y_arr.nrows(), cats.nrows())?;
-            run_batch(py, move || -> Result<_, WithinError> {
+            run_batch_with_warnings(py, move || {
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
                 let w_cow = w_view.as_ref().map(coerce_to_slice);
-                solve_batch_native(cats, &col_refs, w_cow.as_deref(), &params, precond)
+                build_and_solve_batch(cats, &col_refs, w_cow.as_deref(), &params, precond)
             })
         }
         DesignSource::Effects(terms) => {
             if let Some(first) = terms.first() {
                 validate_batch_rows(y_arr.nrows(), first.levels.len())?;
             }
-            run_batch(py, move || -> Result<_, WithinError> {
+            run_batch_with_warnings(py, move || {
                 let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
                 let w_cow = w_view.as_ref().map(coerce_to_slice);
-                solve_batch_native(effects, &col_refs, w_cow.as_deref(), &params, precond)
+                build_and_solve_batch(effects, &col_refs, w_cow.as_deref(), &params, precond)
             })
         }
     }
@@ -242,16 +278,7 @@ impl PySolver {
         }
         .map_err(value_err)?;
 
-        for warning in solver.warnings() {
-            let message = std::ffi::CString::new(warning.to_string())
-                .expect("warning messages contain no NUL bytes");
-            PyErr::warn(
-                py,
-                &py.get_type::<pyo3::exceptions::PyUserWarning>(),
-                &message,
-                1,
-            )?;
-        }
+        emit_build_warnings(py, solver.warnings())?;
         Ok(Self { solver })
     }
 

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -18,13 +18,13 @@ use crate::results::{run_batch, run_solve, PyBatchSolveResult, PySolveResult};
 // ---------------------------------------------------------------------------
 
 #[pyfunction]
-#[pyo3(signature = (design, y, options=None, weights=None, preconditioner=None))]
+#[pyo3(signature = (design, y, weights=None, options=None, preconditioner=None))]
 pub fn solve<'py>(
     py: Python<'py>,
     design: &Bound<'py, PyAny>,
     y: PyReadonlyArray1<'py, f64>,
-    options: Option<&Bound<'py, PyAny>>,
     weights: Option<PyReadonlyArray1<'py, f64>>,
+    options: Option<&Bound<'py, PyAny>>,
     preconditioner: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<PySolveResult> {
     let params = resolve_lsmr_config(options)?;
@@ -57,13 +57,13 @@ pub fn solve<'py>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (design, Y, options=None, weights=None, preconditioner=None))]
+#[pyo3(signature = (design, Y, weights=None, options=None, preconditioner=None))]
 pub fn solve_batch<'py>(
     py: Python<'py>,
     design: &Bound<'py, PyAny>,
     #[allow(non_snake_case)] Y: PyReadonlyArray2<'py, f64>,
-    options: Option<&Bound<'py, PyAny>>,
     weights: Option<PyReadonlyArray1<'py, f64>>,
+    options: Option<&Bound<'py, PyAny>>,
     preconditioner: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<PyBatchSolveResult> {
     let params = resolve_lsmr_config(options)?;

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -349,7 +349,7 @@ impl PyPreconditioner {
         self.inner
             .apply(x_slice, &mut y)
             .map_err(|e: within::SolveError| {
-                pyo3::exceptions::PyRuntimeError::new_err(e.to_string())
+                pyo3::exceptions::PyValueError::new_err(e.to_string())
             })?;
         Ok(numpy::PyArray1::from_vec(py, y))
     }

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -9,7 +9,7 @@ use pyo3::prelude::*;
 
 use within::config::{
     ApproxCholConfig, ApproxSchurConfig, LocalSolverConfig, LsmrOptions, PreconditionerConfig,
-    ReductionStrategy, ScalingConfig, ScalingFailure,
+    ReductionStrategy, ScalingConfig, ScalingFailure, SchurMode,
 };
 use within::{Preconditioner, PreconditionerInput};
 
@@ -81,6 +81,55 @@ impl PyApproxSchurConfig {
 /// ``max_sweeps`` budget, and ``on_failure`` disposition (``"warn"`` clamps
 /// residual deficits — preconditioner quality only — and emits a
 /// ``UserWarning``; ``"error"`` fails the build).
+/// Schur-complement reduction mode for `LocalSolverConfig`: approximate (the
+/// library default) or exact. Build via `Schur.approximate(...)` or
+/// `Schur.exact()`.
+#[pyclass(frozen, module = "within._within")]
+#[pyo3(name = "Schur")]
+#[derive(Clone)]
+pub struct PySchur {
+    inner: SchurMode,
+}
+
+#[pymethods]
+impl PySchur {
+    /// Approximate Schur via clique-tree sampling (the library default).
+    /// `config` tunes the sampler; omitted uses the default.
+    #[staticmethod]
+    #[pyo3(signature = (config=None))]
+    fn approximate(py: Python<'_>, config: Option<Py<PyApproxSchurConfig>>) -> Self {
+        let cfg = config
+            .map(|c| c.bind(py).get().to_native())
+            .unwrap_or_default();
+        Self {
+            inner: SchurMode::Approximate(cfg),
+        }
+    }
+
+    /// Exact Schur complement (higher fidelity, slower per subdomain).
+    #[staticmethod]
+    fn exact() -> Self {
+        Self {
+            inner: SchurMode::Exact,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        match &self.inner {
+            SchurMode::Approximate(cfg) => {
+                format!("Schur.approximate(seed={}, split={})", cfg.seed, cfg.split)
+            }
+            SchurMode::Exact => "Schur.exact()".to_string(),
+        }
+    }
+}
+
+impl PySchur {
+    pub(crate) fn to_native(&self) -> SchurMode {
+        self.inner.clone()
+    }
+}
+
 #[pyclass(frozen, module = "within._within")]
 #[pyo3(name = "ScalingConfig")]
 pub struct PyScalingConfig {
@@ -178,13 +227,13 @@ impl PyReductionStrategy {
 // Local solver config (available via `_within` for benchmarks)
 // ---------------------------------------------------------------------------
 
-#[pyclass(frozen, subclass, module = "within._within")]
+#[pyclass(frozen, module = "within._within")]
 #[pyo3(name = "LocalSolverConfig")]
 pub struct PyLocalSolverConfig {
     #[pyo3(get)]
     pub approx_chol: Option<Py<PyApproxCholConfig>>,
     #[pyo3(get)]
-    pub approx_schur: Option<Py<PyApproxSchurConfig>>,
+    pub schur: Option<Py<PySchur>>,
     #[pyo3(get)]
     pub dense_threshold: usize,
     #[pyo3(get)]
@@ -194,16 +243,16 @@ pub struct PyLocalSolverConfig {
 #[pymethods]
 impl PyLocalSolverConfig {
     #[new]
-    #[pyo3(signature = (approx_chol=None, approx_schur=None, dense_threshold=None, scaling=None))]
+    #[pyo3(signature = (approx_chol=None, schur=None, dense_threshold=None, scaling=None))]
     fn new(
         approx_chol: Option<Py<PyApproxCholConfig>>,
-        approx_schur: Option<Py<PyApproxSchurConfig>>,
+        schur: Option<Py<PySchur>>,
         dense_threshold: Option<usize>,
         scaling: Option<Py<PyScalingConfig>>,
     ) -> Self {
         Self {
             approx_chol,
-            approx_schur,
+            schur,
             dense_threshold: dense_threshold
                 .unwrap_or_else(|| LocalSolverConfig::default().dense_threshold),
             scaling,
@@ -428,10 +477,11 @@ fn extract_preconditioner_config(
                     .as_ref()
                     .map(|c| c.bind(py).get().to_native())
                     .unwrap_or_else(|| LocalSolverConfig::default().approx_chol);
-                let approx_schur = sc
-                    .approx_schur
+                let schur = sc
+                    .schur
                     .as_ref()
-                    .map(|c| c.bind(py).get().to_native());
+                    .map(|s| s.bind(py).get().to_native())
+                    .unwrap_or_default();
                 let scaling = sc
                     .scaling
                     .as_ref()
@@ -439,7 +489,7 @@ fn extract_preconditioner_config(
                     .unwrap_or_default();
                 LocalSolverConfig {
                     approx_chol,
-                    approx_schur,
+                    schur,
                     dense_threshold: sc.dense_threshold,
                     scaling,
                 }

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -76,11 +76,6 @@ impl PyApproxSchurConfig {
     }
 }
 
-/// Certification policy for the diagonal scaling of signed (varying-slope)
-/// components: relative ``tolerance`` for weak diagonal dominance, relaxation
-/// ``max_sweeps`` budget, and ``on_failure`` disposition (``"warn"`` clamps
-/// residual deficits — preconditioner quality only — and emits a
-/// ``UserWarning``; ``"error"`` fails the build).
 /// Schur-complement reduction mode for `LocalSolverConfig`: approximate (the
 /// library default) or exact. Build via `Schur.approximate(...)` or
 /// `Schur.exact()`.
@@ -130,6 +125,11 @@ impl PySchur {
     }
 }
 
+/// Certification policy for the diagonal scaling of signed (varying-slope)
+/// components: relative ``tolerance`` for weak diagonal dominance, relaxation
+/// ``max_sweeps`` budget, and ``on_failure`` disposition (``"warn"`` clamps
+/// residual deficits — preconditioner quality only — and emits a
+/// ``UserWarning``; ``"error"`` fails the build).
 #[pyclass(frozen, module = "within._within")]
 #[pyo3(name = "ScalingConfig")]
 pub struct PyScalingConfig {

--- a/crates/within-py/src/convert.rs
+++ b/crates/within-py/src/convert.rs
@@ -3,6 +3,7 @@
 
 use std::borrow::Cow;
 
+use numpy::{PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
 
 // ---------------------------------------------------------------------------
@@ -20,6 +21,45 @@ pub(crate) fn coerce_to_slice<'a>(arr: &'a numpy::ndarray::ArrayView1<'_, f64>) 
 /// Wrap a display-able error as a `PyValueError`.
 pub(crate) fn value_err(e: impl std::fmt::Display) -> PyErr {
     PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string())
+}
+
+/// A `TypeError` naming the dtype an input array must have (and the dtype it
+/// actually had, when the object exposes one) — the opaque PyO3 extraction
+/// failure names neither.
+fn dtype_err(name: &str, expected: &str, obj: &Bound<'_, PyAny>) -> PyErr {
+    let got = obj
+        .getattr("dtype")
+        .and_then(|d| d.str())
+        .and_then(|s| s.extract::<String>())
+        .map(|s| format!(", got dtype {s}"))
+        .unwrap_or_default();
+    PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+        "{name} must be a {expected} array{got}"
+    ))
+}
+
+/// Extract a `float64` 1-D array, or raise a `TypeError` naming the dtype.
+pub(crate) fn readonly_f64_1d<'py>(
+    name: &str,
+    obj: &Bound<'py, PyAny>,
+) -> PyResult<PyReadonlyArray1<'py, f64>> {
+    obj.extract().map_err(|_| dtype_err(name, "float64", obj))
+}
+
+/// Extract a `float64` 2-D array, or raise a `TypeError` naming the dtype.
+pub(crate) fn readonly_f64_2d<'py>(
+    name: &str,
+    obj: &Bound<'py, PyAny>,
+) -> PyResult<PyReadonlyArray2<'py, f64>> {
+    obj.extract().map_err(|_| dtype_err(name, "float64", obj))
+}
+
+/// Extract a `uint32` 2-D array, or raise a `TypeError` naming the dtype.
+pub(crate) fn readonly_u32_2d<'py>(
+    name: &str,
+    obj: &Bound<'py, PyAny>,
+) -> PyResult<PyReadonlyArray2<'py, u32>> {
+    obj.extract().map_err(|_| dtype_err(name, "uint32", obj))
 }
 
 /// Build a slice-of-slices reference view from borrowed-or-owned columns.

--- a/crates/within-py/src/lib.rs
+++ b/crates/within-py/src/lib.rs
@@ -16,7 +16,7 @@ mod results;
 use api::{solve, solve_batch, PyEffect, PySolver};
 use config::{
     PyAdditiveSchwarz, PyApproxCholConfig, PyApproxSchurConfig, PyLocalSolverConfig, PyLsmrOptions,
-    PyPreconditioner, PyPreconditionerConfig, PyReductionStrategy, PyScalingConfig,
+    PyPreconditioner, PyPreconditionerConfig, PyReductionStrategy, PyScalingConfig, PySchur,
 };
 use results::{PyBatchSolveResult, PyCoefficientLayout, PySolveResult, PyUnidentifiedDirection};
 
@@ -38,6 +38,7 @@ fn _within(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyApproxSchurConfig>()?;
     m.add_class::<PyLocalSolverConfig>()?;
     m.add_class::<PyScalingConfig>()?;
+    m.add_class::<PySchur>()?;
     m.add_class::<PyPreconditioner>()?;
     m.add_class::<PySolver>()?;
     m.add_class::<PyEffect>()?;

--- a/crates/within-py/src/results.rs
+++ b/crates/within-py/src/results.rs
@@ -1,11 +1,13 @@
 //! PyO3 result wrapper classes and native-to-Python result conversions.
 
+use std::ffi::CString;
+
 use numpy::ndarray::{Array2, ShapeBuilder};
 use numpy::IntoPyArray;
-use pyo3::exceptions::PyIndexError;
+use pyo3::exceptions::{PyIndexError, PyUserWarning};
 use pyo3::prelude::*;
 
-use within::{BatchSolveResult, CoefficientLayout, SolveResult};
+use within::{BatchSolveResult, BuildWarning, CoefficientLayout, SolveResult};
 
 use crate::convert::value_err;
 
@@ -240,5 +242,42 @@ where
     F: Send + FnOnce() -> Result<BatchSolveResult, E>,
 {
     let result = py.allow_threads(solve).map_err(value_err)?;
+    into_py_batch_result(py, result)
+}
+
+/// Re-emit build-time warnings as Python `UserWarning`s. Shared by the
+/// persistent `Solver` (at construction) and the one-shot `solve` path.
+pub(crate) fn emit_build_warnings(py: Python<'_>, warnings: &[BuildWarning]) -> PyResult<()> {
+    for warning in warnings {
+        let message =
+            CString::new(warning.to_string()).expect("warning messages contain no NUL bytes");
+        PyErr::warn(py, &py.get_type::<PyUserWarning>(), &message, 1)?;
+    }
+    Ok(())
+}
+
+/// [`run_solve`] for the one-shot path: the off-GIL closure also returns the
+/// build warnings collected during construction, which are re-emitted on-GIL.
+pub(crate) fn run_solve_with_warnings<E, F>(py: Python<'_>, solve: F) -> PyResult<PySolveResult>
+where
+    E: std::fmt::Display + Send,
+    F: Send + FnOnce() -> Result<(SolveResult, Vec<BuildWarning>), E>,
+{
+    let (result, warnings) = py.allow_threads(solve).map_err(value_err)?;
+    emit_build_warnings(py, &warnings)?;
+    Ok(into_py_result(py, result))
+}
+
+/// Batch counterpart to [`run_solve_with_warnings`].
+pub(crate) fn run_batch_with_warnings<E, F>(
+    py: Python<'_>,
+    solve: F,
+) -> PyResult<PyBatchSolveResult>
+where
+    E: std::fmt::Display + Send,
+    F: Send + FnOnce() -> Result<(BatchSolveResult, Vec<BuildWarning>), E>,
+{
+    let (result, warnings) = py.allow_threads(solve).map_err(value_err)?;
+    emit_build_warnings(py, &warnings)?;
     into_py_batch_result(py, result)
 }

--- a/crates/within/src/block_elim/solver.rs
+++ b/crates/within/src/block_elim/solver.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use rayon::prelude::*;
 use schwarz_precond::{LocalSolveError, LocalSolver};
 
-use crate::config::LocalSolverConfig;
+use crate::config::{LocalSolverConfig, SchurMode};
 use crate::csr_block::{CsrBlock, PAR_SPMV_THRESHOLD};
 use crate::domain::{
     BlockDiagonals, CoordinateMap, CrossTab, GroundEdges, LocalComponent, SchurReduction,
@@ -189,9 +189,9 @@ fn build_reduced_factor(
     match dense_factor {
         Some(factor) => Ok(factor),
         None => {
-            let schur_csr = match config.approx_schur {
-                Some(cfg) => schur::sampled(elim, &cfg),
-                None => schur::exact_for_factor(elim),
+            let schur_csr = match &config.schur {
+                SchurMode::Approximate(cfg) => schur::sampled(elim, cfg),
+                SchurMode::Exact => schur::exact_for_factor(elim),
             };
             factor_sparse(&schur_csr, config.approx_chol)
         }

--- a/crates/within/src/block_elim/solver/tests.rs
+++ b/crates/within/src/block_elim/solver/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::block_elim::csr_matrix::CsrMatrix;
-use crate::config::ApproxCholConfig;
+use crate::config::{ApproxCholConfig, SchurMode};
 use crate::csr_block::CsrBlock;
 use crate::domain::BlockDiagonals;
 
@@ -58,7 +58,7 @@ fn test_block_elim_solver_eliminate_q_false() {
 
     let config = LocalSolverConfig {
         approx_chol: ApproxCholConfig::default(),
-        approx_schur: None,
+        schur: SchurMode::Exact,
         dense_threshold: 0, // disable dense fast path to ensure sparse path is covered
         scaling: Default::default(),
     };
@@ -97,7 +97,7 @@ fn trivial_singleton_component_solves_r_over_d() {
     // both block orientations.
     let config = LocalSolverConfig {
         approx_chol: ApproxCholConfig::default(),
-        approx_schur: None,
+        schur: SchurMode::Exact,
         dense_threshold: 0,
         scaling: Default::default(),
     };
@@ -136,7 +136,7 @@ fn sampled_sparse_preserves_barely_pd_direction() {
     );
     let config = LocalSolverConfig {
         approx_chol: ApproxCholConfig::default(),
-        approx_schur: Some(crate::config::ApproxSchurConfig::default()),
+        schur: SchurMode::Approximate(crate::config::ApproxSchurConfig::default()),
         dense_threshold: 0,
         scaling: Default::default(),
     };
@@ -224,13 +224,13 @@ fn signed_component_realizes_congruence_transformed_solve() {
         }
     }
 
-    for (label, dense_threshold, approx_schur) in [
-        ("dense full minor", 8, None),
-        ("exact sparse", 0, None),
+    for (label, dense_threshold, schur) in [
+        ("dense full minor", 8, SchurMode::Exact),
+        ("exact sparse", 0, SchurMode::Exact),
         (
             "sampled sparse",
             0,
-            Some(crate::config::ApproxSchurConfig::default()),
+            SchurMode::Approximate(crate::config::ApproxSchurConfig::default()),
         ),
     ] {
         let c = CsrBlock::from_dense_table(&c_raw, n_q, n_r);
@@ -243,7 +243,7 @@ fn signed_component_realizes_congruence_transformed_solve() {
         };
         let config = LocalSolverConfig {
             approx_chol: ApproxCholConfig::default(),
-            approx_schur,
+            schur,
             dense_threshold,
             scaling: Default::default(),
         };
@@ -320,7 +320,7 @@ fn frustrated_component_solves_exactly_through_cover() {
     );
     let config = LocalSolverConfig {
         approx_chol: ApproxCholConfig::default(),
-        approx_schur: None,
+        schur: SchurMode::Exact,
         dense_threshold: 8,
         scaling: Default::default(),
     };

--- a/crates/within/src/config.rs
+++ b/crates/within/src/config.rs
@@ -34,6 +34,26 @@ impl ApproxCholConfig {
 // Local solver configuration
 // ---------------------------------------------------------------------------
 
+/// Schur-complement reduction mode for the local solver.
+///
+/// [`Approximate`](Self::Approximate) (the default) uses clique-tree sampling,
+/// which keeps per-subdomain factorization cost bounded under the iterative
+/// solver. [`Exact`](Self::Exact) forms the exact Schur complement — higher
+/// fidelity, slower per subdomain — for validation and callers who want it.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SchurMode {
+    /// Approximate Schur via clique-tree sampling.
+    Approximate(ApproxSchurConfig),
+    /// Exact Schur complement.
+    Exact,
+}
+
+impl Default for SchurMode {
+    fn default() -> Self {
+        SchurMode::Approximate(ApproxSchurConfig::default())
+    }
+}
+
 /// Local solver configuration for Schwarz subdomains.
 ///
 /// Uses Schur complement reduction: eliminates the larger diagonal block
@@ -42,14 +62,8 @@ impl ApproxCholConfig {
 pub struct LocalSolverConfig {
     /// ApproxChol config for the reduced system.
     pub approx_chol: ApproxCholConfig,
-    /// Approximate Schur complement configuration.
-    ///
-    /// `Some(ApproxSchurConfig::default())` is the library default — approximate
-    /// Schur with clique-tree sampling, which keeps per-subdomain factorization
-    /// cost bounded under the iterative-solver context. `None` requests an
-    /// exact Schur complement, used by tests and by callers who specifically
-    /// want the higher-fidelity factorization.
-    pub approx_schur: Option<ApproxSchurConfig>,
+    /// Schur-complement reduction mode (default: approximate).
+    pub schur: SchurMode,
     /// Dense Schur fast-path threshold on reduced size `n_keep=min(n_q,n_r)`.
     ///
     /// `0` disables the dense fast path; larger values allow dense Cholesky for
@@ -66,7 +80,7 @@ impl Default for LocalSolverConfig {
                 seed: 0,
                 split_merge: Some(2),
             },
-            approx_schur: Some(ApproxSchurConfig::default()),
+            schur: SchurMode::default(),
             dense_threshold: DEFAULT_DENSE_SCHUR_THRESHOLD,
             scaling: ScalingConfig::default(),
         }
@@ -131,7 +145,7 @@ impl Default for ScalingConfig {
 /// copies (each carrying `1/split` of the original weight) before sampling
 /// the clique-tree. This produces a denser Schur approximation at the cost of
 /// more fill-in.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ApproxSchurConfig {
     /// Random seed for the clique-tree sampler.
     pub seed: u64,

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -23,7 +23,10 @@ pub(crate) mod domain;
 pub(crate) mod operator;
 pub(crate) mod solver;
 
-pub use config::{LsmrOptions, PreconditionerConfig, ScalingConfig, ScalingFailure, SchurMode};
+pub use config::{
+    ApproxCholConfig, ApproxSchurConfig, LocalSolverConfig, LsmrOptions, PreconditionerConfig,
+    ReductionStrategy, ScalingConfig, ScalingFailure, SchurMode,
+};
 pub use domain::{Design, Effect};
 pub use error::{BuildError, BuildWarning, SignedPair, SolveError, WithinError};
 pub use operator::schwarz::Preconditioner;

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -23,7 +23,7 @@ pub(crate) mod domain;
 pub(crate) mod operator;
 pub(crate) mod solver;
 
-pub use config::{LsmrOptions, PreconditionerConfig, ScalingConfig, ScalingFailure};
+pub use config::{LsmrOptions, PreconditionerConfig, ScalingConfig, ScalingFailure, SchurMode};
 pub use domain::{Design, Effect};
 pub use error::{BuildError, BuildWarning, SignedPair, SolveError, WithinError};
 pub use operator::schwarz::Preconditioner;

--- a/crates/within/src/operator/tests.rs
+++ b/crates/within/src/operator/tests.rs
@@ -523,7 +523,7 @@ mod schwarz_tests {
     use std::time::{Duration, Instant};
 
     use crate::config::{
-        ApproxCholConfig, ApproxSchurConfig, LocalSolverConfig, ScalingConfig,
+        ApproxCholConfig, ApproxSchurConfig, LocalSolverConfig, ScalingConfig, SchurMode,
         DEFAULT_DENSE_SCHUR_THRESHOLD,
     };
     use schwarz_precond::SubdomainCore;
@@ -630,7 +630,7 @@ mod schwarz_tests {
                 split_merge: Some(8),
                 seed: 42,
             },
-            approx_schur: Some(ApproxSchurConfig {
+            schur: SchurMode::Approximate(ApproxSchurConfig {
                 seed: 7,
                 ..Default::default()
             }),
@@ -745,7 +745,7 @@ mod schwarz_tests {
 
         let config = LocalSolverConfig {
             approx_chol: ApproxCholConfig::default(),
-            approx_schur: None,
+            schur: SchurMode::Exact,
             dense_threshold: DEFAULT_DENSE_SCHUR_THRESHOLD,
             scaling: Default::default(),
         };
@@ -763,7 +763,7 @@ mod schwarz_tests {
 
         let config = LocalSolverConfig {
             approx_chol: ApproxCholConfig::default(),
-            approx_schur: Some(ApproxSchurConfig {
+            schur: SchurMode::Approximate(ApproxSchurConfig {
                 seed: 7,
                 ..Default::default()
             }),
@@ -784,7 +784,7 @@ mod schwarz_tests {
 
         let config = LocalSolverConfig {
             approx_chol: ApproxCholConfig::default(),
-            approx_schur: None,
+            schur: SchurMode::Exact,
             dense_threshold: 0,
             scaling: Default::default(),
         };

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -385,7 +385,13 @@ impl<'a> Solver<'a> {
     }
 
     /// Solve for a single RHS vector with the given LSMR tuning.
-    pub fn solve(&self, y: &[f64], lsmr: &LsmrOptions) -> Result<SolveResult, SolveError> {
+    pub fn solve<'o>(
+        &self,
+        y: &[f64],
+        lsmr: impl Into<Option<&'o LsmrOptions>>,
+    ) -> Result<SolveResult, SolveError> {
+        let default = LsmrOptions::default();
+        let lsmr = lsmr.into().unwrap_or(&default);
         // Guard the silent-truncation hole: weighted_rhs zips y with sqrt-weights,
         // which would otherwise discard trailing values when y.len() > n_rows.
         if y.len() != self.design.n_obs {
@@ -467,12 +473,14 @@ impl<'a> Solver<'a> {
     }
 
     /// Solve for multiple RHS vectors in parallel.
-    pub fn solve_batch(
+    pub fn solve_batch<'o>(
         &self,
         ys: &[&[f64]],
-        lsmr: &LsmrOptions,
+        lsmr: impl Into<Option<&'o LsmrOptions>>,
     ) -> Result<BatchSolveResult, SolveError> {
         let t_start = Instant::now();
+        let default = LsmrOptions::default();
+        let lsmr = lsmr.into().unwrap_or(&default);
         let n_rhs = ys.len();
 
         // Fail fast on the first per-RHS error rather than materializing a
@@ -556,11 +564,11 @@ impl<'a> Solver<'a> {
 /// [`crate::Preconditioner`], or a `&Preconditioner` for amortized reuse.
 ///
 /// This is a convenience wrapper around [`Solver::new`] + [`Solver::solve`].
-pub fn solve<'a>(
+pub fn solve<'a, 'o>(
     design: impl IntoDesign<'a>,
     y: &[f64],
     weights: Option<&[f64]>,
-    lsmr: &LsmrOptions,
+    lsmr: impl Into<Option<&'o LsmrOptions>>,
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<SolveResult, WithinError> {
     let t_start = Instant::now();
@@ -577,11 +585,11 @@ pub fn solve<'a>(
 ///
 /// Same as [`solve`] but solves all RHS vectors in parallel (via rayon),
 /// reusing the preconditioner across all solves.
-pub fn solve_batch<'a>(
+pub fn solve_batch<'a, 'o>(
     design: impl IntoDesign<'a>,
     ys: &[&[f64]],
     weights: Option<&[f64]>,
-    lsmr: &LsmrOptions,
+    lsmr: impl Into<Option<&'o LsmrOptions>>,
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<BatchSolveResult, WithinError> {
     let t_start = Instant::now();

--- a/crates/within/tests/api_pinning.rs
+++ b/crates/within/tests/api_pinning.rs
@@ -93,3 +93,40 @@ fn solver_new_weights_call_shapes_compile() {
     // Owned `Vec<f64>` weights — moved into the solver.
     let _ = Solver::new(categories.view(), Some(w_vec), None).expect("Vec<f64> weights");
 }
+
+#[test]
+fn options_are_optional_and_tuned_additive_builds_from_crate_root() {
+    // A tuned Additive preconditioner is constructible from crate-root imports
+    // alone — no `within::config::` paths — and LSMR options are optional (#105).
+    use within::{
+        ApproxCholConfig, ApproxSchurConfig, LocalSolverConfig, PreconditionerConfig,
+        ReductionStrategy, SchurMode,
+    };
+
+    let categories = cats();
+    let y = vec![0.0; 4];
+    let opts = LsmrOptions::default();
+
+    let tuned = PreconditionerConfig::Additive {
+        local_solver: LocalSolverConfig {
+            approx_chol: ApproxCholConfig::default(),
+            schur: SchurMode::Approximate(ApproxSchurConfig::default()),
+            ..Default::default()
+        },
+        reduction: ReductionStrategy::Auto,
+    };
+    let solver = Solver::new(categories.view(), None, tuned).expect("tuned Additive builds");
+
+    // `None` accepts the default options; `&opts` still works.
+    let _ = solver.solve(&y, None).expect("solve, default options");
+    let _ = solver.solve(&y, &opts).expect("solve, explicit options");
+    let ys: Vec<&[f64]> = vec![&y];
+    let _ = solver
+        .solve_batch(&ys, None)
+        .expect("solve_batch, default options");
+
+    // Free functions accept `None` options too (previously `&LsmrOptions::default()`).
+    let _ = solve(categories.view(), &y, None, None, None).expect("free solve, None options");
+    let _ = solve_batch(categories.view(), &ys, None, None, None)
+        .expect("free solve_batch, None options");
+}

--- a/crates/within/tests/slopes_routing.rs
+++ b/crates/within/tests/slopes_routing.rs
@@ -2,7 +2,7 @@
 //! factors through balanced/scaled signed subdomains, with frustrated
 //! components solving through their Gremban double cover (#62).
 
-use within::{Effect, LsmrOptions, Preconditioner, PreconditionerConfig, Solver};
+use within::{Effect, LsmrOptions, Preconditioner, PreconditionerConfig, SchurMode, Solver};
 
 fn lcg(seed: &mut u64) -> u64 {
     *seed = seed
@@ -205,7 +205,7 @@ fn surplus_component_sampled_matches_exact_reduction() {
     // DGP in lockstep with `positive_slope_only_pair_grounds_beyond_dense_threshold`
     // (src/solver/tests.rs), which pins that this design grounds a surplus-carrying
     // component whose kept side exceeds the dense threshold: the default arm below
-    // exercises the sparse SAMPLED reduction on it; `approx_schur: None` is the
+    // exercises the sparse SAMPLED reduction on it; `SchurMode::Exact` is the
     // exact-reduction reference (#83).
     let n = 8000usize;
     let f: Vec<u32> = (0..n).map(|i| (i % 80) as u32).collect();
@@ -222,14 +222,14 @@ fn surplus_component_sampled_matches_exact_reduction() {
         })
         .collect();
 
-    let solve = |approx_schur| {
+    let solve = |schur: SchurMode| {
         let effects = vec![
             Effect::new(&f, false, [&z[..]]).expect("slope effect"),
             Effect::new(&g, true, []).expect("plain effect"),
         ];
         let config = PreconditionerConfig::Additive {
             local_solver: within::config::LocalSolverConfig {
-                approx_schur,
+                schur,
                 ..Default::default()
             },
             reduction: Default::default(),
@@ -240,8 +240,10 @@ fn surplus_component_sampled_matches_exact_reduction() {
             .expect("solve")
     };
 
-    let sampled = solve(Some(within::config::ApproxSchurConfig::default()));
-    let exact = solve(None);
+    let sampled = solve(SchurMode::Approximate(
+        within::config::ApproxSchurConfig::default(),
+    ));
+    let exact = solve(SchurMode::Exact);
     assert!(sampled.converged, "sampled arm did not converge");
     assert!(exact.converged, "exact arm did not converge");
     assert!(sampled.unidentified.is_empty());

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -7,13 +7,13 @@ Most users should import from ``within`` directly rather than from
 
 import numpy as np
 from numpy.typing import NDArray
-from enum import IntEnum
 
-class PreconditionerConfig(IntEnum):
+class PreconditionerConfig:
     """Preconditioner selection shortcut for the LSMR solver.
 
-    Use the enum variants for defaults, or pass an ``AdditiveSchwarz``
-    instance for fine-grained control.
+    Not an ``Enum``: the members below are class attributes (not iterable, so
+    ``list(PreconditionerConfig)`` raises). Use them for defaults, or pass an
+    ``AdditiveSchwarz`` instance for fine-grained control.
 
     Attributes:
         Additive: Additive Schwarz (default).
@@ -21,12 +21,14 @@ class PreconditionerConfig(IntEnum):
         Diagonal: Diagonal/Jacobi preconditioner.
     """
 
-    Additive = 0
-    Off = 1
-    Diagonal = 2
+    Additive: PreconditionerConfig
+    Off: PreconditionerConfig
+    Diagonal: PreconditionerConfig
 
-class ReductionStrategy(IntEnum):
+class ReductionStrategy:
     """Strategy for combining subdomain contributions in additive Schwarz.
+
+    Not an ``Enum``: the members below are class attributes (not iterable).
 
     Attributes:
         Auto: Let the solver choose based on problem structure (recommended).
@@ -34,9 +36,9 @@ class ReductionStrategy(IntEnum):
         ParallelReduction: Use parallel reduction over subdomain results.
     """
 
-    Auto = 0
-    AtomicScatter = 1
-    ParallelReduction = 2
+    Auto: ReductionStrategy
+    AtomicScatter: ReductionStrategy
+    ParallelReduction: ReductionStrategy
 
 class LsmrOptions:
     """Modified LSMR solver configuration.

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -199,8 +199,8 @@ class Effect:
 def solve(
     design: NDArray[np.uint32] | list[Effect],
     y: NDArray[np.float64],
-    options: LsmrOptions | None = None,
     weights: NDArray[np.float64] | None = None,
+    options: LsmrOptions | None = None,
     preconditioner: (
         PreconditionerConfig | AdditiveSchwarz | Preconditioner | None
     ) = None,
@@ -216,10 +216,10 @@ def solve(
             assignments (F-contiguous for best performance; a ``UserWarning``
             is emitted otherwise), or a list of :class:`Effect` terms.
         y: Response vector, shape ``(n_obs,)``, dtype ``float64``.
-        options: LSMR solver tuning. Pass ``LsmrOptions(...)`` to override
-            defaults. Default: ``LsmrOptions(tol=1e-8, maxiter=1000)``.
         weights: Observation weights, shape ``(n_obs,)``, dtype ``float64``.
             Default: unit weights (unweighted).
+        options: LSMR solver tuning. Pass ``LsmrOptions(...)`` to override
+            defaults. Default: ``LsmrOptions(tol=1e-8, maxiter=1000)``.
         preconditioner: Controls preconditioning. Five input forms are accepted:
             ``None`` (default) builds the additive Schwarz preconditioner with
             default settings. ``PreconditionerConfig.Off`` disables it.
@@ -251,8 +251,8 @@ def solve(
 def solve_batch(
     design: NDArray[np.uint32] | list[Effect],
     Y: NDArray[np.float64],
-    options: LsmrOptions | None = None,
     weights: NDArray[np.float64] | None = None,
+    options: LsmrOptions | None = None,
     preconditioner: (
         PreconditionerConfig | AdditiveSchwarz | Preconditioner | None
     ) = None,
@@ -268,8 +268,8 @@ def solve_batch(
             is emitted otherwise), or a list of :class:`Effect` terms.
         Y: Response matrix, shape ``(n_obs, k)``, dtype ``float64``. Each column
             is a separate response vector.
-        options: LSMR solver tuning. Default: ``LsmrOptions(tol=1e-8, maxiter=1000)``.
         weights: Observation weights. Default: unit weights.
+        options: LSMR solver tuning. Default: ``LsmrOptions(tol=1e-8, maxiter=1000)``.
         preconditioner: Preconditioner configuration; see :func:`solve` for the
             accepted forms.
 

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -357,6 +357,18 @@ class ApproxSchurConfig:
     split: int
     def __init__(self, seed: int = 0, split: int = 1) -> None: ...
 
+class Schur:
+    """Schur-complement reduction mode for :class:`LocalSolverConfig`.
+
+    Omitting ``schur`` on ``LocalSolverConfig`` uses the library default
+    (approximate); use these static constructors to request a specific mode.
+    """
+
+    @staticmethod
+    def approximate(config: ApproxSchurConfig | None = None) -> Schur: ...
+    @staticmethod
+    def exact() -> Schur: ...
+
 class ScalingConfig:
     """Certification policy for the diagonal scaling of signed components.
 
@@ -377,21 +389,18 @@ class ScalingConfig:
 class LocalSolverConfig:
     """Local solver: Schur reduction + approximate Cholesky.
 
-    Note: the Python-level constructor exposed via ``within.config`` uses an
-    explicit default for ``approx_schur`` (the library-default approximate
-    config). The native PyO3 constructor accepts ``None`` as the *explicit*
-    "exact Schur" signal — see ``python/within/config.py`` for the wrapper
-    that injects the default.
+    Omit ``schur`` for the library default (approximate Schur); pass
+    ``Schur.exact()`` for the exact complement.
     """
 
     approx_chol: ApproxCholConfig | None
-    approx_schur: ApproxSchurConfig | None
+    schur: Schur | None
     dense_threshold: int
     scaling: ScalingConfig | None
     def __init__(
         self,
         approx_chol: ApproxCholConfig | None = None,
-        approx_schur: ApproxSchurConfig | None = None,
+        schur: Schur | None = None,
         dense_threshold: int | None = None,
         scaling: ScalingConfig | None = None,
     ) -> None: ...

--- a/python/within/config.py
+++ b/python/within/config.py
@@ -11,74 +11,34 @@ Typical usage::
     from within.config import (
         AdditiveSchwarz,
         ApproxCholConfig,
+        ApproxSchurConfig,
         LocalSolverConfig,
         ReductionStrategy,
+        Schur,
     )
 
     schwarz = AdditiveSchwarz(
         local_solver=LocalSolverConfig(
             approx_chol=ApproxCholConfig(split_merge=2),
+            schur=Schur.approximate(ApproxSchurConfig(split=2)),
         ),
         reduction=ReductionStrategy.Auto,
     )
     result = solve(categories, y, preconditioner=schwarz)
+
+``LocalSolverConfig`` omits ``schur`` for the library default (approximate
+Schur); pass ``Schur.exact()`` for the exact complement.
 """
 
 from within._within import (
     AdditiveSchwarz,
     ApproxCholConfig,
     ApproxSchurConfig,
-    LocalSolverConfig as _NativeLocalSolverConfig,
+    LocalSolverConfig,
     ReductionStrategy,
     ScalingConfig,
+    Schur,
 )
-
-# Module-level constant capturing the library-default approximate Schur config.
-# Used as the kwarg default for `LocalSolverConfig` so that omitting the
-# argument means "library default" while explicitly passing ``approx_schur=None``
-# means "exact Schur" — preserving the Rust ``Option<ApproxSchurConfig>``
-# semantics where ``None`` is exact.
-_DEFAULT_APPROX_SCHUR = ApproxSchurConfig()
-
-
-class LocalSolverConfig(_NativeLocalSolverConfig):
-    """Local solver configuration for Schwarz subdomains (Schur reduction).
-
-    ``approx_schur`` carries three-way semantics:
-
-    - Omitted: use the library default (approximate Schur with clique-tree
-      sampling).
-    - ``None``: request an exact Schur complement (slower per subdomain, used
-      for validation benchmarks).
-    - An ``ApproxSchurConfig(...)`` instance: approximate Schur with custom
-      seed/split.
-    """
-
-    __slots__ = ()  # Mirror the native class's `frozen` semantics — no extra attrs.
-
-    def __new__(
-        cls,
-        approx_chol: ApproxCholConfig | None = None,
-        approx_schur: ApproxSchurConfig | None = _DEFAULT_APPROX_SCHUR,
-        dense_threshold: int | None = None,
-        scaling: ScalingConfig | None = None,
-    ) -> "LocalSolverConfig":
-        return _NativeLocalSolverConfig.__new__(
-            cls,
-            approx_chol=approx_chol,
-            approx_schur=approx_schur,
-            dense_threshold=dense_threshold,
-            scaling=scaling,
-        )
-
-    def __reduce__(self):
-        # Pickle through this Python wrapper (not the native class) so unpickle
-        # goes back through the default-injection logic in ``__new__``.
-        return (
-            LocalSolverConfig,
-            (self.approx_chol, self.approx_schur, self.dense_threshold, self.scaling),
-        )
-
 
 __all__ = [
     "AdditiveSchwarz",
@@ -87,4 +47,5 @@ __all__ = [
     "LocalSolverConfig",
     "ReductionStrategy",
     "ScalingConfig",
+    "Schur",
 ]

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -167,7 +167,7 @@ class TestSolverConfigLimits:
             [rng.integers(0, 50, size=1000), rng.integers(0, 50, size=1000)]
         )
         y = rng.standard_normal(1000)
-        result = solve(cats, y, LsmrOptions(maxiter=1, tol=1e-15))
+        result = solve(cats, y, options=LsmrOptions(maxiter=1, tol=1e-15))
         assert not result.converged
         assert np.all(np.isfinite(result.x))
 
@@ -178,7 +178,7 @@ class TestSolverConfigLimits:
             [rng.integers(0, 50, size=1000), rng.integers(0, 50, size=1000)]
         )
         y = rng.standard_normal(1000)
-        result = solve(cats, y, LsmrOptions(maxiter=2, tol=1e-15))
+        result = solve(cats, y, options=LsmrOptions(maxiter=2, tol=1e-15))
         assert not result.converged
         assert np.all(np.isfinite(result.x))
 
@@ -188,7 +188,7 @@ class TestSolverConfigLimits:
             [np.array([0, 1, 0, 1, 2]), np.array([0, 0, 1, 1, 0])]
         )
         y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-        result = solve(cats, y, LsmrOptions(tol=1e-14))
+        result = solve(cats, y, options=LsmrOptions(tol=1e-14))
         assert np.all(np.isfinite(result.x))
 
     def test_tol_1_converges_immediately(self):
@@ -198,7 +198,7 @@ class TestSolverConfigLimits:
             [rng.integers(0, 20, size=200), rng.integers(0, 20, size=200)]
         )
         y = rng.standard_normal(200)
-        result = solve(cats, y, LsmrOptions(tol=1.0))
+        result = solve(cats, y, options=LsmrOptions(tol=1.0))
         assert result.converged
         assert result.iterations <= 5
 
@@ -209,7 +209,7 @@ class TestSolverConfigLimits:
         )
         y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
         try:
-            result = solve(cats, y, LsmrOptions(tol=0.0))
+            result = solve(cats, y, options=LsmrOptions(tol=0.0))
             assert np.all(np.isfinite(result.x))
         except Exception:
             pass  # raising is also acceptable
@@ -219,7 +219,7 @@ class TestSolverConfigLimits:
         cats = as_solver_categories([np.array([0, 1, 0]), np.array([0, 0, 1])])
         y = np.array([1.0, 2.0, 3.0])
         try:
-            result = solve(cats, y, LsmrOptions(tol=float("nan")))
+            result = solve(cats, y, options=LsmrOptions(tol=float("nan")))
             # If it ran, result should be finite or non-converged
             assert isinstance(result.converged, bool)
         except Exception:

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -35,18 +35,26 @@ class TestErrorHandling:
             solve(cats, y, weights=weights)
 
     def test_wrong_dtype_categories(self):
-        """float64 categories should raise TypeError."""
+        """float64 categories should raise a TypeError naming uint32."""
         cats = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float64, order="F")
         y = np.array([1.0, 2.0])
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="uint32"):
             solve(cats, y)
 
     def test_wrong_dtype_y(self):
-        """int32 y should raise TypeError."""
+        """int32 y should raise a TypeError naming float64."""
         cats = as_solver_categories([np.array([0, 1, 0]), np.array([0, 0, 1])])
         y = np.array([1, 2, 3], dtype=np.int32)
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="float64"):
             solve(cats, y)
+
+    def test_wrong_dtype_weights(self):
+        """float32 weights should raise a TypeError naming float64."""
+        cats = as_solver_categories([np.array([0, 1, 0]), np.array([0, 0, 1])])
+        y = np.array([1.0, 2.0, 3.0])
+        w = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+        with pytest.raises(TypeError, match="float64"):
+            solve(cats, y, weights=w)
 
     def test_1d_categories_raises(self):
         """1-D categories should raise TypeError."""

--- a/tests/test_preconditioner.py
+++ b/tests/test_preconditioner.py
@@ -11,6 +11,7 @@ from within._within import (
     ApproxCholConfig,
     ApproxSchurConfig,
     LocalSolverConfig,
+    Schur,
 )
 
 
@@ -59,6 +60,27 @@ class TestAdvancedConfigs:
     def test_schur_complement_defaults(self):
         sc = LocalSolverConfig()
         assert sc.dense_threshold == 24
+        # Omitted schur means the library default (approximate), not exact.
+        assert sc.schur is None
+
+    def test_schur_mode_spellings(self):
+        # Omission and Schur.approximate() are the default; Schur.exact() is the
+        # explicit opt-in — all three build and solve.
+        rng = np.random.default_rng(7)
+        cats = as_solver_categories(
+            [rng.integers(0, 12, size=600), rng.integers(0, 9, size=600)]
+        )
+        y = rng.standard_normal(600)
+        for schur in (None, Schur.approximate(), Schur.exact()):
+            local = LocalSolverConfig(schur=schur)
+            assert local.schur is schur
+            result = solve(
+                cats,
+                y,
+                LsmrOptions(maxiter=2000),
+                preconditioner=AdditiveSchwarz(local_solver=local),
+            )
+            assert result.converged
 
     def test_schur_complement_solve(self, problem):
         cats, y = problem

--- a/tests/test_preconditioner.py
+++ b/tests/test_preconditioner.py
@@ -77,7 +77,7 @@ class TestAdvancedConfigs:
             result = solve(
                 cats,
                 y,
-                LsmrOptions(maxiter=2000),
+                options=LsmrOptions(maxiter=2000),
                 preconditioner=AdditiveSchwarz(local_solver=local),
             )
             assert result.converged
@@ -87,7 +87,7 @@ class TestAdvancedConfigs:
         result = solve(
             as_solver_categories(cats),
             y,
-            LsmrOptions(),
+            options=LsmrOptions(),
             preconditioner=AdditiveSchwarz(local_solver=LocalSolverConfig()),
         )
         assert result.converged

--- a/tests/test_slopes.py
+++ b/tests/test_slopes.py
@@ -55,7 +55,7 @@ def _assert_matches(res, coef, *, intercepts=True, skip_slopes=()):
 
 def test_single_slope_matches_pyfixest():
     f, z, y = _panel(seed=42)
-    res = within.solve([Effect(f, True, [z])], y, OPTS)
+    res = within.solve([Effect(f, True, [z])], y, options=OPTS)
     assert res.converged
     assert res.unidentified == []
 
@@ -65,7 +65,7 @@ def test_single_slope_matches_pyfixest():
 def test_weighted_single_slope_matches_pyfixest():
     f, z, y = _panel(seed=7)
     w = np.random.default_rng(11).uniform(0.2, 3.0, size=len(y))
-    res = within.solve([Effect(f, True, [z])], y, OPTS, weights=w)
+    res = within.solve([Effect(f, True, [z])], y, options=OPTS, weights=w)
     assert res.converged
 
     _assert_matches(res, _pyfixest_coef(f, z, y, "y ~ C(f) + i(f, z) - 1", w=w))
@@ -73,7 +73,7 @@ def test_weighted_single_slope_matches_pyfixest():
 
 def test_slope_only_term_matches_pyfixest():
     f, z, y = _panel(seed=3)
-    res = within.solve([Effect(f, False, [z])], y, OPTS)
+    res = within.solve([Effect(f, False, [z])], y, options=OPTS)
     assert res.converged
     assert res.unidentified == []
     assert len(res.x) == N_LEVELS
@@ -85,7 +85,7 @@ def test_constant_slope_level_reports_drop_with_exact_zero():
     f, z, y = _panel(seed=5)
     z = z.copy()
     z[f == 1] = 2.5
-    res = within.solve([Effect(f, True, [z])], y, OPTS)
+    res = within.solve([Effect(f, True, [z])], y, options=OPTS)
 
     (u,) = res.unidentified
     assert (u.term, u.level, u.column) == (0, 1, 1)
@@ -131,7 +131,7 @@ def _pyfixest_coef_multi(f, zs, y, w=None):
 def test_three_correlated_weighted_slopes_match_pyfixest():
     f, zs, y = _panel_multi(seed=19, v=3)
     w = np.random.default_rng(29).uniform(0.2, 3.0, size=len(y))
-    res = within.solve([Effect(f, True, zs)], y, OPTS, weights=w)
+    res = within.solve([Effect(f, True, zs)], y, options=OPTS, weights=w)
     assert res.converged
     assert res.unidentified == []
 
@@ -155,7 +155,7 @@ def test_two_factor_slope_matches_pyfixest():
     c = rng.normal(size=2)
     y = a[f] + b[f] * z + c[g] + rng.normal(scale=0.1, size=n)
 
-    res = within.solve([Effect(f, True, [z]), Effect(g, True)], y, OPTS)
+    res = within.solve([Effect(f, True, [z]), Effect(g, True)], y, options=OPTS)
     assert res.converged
     assert res.unidentified == []
 
@@ -188,7 +188,7 @@ def test_unit_trends_time_effects_boundary_matches_pyfixest():
         + rng.normal(scale=0.1, size=n_units * n_times)
     )
 
-    res = within.solve([Effect(unit, True, [t]), Effect(time, True)], y, OPTS)
+    res = within.solve([Effect(unit, True, [t]), Effect(time, True)], y, options=OPTS)
     assert res.converged
     assert res.unidentified == []
 
@@ -226,7 +226,7 @@ def test_frustrated_two_factor_slope_matches_pyfixest():
     c = rng.normal(size=5)
     y = a[f] + b[f] * z + c[g] + rng.normal(scale=0.1, size=n)
 
-    res = within.solve([Effect(f, True, [z]), Effect(g, True)], y, OPTS)
+    res = within.solve([Effect(f, True, [z]), Effect(g, True)], y, options=OPTS)
     assert res.converged
     assert res.unidentified == []
 

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -58,6 +58,20 @@ def test_coefficient_layout_locates_unidentified_and_round_trips():
         layout.address(layout.n_dofs())
 
 
+def test_free_solve_positional_order_is_weights_then_options():
+    # Pins (design, y, weights, options, ...): a weights array 3rd and
+    # LsmrOptions 4th must be accepted. A re-swap would parse the array as
+    # options (and LsmrOptions as weights) and raise.
+    rng = np.random.default_rng(0)
+    cats = as_solver_categories(
+        [rng.integers(0, 8, size=300), rng.integers(0, 6, size=300)]
+    )
+    y = rng.standard_normal(300)
+    w = rng.uniform(0.5, 2.0, size=300)
+    result = solve(cats, y, w, LsmrOptions(maxiter=2000))
+    assert result.converged
+
+
 @pytest.fixture()
 def problem():
     """Two-factor problem with 50 levels each, 10k observations."""
@@ -83,7 +97,7 @@ class TestSolveDefaults:
         result = solve(
             as_solver_categories(cats),
             y,
-            LsmrOptions(),
+            options=LsmrOptions(),
             preconditioner=PreconditionerConfig.Off,
         )
         assert result.converged
@@ -103,7 +117,7 @@ class TestPreconditioners:
         result = solve(
             as_solver_categories(cats),
             y,
-            LsmrOptions(),
+            options=LsmrOptions(),
             preconditioner=PreconditionerConfig.Additive,
         )
         assert result.converged
@@ -114,7 +128,7 @@ class TestPreconditioners:
         result = solve(
             as_solver_categories(cats),
             y,
-            LsmrOptions(),
+            options=LsmrOptions(),
             preconditioner=AdditiveSchwarz(),
         )
         assert result.converged
@@ -128,7 +142,7 @@ class TestPreconditioners:
         result = solve(
             categories,
             y,
-            LsmrOptions(maxiter=2000),
+            options=LsmrOptions(maxiter=2000),
             preconditioner=PreconditionerConfig.Diagonal,
         )
         assert result.converged

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -15,7 +15,7 @@ from within import (
     Solver,
     solve,
 )
-from within.config import AdditiveSchwarz
+from within.config import AdditiveSchwarz, LocalSolverConfig, ScalingConfig
 
 from conftest import generate_synthetic_data
 
@@ -70,6 +70,38 @@ def test_free_solve_positional_order_is_weights_then_options():
     w = rng.uniform(0.5, 2.0, size=300)
     result = solve(cats, y, w, LsmrOptions(maxiter=2000))
     assert result.converged
+
+
+def test_one_shot_solve_surfaces_build_warnings():
+    # A frustrated slope design with scaling certification disabled emits a
+    # build warning; the one-shot solve/solve_batch must re-emit it, matching
+    # the persistent Solver (#103).
+    f = np.array([0, 0, 0, 1, 1, 1], np.uint32)
+    g = np.array([0, 1, 2, 0, 1, 2], np.uint32)
+    z = np.array([-2.0, 1.0, 1.0, -1.0, -1.0, 2.0])
+    y = np.array([1.0, -2.0, 0.5, 3.0, -1.5, 2.5])
+    from within import solve_batch
+
+    design = [Effect(f, True, [z]), Effect(g, True)]
+    precond = AdditiveSchwarz(
+        local_solver=LocalSolverConfig(scaling=ScalingConfig(max_sweeps=0))
+    )
+
+    def user_warnings(call):
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            call()
+        return [str(w.message) for w in record if issubclass(w.category, UserWarning)]
+
+    persistent = user_warnings(lambda: Solver(design, preconditioner=precond))
+    assert persistent, "fixture should emit a build warning"
+    assert user_warnings(lambda: solve(design, y, preconditioner=precond)) == persistent
+    assert (
+        user_warnings(
+            lambda: solve_batch(design, np.column_stack([y, y]), preconditioner=precond)
+        )
+        == persistent
+    )
 
 
 @pytest.fixture()


### PR DESCRIPTION
Resolves #100, #101, #102, #103, #104, #105 (close manually on merge).

Supersedes #108, which GitHub auto-closed when its stacked base branch (`slopes/99-coeff-layout`) was deleted on #107's merge. Same six commits, rebased onto `feature/slopes`.

The pre-merge API battle-check fallout, done as one sweep because the items interleave on the same files (`api.rs`, `_within.pyi`, `LocalSolverConfig`):

- **#104** — `LocalSolverConfig.approx_schur: Option<_>` (where `None` meant *exact*) → a `SchurMode` enum (Rust) / `Schur.approximate(...)` / `Schur.exact()` (Python). Omitted/`None` now uniformly means the library default. Removes the `within.config.LocalSolverConfig` compat subclass. **Breaking.**
- **#105** — LSMR options are optional (`None` → default) on `solve`/`solve_batch`/`Solver::solve`; crate root re-exports `LocalSolverConfig`/`ReductionStrategy`/`ApproxCholConfig`/`ApproxSchurConfig`; `Preconditioner.apply` maps solve errors to `ValueError` like the solve paths.
- **#101** — Python free `solve`/`solve_batch` take `weights` before `options`, matching `Solver` + the Rust core. **Breaking** (positional `options` callers).
- **#103** — one-shot `solve`/`solve_batch` re-emit build warnings as `UserWarning`s, matching the persistent `Solver`.
- **#100** — wrong-dtype inputs raise a `TypeError` naming the expected dtype (and the one received).
- **#102** — corrected README + type stubs (`PreconditionerConfig`/`ReductionStrategy` are not `IntEnum`; current arg order and `Schur`/`split_merge` spellings; varying-slopes example; minimal-norm normalization documented).

Full Rust workspace + 119 Python tests green; clippy clean. New tests pin each behavior.
