### PR TITLE
fix(schwarz-precond): tolerate rounding-scale negative vp in MLSMR

### DIFF
--- a/crates/schwarz-precond/src/lsmr/bidiag.rs
+++ b/crates/schwarz-precond/src/lsmr/bidiag.rs
@@ -97,6 +97,33 @@ fn par_dot(a: &[f64], b: &[f64]) -> f64 {
     }
 }
 
+/// Relative floor separating a rounding-scale negative `⟨v, p̃⟩` (near a lucky
+/// breakdown) from a genuinely indefinite preconditioner. `√ε`: loose enough to
+/// absorb accumulated rounding across the recurrence, yet — being relative to
+/// `‖v‖‖p̃‖` — orders of magnitude below the `≈ 1` relative magnitude an
+/// indefinite `M` produces at any eigenvalue scale.
+const MLSMR_INDEFINITE_REL_TOL: f64 = 1.4901161193847656e-8; // f64::EPSILON.sqrt()
+
+/// `α = √⟨v, p̃⟩` with a near-breakdown guard. `⟨v, p̃⟩ = ‖v‖²_M ≥ 0` for an SPD
+/// preconditioner; a negative within [`MLSMR_INDEFINITE_REL_TOL`]`·‖v‖‖p̃‖` is a
+/// rounding artifact of an essentially-converged step and is clamped to `α = 0`
+/// (breakdown). Only a more negative value — a genuinely non-positive-definite
+/// preconditioner, which would otherwise yield a silent premature "converged"
+/// at the wrong solution — is rejected.
+fn alpha_from_vp(v: &[f64], p_tilde: &[f64]) -> Result<f64, SolveError> {
+    let vp = par_dot(v, p_tilde);
+    if vp < 0.0 {
+        let bound = MLSMR_INDEFINITE_REL_TOL * (par_dot(v, v) * par_dot(p_tilde, p_tilde)).sqrt();
+        if vp < -bound {
+            return Err(SolveError::InvalidInput {
+                context: "mlsmr",
+                message: "preconditioner not positive definite (⟨v, Mv⟩ < 0)".to_string(),
+            });
+        }
+    }
+    Ok(vp.max(0.0).sqrt())
+}
+
 /// Windowed ring of recent basis vectors for local (windowed) modified
 /// Gram-Schmidt reorthogonalization.
 ///
@@ -487,17 +514,8 @@ impl<'a, A: Operator + ?Sized, M: Operator + ?Sized> ModifiedGolubKahan<'a, A, M
         // ṽ₁ = M⁻¹ p̃
         preconditioner.apply(&bufs.p_tilde, &mut bufs.v)?;
 
-        // α₁ = √⟨ṽ₁, p̃⟩ via the M-norm dot product trick. vp == 0 is a clean
-        // breakdown; vp < 0 means a non-positive-definite preconditioner and
-        // must be rejected rather than silently yielding α₁ = 0.
-        let vp = par_dot(&bufs.v, &bufs.p_tilde);
-        if vp < 0.0 {
-            return Err(SolveError::InvalidInput {
-                context: "mlsmr",
-                message: "preconditioner not positive definite (⟨v, Mv⟩ < 0)".to_string(),
-            });
-        }
-        let alpha = vp.sqrt();
+        // α₁ = √⟨ṽ₁, p̃⟩ via the M-norm dot product trick.
+        let alpha = alpha_from_vp(&bufs.v, &bufs.p_tilde)?;
 
         // Normalize v; leave p_tilde at α₁·p̃_norm.
         if alpha > 0.0 {
@@ -564,17 +582,7 @@ impl<'a, A: Operator + ?Sized, M: Operator + ?Sized> ModifiedGolubKahan<'a, A, M
             reorth.reorthogonalize(&mut self.bufs.v, &mut self.bufs.p_tilde);
         }
 
-        let vp = par_dot(&self.bufs.v, &self.bufs.p_tilde);
-        // vp = ⟨v, M v⟩. vp == 0 is a clean (lucky) breakdown; vp < 0 means
-        // the preconditioner is not positive definite, which would otherwise
-        // produce a silent premature "converged" at the wrong solution.
-        if vp < 0.0 {
-            return Err(SolveError::InvalidInput {
-                context: "mlsmr",
-                message: "preconditioner not positive definite (⟨v, Mv⟩ < 0)".to_string(),
-            });
-        }
-        let alpha_new = vp.sqrt();
+        let alpha_new = alpha_from_vp(&self.bufs.v, &self.bufs.p_tilde)?;
 
         if alpha_new > 0.0 {
             scale_in_place(&mut self.bufs.v, 1.0 / alpha_new);

--- a/crates/schwarz-precond/src/lsmr/bidiag.rs
+++ b/crates/schwarz-precond/src/lsmr/bidiag.rs
@@ -97,23 +97,13 @@ fn par_dot(a: &[f64], b: &[f64]) -> f64 {
     }
 }
 
-/// Relative floor separating a rounding-scale negative `⟨v, p̃⟩` (near a lucky
-/// breakdown) from a genuinely indefinite preconditioner. `√ε`: loose enough to
-/// absorb accumulated rounding across the recurrence, yet — being relative to
-/// `‖v‖‖p̃‖` — orders of magnitude below the `≈ 1` relative magnitude an
-/// indefinite `M` produces at any eigenvalue scale.
-const MLSMR_INDEFINITE_REL_TOL: f64 = 1.4901161193847656e-8; // f64::EPSILON.sqrt()
-
-/// `α = √⟨v, p̃⟩` with a near-breakdown guard. `⟨v, p̃⟩ = ‖v‖²_M ≥ 0` for an SPD
-/// preconditioner; a negative within [`MLSMR_INDEFINITE_REL_TOL`]`·‖v‖‖p̃‖` is a
-/// rounding artifact of an essentially-converged step and is clamped to `α = 0`
-/// (breakdown). Only a more negative value — a genuinely non-positive-definite
-/// preconditioner, which would otherwise yield a silent premature "converged"
-/// at the wrong solution — is rejected.
+/// `α = √⟨v, p̃⟩`. A near-breakdown negative `vp` (exact `‖v‖²_M ≥ 0` rounded
+/// below 0) within the relative floor `√ε·‖v‖‖p̃‖` clamps to `α = 0`; a genuinely
+/// indefinite preconditioner raises.
 fn alpha_from_vp(v: &[f64], p_tilde: &[f64]) -> Result<f64, SolveError> {
     let vp = par_dot(v, p_tilde);
     if vp < 0.0 {
-        let bound = MLSMR_INDEFINITE_REL_TOL * (par_dot(v, v) * par_dot(p_tilde, p_tilde)).sqrt();
+        let bound = f64::EPSILON.sqrt() * (par_dot(v, v) * par_dot(p_tilde, p_tilde)).sqrt();
         if vp < -bound {
             return Err(SolveError::InvalidInput {
                 context: "mlsmr",

--- a/crates/schwarz-precond/src/lsmr/tests.rs
+++ b/crates/schwarz-precond/src/lsmr/tests.rs
@@ -713,3 +713,75 @@ fn test_mlsmr_rejects_bad_preconditioner_shape() {
     let result = mlsmr(&OverdeterminedOp, &b, &BadPrecond, 1e-10, 100, None);
     assert!(matches!(result, Err(SolveError::InvalidInput { .. })));
 }
+
+/// Near a lucky breakdown `p̃ ≈ 0`, `vp = ⟨v, p̃⟩` (mathematically `≥ 0`) can
+/// come out slightly negative from rounding. A value well inside the relative
+/// tolerance must be treated as an `α = 0` breakdown, not rejected as an
+/// indefinite preconditioner. Regression for the old strict `vp < 0.0` abort.
+#[test]
+fn test_mlsmr_near_breakdown_vp_clamps_to_zero() {
+    // M⁻¹ maps p̃ to (perp(p̃) − 1e-10·p̃): the perpendicular part cancels in
+    // ⟨v, p̃⟩, leaving vp ≈ −1e-10·‖p̃‖² — negative, but ~8 orders inside the
+    // √ε·‖v‖‖p̃‖ floor, so it must clamp rather than raise.
+    struct NearBreakdownPrecond;
+    impl Operator for NearBreakdownPrecond {
+        fn nrows(&self) -> usize {
+            2
+        }
+        fn ncols(&self) -> usize {
+            2
+        }
+        fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), SolveError> {
+            y[0] = -x[1] - 1e-10 * x[0];
+            y[1] = x[0] - 1e-10 * x[1];
+            Ok(())
+        }
+        fn apply_adjoint(&self, x: &[f64], y: &mut [f64]) -> Result<(), SolveError> {
+            self.apply(x, y)
+        }
+    }
+
+    let b = vec![3.0, 4.0];
+    let result = mlsmr(
+        &IdentityOp { n: 2 },
+        &b,
+        &NearBreakdownPrecond,
+        1e-10,
+        100,
+        None,
+    );
+    assert!(
+        result.is_ok(),
+        "rounding-scale negative vp must clamp to breakdown, got err {:?}",
+        result.err()
+    );
+}
+
+/// A genuinely indefinite preconditioner (`M⁻¹ = −I` ⇒ `vp = −‖p̃‖²`, relative
+/// magnitude 1) must still be rejected — the clamp only ever absorbs a
+/// negligible negative direction, never a real loss of positive-definiteness.
+#[test]
+fn test_mlsmr_rejects_indefinite_preconditioner() {
+    struct NegIdentity;
+    impl Operator for NegIdentity {
+        fn nrows(&self) -> usize {
+            2
+        }
+        fn ncols(&self) -> usize {
+            2
+        }
+        fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), SolveError> {
+            for (yi, &xi) in y.iter_mut().zip(x) {
+                *yi = -xi;
+            }
+            Ok(())
+        }
+        fn apply_adjoint(&self, x: &[f64], y: &mut [f64]) -> Result<(), SolveError> {
+            self.apply(x, y)
+        }
+    }
+
+    let b = vec![3.0, 4.0];
+    let result = mlsmr(&IdentityOp { n: 2 }, &b, &NegIdentity, 1e-10, 100, None);
+    assert!(matches!(result, Err(SolveError::InvalidInput { .. })));
+}


### PR DESCRIPTION
Closes #109.

Near a lucky breakdown (`p̃ ≈ 0`), MLSMR's `vp = ⟨v, p̃⟩` — the M-norm that is `≥ 0` in exact arithmetic — can round slightly negative, and the strict `vp < 0.0` test aborted an essentially-converged solve as a non-positive-definite preconditioner.

Both bidiagonalization sites now route through a shared `alpha_from_vp`: a negative within `√ε·‖v‖‖p̃‖` clamps to an `α = 0` breakdown; only a more negative value (genuinely indefinite `M`) is rejected. The bound is relative, so it detects indefiniteness at any eigenvalue scale, and the extra norms run only on the rare `vp < 0` branch — the hot loop is unchanged.

Two regression tests through the public `mlsmr` API: a rounding-scale negative clamps (fails on the old code), a genuinely indefinite `M⁻¹ = −I` still raises.