### PR TITLE
perf(within): resolve design terms inline, not per-matvec allocation

### DIFF
--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use portable_atomic::AtomicF64;
 use schwarz_precond::Operator;
 
-use crate::domain::{Design, TermMeta};
+use crate::domain::Design;
 
 mod gather;
 mod scatter;
@@ -13,30 +13,6 @@ use scatter::scatter_apply;
 
 /// Minimum number of rows before scatter/gather loops are parallelized.
 const PAR_THRESHOLD: usize = 10_000;
-
-/// A [`TermMeta`] with its frame columns resolved into borrows for the kernels.
-struct ResolvedTerm<'a> {
-    meta: &'a TermMeta,
-    levels: &'a [u32],
-    zs: Vec<&'a [f64]>,
-}
-
-fn resolve_terms<'a>(design: &'a Design<'_>) -> Vec<ResolvedTerm<'a>> {
-    design
-        .terms
-        .iter()
-        .enumerate()
-        .map(|(q, t)| ResolvedTerm {
-            meta: t,
-            levels: design.frame.level_column(q),
-            zs: t
-                .slopes
-                .iter()
-                .map(|&c| design.frame.loading_column(c))
-                .collect(),
-        })
-        .collect()
-}
 
 // ===========================================================================
 // DesignOperator — D, optionally rescaled by W^{1/2}

--- a/crates/within/src/operator/design/gather.rs
+++ b/crates/within/src/operator/design/gather.rs
@@ -2,7 +2,7 @@
 
 use rayon::prelude::*;
 
-use super::{resolve_terms, ResolvedTerm, PAR_THRESHOLD};
+use super::PAR_THRESHOLD;
 use crate::domain::Design;
 
 /// Gather-apply: `dst[i] = Σ_t Σ_c src[off_t + c·L_t + level(i,t)] · loading_c(i)`,
@@ -19,10 +19,45 @@ pub(crate) fn gather_apply(
 
     dst.fill(0.0);
 
-    let terms = resolve_terms(design);
+    let frame = &design.frame;
     for_each_chunk(dst, |chunk, row_start| {
-        for t in &terms {
-            apply_term(t, src, chunk, row_start);
+        for (q, t) in design.terms.iter().enumerate() {
+            let (offset, n_levels) = (t.offset, t.n_levels);
+            let levels = frame.level_column(q);
+            let col = |c: usize| &src[offset + c * n_levels..offset + (c + 1) * n_levels];
+            match (t.intercept, t.slopes.as_slice()) {
+                (true, []) => gather_term(chunk, row_start, levels, [col(0)], |_| [1.0]),
+                (true, &[c0]) => {
+                    let z0 = frame.loading_column(c0);
+                    gather_term(chunk, row_start, levels, [col(0), col(1)], |i| [1.0, z0[i]])
+                }
+                (true, &[c0, c1]) => {
+                    let z0 = frame.loading_column(c0);
+                    let z1 = frame.loading_column(c1);
+                    gather_term(chunk, row_start, levels, [col(0), col(1), col(2)], |i| {
+                        [1.0, z0[i], z1[i]]
+                    })
+                }
+                (false, &[c0]) => {
+                    let z0 = frame.loading_column(c0);
+                    gather_term(chunk, row_start, levels, [col(0)], |i| [z0[i]])
+                }
+                (intercept, slope_cols) => {
+                    // Cold path: a dynamic slope count can't monomorphize a
+                    // fixed-arity `gather_term`, so accumulate by hand.
+                    let zoff = usize::from(intercept);
+                    for (local, dst_val) in chunk.iter_mut().enumerate() {
+                        let i = row_start + local;
+                        let lev = levels[i] as usize;
+                        let mut acc = if intercept { src[offset + lev] } else { 0.0 };
+                        for (v, &c) in slope_cols.iter().enumerate() {
+                            acc += src[offset + (zoff + v) * n_levels + lev]
+                                * frame.loading_column(c)[i];
+                        }
+                        *dst_val += acc;
+                    }
+                }
+            }
         }
         if let Some(scale) = scale {
             for (s, dst_val) in scale[row_start..].iter().zip(chunk.iter_mut()) {
@@ -43,35 +78,6 @@ fn for_each_chunk(dst: &mut [f64], kernel: impl Fn(&mut [f64], usize) + Sync) {
             .for_each(|(chunk_idx, chunk)| kernel(chunk, chunk_idx * CHUNK_SIZE));
     } else {
         kernel(dst, 0);
-    }
-}
-
-/// One term's contribution to a chunk of rows: dispatch the term's shape to a
-/// monomorphized sweep.
-fn apply_term(t: &ResolvedTerm<'_>, src: &[f64], chunk: &mut [f64], row_start: usize) {
-    let offset = t.meta.offset;
-    let n_levels = t.meta.n_levels;
-    let levels = t.levels;
-    let col = |c: usize| &src[offset + c * n_levels..offset + (c + 1) * n_levels];
-    match (t.meta.intercept, t.zs.as_slice()) {
-        (true, []) => gather_term(chunk, row_start, levels, [col(0)], |_| [1.0]),
-        (true, &[z0]) => gather_term(chunk, row_start, levels, [col(0), col(1)], |i| [1.0, z0[i]]),
-        (true, &[z0, z1]) => gather_term(chunk, row_start, levels, [col(0), col(1), col(2)], |i| {
-            [1.0, z0[i], z1[i]]
-        }),
-        (false, &[z0]) => gather_term(chunk, row_start, levels, [col(0)], |i| [z0[i]]),
-        (intercept, zs) => {
-            let zoff = usize::from(intercept);
-            for (local, dst_val) in chunk.iter_mut().enumerate() {
-                let i = row_start + local;
-                let lev = levels[i] as usize;
-                let mut acc = if intercept { src[offset + lev] } else { 0.0 };
-                for (v, z) in zs.iter().enumerate() {
-                    acc += src[offset + (zoff + v) * n_levels + lev] * z[i];
-                }
-                *dst_val += acc;
-            }
-        }
     }
 }
 

--- a/crates/within/src/operator/design/scatter.rs
+++ b/crates/within/src/operator/design/scatter.rs
@@ -6,8 +6,8 @@ use std::sync::atomic::Ordering;
 use portable_atomic::AtomicF64;
 use rayon::prelude::*;
 
-use super::{resolve_terms, ResolvedTerm, PAR_THRESHOLD};
-use crate::domain::Design;
+use super::PAR_THRESHOLD;
+use crate::domain::{Design, TermMeta};
 
 /// Adjoint scatter over all terms; `base(i)` is the row value (`x[i]`, or
 /// `sw[i]·x[i]` when weighted) that each column scales by its loading.
@@ -19,30 +19,47 @@ pub(super) fn scatter_apply(
 ) {
     debug_assert_eq!(dst.len(), design.n_dofs);
     let parallel = design.n_obs > PAR_THRESHOLD;
+    let frame = &design.frame;
 
-    for t in resolve_terms(design) {
-        let n_levels = t.meta.n_levels;
-        let block = &mut dst[t.meta.offset..t.meta.offset + t.meta.n_dofs()];
-        match (t.meta.intercept, t.zs.as_slice()) {
-            (true, []) => scatter_term::<1>(block, &t, parallel, scratch, |i| [base(i)]),
-            (true, &[z0]) => scatter_term::<2>(block, &t, parallel, scratch, |i| {
-                let b = base(i);
-                [b, z0[i] * b]
-            }),
-            (true, &[z0, z1]) => scatter_term::<3>(block, &t, parallel, scratch, |i| {
-                let b = base(i);
-                [b, z0[i] * b, z1[i] * b]
-            }),
-            (intercept, zs) => {
+    for (q, t) in design.terms.iter().enumerate() {
+        let levels = frame.level_column(q);
+        let block = &mut dst[t.offset..t.offset + t.n_dofs()];
+        match (t.intercept, t.slopes.as_slice()) {
+            (true, []) => scatter_term::<1>(block, t, levels, parallel, scratch, |i| [base(i)]),
+            (true, &[c0]) => {
+                let z0 = frame.loading_column(c0);
+                scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
+                    let b = base(i);
+                    [b, z0[i] * b]
+                })
+            }
+            (true, &[c0, c1]) => {
+                let z0 = frame.loading_column(c0);
+                let z1 = frame.loading_column(c1);
+                scatter_term::<3>(block, t, levels, parallel, scratch, |i| {
+                    let b = base(i);
+                    [b, z0[i] * b, z1[i] * b]
+                })
+            }
+            (intercept, slope_cols) => {
                 let zoff = usize::from(intercept);
                 if intercept {
-                    scatter_term::<1>(&mut block[..n_levels], &t, parallel, scratch, |i| [base(i)]);
-                }
-                for (v, &z) in zs.iter().enumerate() {
-                    let start = (zoff + v) * n_levels;
                     scatter_term::<1>(
-                        &mut block[start..start + n_levels],
-                        &t,
+                        &mut block[..t.n_levels],
+                        t,
+                        levels,
+                        parallel,
+                        scratch,
+                        |i| [base(i)],
+                    );
+                }
+                for (v, &c) in slope_cols.iter().enumerate() {
+                    let z = frame.loading_column(c);
+                    let start = (zoff + v) * t.n_levels;
+                    scatter_term::<1>(
+                        &mut block[start..start + t.n_levels],
+                        t,
+                        levels,
                         parallel,
                         scratch,
                         move |i| [z[i] * base(i)],
@@ -56,22 +73,20 @@ pub(super) fn scatter_apply(
 /// Scatter one term's coefficient block: `block[c·L + level(i)] += values(i)[c]`.
 fn scatter_term<const C: usize>(
     block: &mut [f64],
-    term: &ResolvedTerm<'_>,
+    meta: &TermMeta,
+    levels: &[u32],
     parallel: bool,
     scratch: &[AtomicF64],
     values: impl Fn(usize) -> [f64; C] + Sync,
 ) {
-    debug_assert_eq!(block.len(), C * term.meta.n_levels);
-    match ScatterStrategy::pick(parallel, C * term.meta.n_levels, term.meta.sorted) {
-        ScatterStrategy::Sequential => {
-            scatter_sequential::<C>(block, term.meta.n_levels, term.levels, &values)
-        }
-        ScatterStrategy::Fold => scatter_fold::<C>(block, term.meta.n_levels, term.levels, &values),
-        ScatterStrategy::Atomic => {
-            scatter_atomic::<C>(block, term.meta.n_levels, term.levels, &values, scratch)
-        }
+    let n_levels = meta.n_levels;
+    debug_assert_eq!(block.len(), C * n_levels);
+    match ScatterStrategy::pick(parallel, C * n_levels, meta.sorted) {
+        ScatterStrategy::Sequential => scatter_sequential::<C>(block, n_levels, levels, &values),
+        ScatterStrategy::Fold => scatter_fold::<C>(block, n_levels, levels, &values),
+        ScatterStrategy::Atomic => scatter_atomic::<C>(block, n_levels, levels, &values, scratch),
         ScatterStrategy::SortedCoalesced => {
-            scatter_sorted_coalesced::<C>(block, term.meta.n_levels, term.levels, &values, scratch)
+            scatter_sorted_coalesced::<C>(block, n_levels, levels, &values, scratch)
         }
     }
 }


### PR DESCRIPTION
Closes #115.

`resolve_terms` rebuilt a `Vec<ResolvedTerm>` (plus an inner `Vec<&[f64]>` per slope-bearing term) on every `apply`/`apply_adjoint` — two heap allocations per LSMR iteration on the solver hot path. The `level_column`/`loading_column` lookups it bundled are O(1) borrows, so the kernels now iterate `design.terms` directly and bind them inline in the arity `match` arms. `ResolvedTerm`/`resolve_terms` are deleted.

Result: `apply`/`apply_adjoint` allocate nothing for term resolution on every realistic design (only gather's cold ≥3-column arm still collects).

Verification: per-iteration allocation rate **2.0 → 0.0** (before/after, clean serial no-preconditioner path); Rust suite + clippy green; solve output bit-identical; hot loop unchanged (~0.049 s/solve at 1M×3FE).

Profiling up front confirmed this is a **hygiene** change, not a speedup: those allocations were 0.000% of hot-loop time (all matvec-path allocation samples across a 36k-sample profile: zero). It restores the "matvec allocates nothing" invariant that `sqrt_weights`/`scatter_scratch` already followed.