### PR TITLE
test: prune weak-oracle duplication across the three test layers

### DIFF
--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -5,6 +5,10 @@ use schwarz_precond::SolveError;
 use within::observation::ObservationFrame;
 use within::{solve, BuildError, Design, LsmrOptions, PreconditionerConfig, Solver, WithinError};
 
+// Behavior: a malformed input produces the right typed error. The Display /
+// source() / From plumbing is covered by a single wiring check per enum below,
+// not by pinning every message string.
+
 #[test]
 fn test_empty_observations_error() {
     // A zero-row frame is valid; EmptyObservations is raised by Design::from_frame.
@@ -66,173 +70,6 @@ fn test_empty_categories_via_solve() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Display tests for BuildError variants
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_build_error_display_empty_observations() {
-    let e = BuildError::EmptyObservations;
-    assert_eq!(e.to_string(), "no observations provided");
-}
-
-#[test]
-fn test_build_error_display_observation_count_mismatch() {
-    let e = BuildError::ObservationCountMismatch {
-        column: 1,
-        expected: 10,
-        got: 5,
-    };
-    let s = e.to_string();
-    assert!(s.contains("column 1"));
-    assert!(s.contains("5"));
-    assert!(s.contains("10"));
-}
-
-#[test]
-fn test_build_error_display_weight_count_mismatch() {
-    let e = BuildError::WeightCountMismatch {
-        expected: 10,
-        got: 5,
-    };
-    let s = e.to_string();
-    assert!(s.contains("5"));
-    assert!(s.contains("10"));
-}
-
-#[test]
-fn test_build_error_display_singular_diagonal() {
-    let e = BuildError::SingularDiagonal {
-        block: "test_block",
-        index: 42,
-    };
-    let s = e.to_string();
-    assert!(s.contains("test_block"));
-    assert!(s.contains("42"));
-}
-
-#[test]
-fn test_build_error_display_local_solver_build() {
-    let e = BuildError::LocalSolverBuild("factorization failed".to_string());
-    assert!(e.to_string().contains("factorization failed"));
-}
-
-#[test]
-fn test_build_error_display_preconditioner() {
-    let inner = schwarz_precond::BuildError::ScratchSizeTooSmall {
-        scratch_size: 1,
-        required_min: 2,
-    };
-    let e = BuildError::Preconditioner(inner);
-    let s = e.to_string();
-    assert!(s.contains("scratch size"));
-}
-
-// ---------------------------------------------------------------------------
-// Display tests for WithinError union
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_within_error_display_build() {
-    let e = WithinError::Build(BuildError::EmptyObservations);
-    assert_eq!(e.to_string(), "no observations provided");
-}
-
-#[test]
-fn test_within_error_display_solve() {
-    let inner = SolveError::Synchronization { context: "test" };
-    let e = WithinError::Solve(inner);
-    assert!(e.to_string().contains("test"));
-}
-
-// ---------------------------------------------------------------------------
-// Error::source() tests
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_build_error_source_leaf_variants_have_no_source() {
-    let variants: Vec<BuildError> = vec![
-        BuildError::EmptyObservations,
-        BuildError::ObservationCountMismatch {
-            column: 0,
-            expected: 1,
-            got: 2,
-        },
-        BuildError::WeightCountMismatch {
-            expected: 1,
-            got: 2,
-        },
-        BuildError::SingularDiagonal {
-            block: "b",
-            index: 0,
-        },
-        BuildError::LocalSolverBuild("x".to_string()),
-    ];
-    for e in &variants {
-        assert!(e.source().is_none(), "expected None source for {:?}", e);
-    }
-}
-
-#[test]
-fn test_build_error_source_preconditioner_chains() {
-    let inner = schwarz_precond::BuildError::ScratchSizeTooSmall {
-        scratch_size: 1,
-        required_min: 2,
-    };
-    let e = BuildError::Preconditioner(inner);
-    assert!(e.source().is_some());
-}
-
-#[test]
-fn test_within_error_build_leaf_variant_has_no_source() {
-    // WithinError::Build is transparent, so source() forwards to the inner
-    // BuildError's source. A leaf variant has no underlying source.
-    let e = WithinError::Build(BuildError::EmptyObservations);
-    assert!(e.source().is_none());
-}
-
-#[test]
-fn test_within_error_build_preconditioner_chains_through_transparent_wrapper() {
-    // Transparent: WithinError -> (BuildError::Preconditioner via #[source]) -> schwarz_precond::BuildError
-    let inner = schwarz_precond::BuildError::ScratchSizeTooSmall {
-        scratch_size: 1,
-        required_min: 2,
-    };
-    let e = WithinError::Build(BuildError::Preconditioner(inner));
-    assert!(e.source().is_some());
-}
-
-#[test]
-fn test_within_error_solve_leaf_variant_has_no_source() {
-    let inner = SolveError::Synchronization { context: "test" };
-    let e = WithinError::Solve(inner);
-    assert!(e.source().is_none());
-}
-
-// ---------------------------------------------------------------------------
-// Convenience-wrapper From conversions
-// ---------------------------------------------------------------------------
-
-#[test]
-fn test_within_error_from_build_error() {
-    let inner = BuildError::EmptyObservations;
-    let e: WithinError = inner.into();
-    match e {
-        WithinError::Build(BuildError::EmptyObservations) => {}
-        other => panic!("expected Build(EmptyObservations), got: {:?}", other),
-    }
-}
-
-#[test]
-fn test_within_error_from_solve_error() {
-    let inner = SolveError::Synchronization { context: "test" };
-    let e: WithinError = inner.into();
-    match e {
-        WithinError::Solve(_) => {}
-        other => panic!("expected Solve, got: {:?}", other),
-    }
-}
-
 #[test]
 fn test_preconditioner_dimension_mismatch_error() {
     // Build a preconditioner against a larger design, then try to reuse it
@@ -262,18 +99,6 @@ fn test_preconditioner_dimension_mismatch_error() {
 }
 
 #[test]
-fn test_build_error_display_preconditioner_dimension_mismatch() {
-    let e = BuildError::PreconditionerDimensionMismatch {
-        expected: 7,
-        actual_rows: 5,
-        actual_cols: 5,
-    };
-    let s = e.to_string();
-    assert!(s.contains("7"));
-    assert!(s.contains("5"));
-}
-
-#[test]
 fn test_solver_accepts_slope_bearing_design_alongside_other_terms() {
     let levels = [0u32, 1, 0, 1];
     let slope = [1.0, 2.0, 3.0, 4.0];
@@ -284,4 +109,40 @@ fn test_solver_accepts_slope_bearing_design_alongside_other_terms() {
     // Cross-factor routing (#61): slope terms alongside other terms build.
     let design = Design::new(effects).expect("slope design builds");
     Solver::new(design, None, None).expect("signed routing builds");
+}
+
+// ---------------------------------------------------------------------------
+// Error-type plumbing: one wiring check per enum (From conversions and the
+// transparent source() forward), not per-message pinning.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_within_error_from_build_error() {
+    let inner = BuildError::EmptyObservations;
+    let e: WithinError = inner.into();
+    match e {
+        WithinError::Build(BuildError::EmptyObservations) => {}
+        other => panic!("expected Build(EmptyObservations), got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_within_error_from_solve_error() {
+    let inner = SolveError::Synchronization { context: "test" };
+    let e: WithinError = inner.into();
+    match e {
+        WithinError::Solve(_) => {}
+        other => panic!("expected Solve, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_within_error_source_chains_through_transparent_wrapper() {
+    // Transparent: WithinError -> (BuildError::Preconditioner via #[source]) -> schwarz_precond::BuildError
+    let inner = schwarz_precond::BuildError::ScratchSizeTooSmall {
+        scratch_size: 1,
+        required_min: 2,
+    };
+    let e = WithinError::Build(BuildError::Preconditioner(inner));
+    assert!(e.source().is_some());
 }

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,7 +1,9 @@
 """Edge case tests for the within fixed-effects solver.
 
-Covers: NaN/Inf inputs, zero/negative weights, degenerate problems,
-non-contiguous arrays, low maxiter, and config boundary values.
+Covers: NaN/Inf input rejection, degenerate problems, non-contiguous arrays,
+low maxiter, and config boundary values. Pathological-weight tolerance
+(zero/negative/tiny/huge) is covered with strong oracles on the Rust side
+(edge_cases.rs); the binding only needs the NaN/Inf validation contract here.
 """
 
 from __future__ import annotations
@@ -17,7 +19,7 @@ def as_solver_categories(cats):
 
 
 # ---------------------------------------------------------------------------
-# NaN / Inf propagation
+# NaN / Inf validation (binding contract)
 # ---------------------------------------------------------------------------
 
 
@@ -35,88 +37,6 @@ class TestNanInfPropagation:
         y = np.array([1.0, np.inf, 3.0])
         with pytest.raises(ValueError, match="finite"):
             solve(cats, y)
-
-    def test_nan_in_weights_propagates_or_raises(self):
-        """NaN weight should either raise or produce NaN/non-converged result."""
-        cats = as_solver_categories([np.array([0, 1, 0]), np.array([0, 0, 1])])
-        y = np.array([1.0, 2.0, 3.0])
-        w = np.array([1.0, np.nan, 1.0])
-        try:
-            result = solve(cats, y, weights=w)
-            assert np.any(np.isnan(result.x)) or not result.converged
-        except Exception:
-            pass  # raising is also acceptable
-
-    def test_inf_in_weights_propagates_or_raises(self):
-        """Inf weight should either raise or produce non-finite/non-converged result."""
-        cats = as_solver_categories([np.array([0, 1, 0]), np.array([0, 0, 1])])
-        y = np.array([1.0, 2.0, 3.0])
-        w = np.array([1.0, np.inf, 1.0])
-        try:
-            result = solve(cats, y, weights=w)
-            assert np.any(~np.isfinite(result.x)) or not result.converged
-        except Exception:
-            pass  # raising is also acceptable
-
-
-# ---------------------------------------------------------------------------
-# Weight edge cases
-# ---------------------------------------------------------------------------
-
-
-class TestWeightEdgeCases:
-    def test_zero_weights_raises_or_fails(self):
-        """All-zero weights produce a singular system; should raise or not converge."""
-        cats = as_solver_categories(
-            [np.array([0, 1, 0, 1, 2]), np.array([0, 0, 1, 1, 0])]
-        )
-        y = np.ones(5)
-        w = np.zeros(5)
-        try:
-            result = solve(
-                cats, y, weights=w, preconditioner=PreconditionerConfig.Additive
-            )
-            assert not result.converged
-        except Exception:
-            pass  # raising is also acceptable
-
-    def test_negative_weights_does_not_crash(self):
-        """Negative weights break positive-definiteness; no crash required."""
-        cats = as_solver_categories(
-            [np.array([0, 1, 0, 1, 2]), np.array([0, 0, 1, 1, 0])]
-        )
-        y = np.ones(5)
-        w = np.array([1.0, -1.0, 1.0, 1.0, 1.0])
-        try:
-            solve(cats, y, weights=w)
-        except Exception:
-            pass  # either outcome is acceptable
-
-    def test_very_small_weights_do_not_crash(self):
-        """Near-zero weights (but positive) should not crash."""
-        cats = as_solver_categories(
-            [np.array([0, 1, 0, 1, 2]), np.array([0, 0, 1, 1, 0])]
-        )
-        y = np.ones(5)
-        w = np.array([1e-300, 1e-300, 1e-300, 1e-300, 1e-300])
-        try:
-            result = solve(cats, y, weights=w)
-            assert isinstance(result.converged, bool)
-        except Exception:
-            pass  # raising is also acceptable
-
-    def test_large_weights_do_not_crash(self):
-        """Very large (but finite) weights should not crash."""
-        cats = as_solver_categories(
-            [np.array([0, 1, 0, 1, 2]), np.array([0, 0, 1, 1, 0])]
-        )
-        y = np.ones(5)
-        w = np.full(5, 1e300)
-        try:
-            result = solve(cats, y, weights=w)
-            assert isinstance(result.converged, bool)
-        except Exception:
-            pass  # raising is also acceptable
 
 
 # ---------------------------------------------------------------------------
@@ -202,29 +122,6 @@ class TestSolverConfigLimits:
         assert result.converged
         assert result.iterations <= 5
 
-    def test_config_zero_tol_does_not_crash(self):
-        """tol=0.0 effectively demands machine precision; no crash required."""
-        cats = as_solver_categories(
-            [np.array([0, 1, 0, 1, 2]), np.array([0, 0, 1, 1, 0])]
-        )
-        y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-        try:
-            result = solve(cats, y, options=LsmrOptions(tol=0.0))
-            assert np.all(np.isfinite(result.x))
-        except Exception:
-            pass  # raising is also acceptable
-
-    def test_config_nan_tol_does_not_crash(self):
-        """NaN tol is pathological; no crash required."""
-        cats = as_solver_categories([np.array([0, 1, 0]), np.array([0, 0, 1])])
-        y = np.array([1.0, 2.0, 3.0])
-        try:
-            result = solve(cats, y, options=LsmrOptions(tol=float("nan")))
-            # If it ran, result should be finite or non-converged
-            assert isinstance(result.converged, bool)
-        except Exception:
-            pass  # raising is also acceptable
-
 
 # ---------------------------------------------------------------------------
 # Minimal / degenerate problem sizes
@@ -232,26 +129,6 @@ class TestSolverConfigLimits:
 
 
 class TestMinimalProblemSizes:
-    def test_single_observation_does_not_crash(self):
-        """A single-row problem is degenerate but should not crash."""
-        cats = np.array([[0, 0]], dtype=np.uint32, order="F")
-        y = np.array([5.0])
-        try:
-            result = solve(cats, y, preconditioner=PreconditionerConfig.Off)
-            assert np.all(np.isfinite(result.x))
-        except Exception:
-            pass  # singular system raising is acceptable
-
-    def test_two_observations_two_factors_does_not_crash(self):
-        """Minimal over-determined problem."""
-        cats = np.array([[0, 0], [1, 1]], dtype=np.uint32, order="F")
-        y = np.array([1.0, 2.0])
-        try:
-            result = solve(cats, y, preconditioner=PreconditionerConfig.Off)
-            assert np.all(np.isfinite(result.x))
-        except Exception:
-            pass  # acceptable
-
     def test_two_factor_levels_each_converges(self):
         """Small but well-connected problem with two levels per factor."""
         cats = as_solver_categories([np.array([0, 0, 1, 1]), np.array([0, 1, 0, 1])])
@@ -262,7 +139,7 @@ class TestMinimalProblemSizes:
 
 
 # ---------------------------------------------------------------------------
-# Non-contiguous input arrays
+# Non-contiguous input arrays (binding contract)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -28,6 +28,11 @@ def random_fe_problem(draw):
 
 
 class TestProperties:
+    # Mathematical properties (residual orthogonality, demeaned == y - D*x,
+    # solve() == Solver().solve()) are proptested with stronger, unguarded
+    # oracles on the Rust side (properties.rs, property_gaps.rs). Kept here:
+    # determinism through the binding, and pickle roundtrip (Python-only path).
+
     @given(data=random_fe_problem())
     @settings(
         max_examples=10, deadline=30000, suppress_health_check=[HealthCheck.too_slow]
@@ -38,36 +43,6 @@ class TestProperties:
         r1 = solve(categories, y)
         r2 = solve(categories, y)
         np.testing.assert_allclose(r1.x, r2.x, atol=1e-14)
-
-    @given(data=random_fe_problem())
-    @settings(
-        max_examples=10, deadline=30000, suppress_health_check=[HealthCheck.too_slow]
-    )
-    def test_residual_orthogonality(self, data):
-        """D^T * (y - D*x) should be approximately zero."""
-        categories, y = data
-        result = solve(categories, y)
-        if not result.converged:
-            return  # skip non-converged cases
-
-        n_obs, n_factors = categories.shape
-        residual = (
-            y - result.demeaned - y
-        )  # demeaned = y - D*x, so residual = D*x... wait
-        # Actually: demeaned = y - D*x, so D*x = y - demeaned
-        # residual = y - D*x = demeaned
-        residual = result.demeaned  # this IS y - D*x
-
-        # Check D^T * residual ≈ 0
-        offset = 0
-        for f in range(n_factors):
-            col = categories[:, f]
-            n_levels = int(col.max()) + 1
-            for lvl in range(n_levels):
-                mask = col == lvl
-                dot = residual[mask].sum()
-                assert abs(dot) < 1e-3, f"factor {f}, level {lvl}: D^T r = {dot}"
-            offset += n_levels
 
     @given(data=random_fe_problem())
     @settings(
@@ -89,114 +64,6 @@ class TestProperties:
         result_after = precond2.apply(x)
 
         np.testing.assert_array_equal(result_before, result_after)
-
-    @given(data=random_fe_problem())
-    @settings(
-        max_examples=10, deadline=30000, suppress_health_check=[HealthCheck.too_slow]
-    )
-    def test_unit_weights_match_unweighted(self, data):
-        """weights=ones should match no weights."""
-        categories, y = data
-        n_obs = len(y)
-        r_no_weights = solve(categories, y)
-        r_unit_weights = solve(categories, y, weights=np.ones(n_obs))
-
-        if not (r_no_weights.converged and r_unit_weights.converged):
-            return
-
-        np.testing.assert_allclose(r_no_weights.x, r_unit_weights.x, atol=1e-6)
-
-    @given(data=random_fe_problem())
-    @settings(
-        max_examples=10, deadline=30000, suppress_health_check=[HealthCheck.too_slow]
-    )
-    def test_solve_vs_solver_equivalence(self, data):
-        """solve() and Solver().solve() produce identical results."""
-        categories, y = data
-        r1 = solve(categories, y)
-        solver = Solver(categories)
-        r2 = solver.solve(y)
-        if r1.converged and r2.converged:
-            np.testing.assert_allclose(r1.x, r2.x, atol=1e-10)
-
-    @given(data=random_fe_problem())
-    @settings(
-        max_examples=10, deadline=30000, suppress_health_check=[HealthCheck.too_slow]
-    )
-    def test_demeaned_is_y_minus_design_times_x(self, data):
-        """demeaned[i] should equal y[i] minus the sum of factor effects for obs i."""
-        categories, y = data
-        result = solve(categories, y)
-        if not result.converged:
-            return
-
-        n_obs, n_factors = categories.shape
-        # Reconstruct D*x from categories and result.x
-        fitted = np.zeros(n_obs)
-        offset = 0
-        for f in range(n_factors):
-            col = categories[:, f]
-            n_levels = int(col.max()) + 1
-            fitted += result.x[offset + col]
-            offset += n_levels
-
-        expected_demeaned = y - fitted
-        np.testing.assert_allclose(result.demeaned, expected_demeaned, atol=1e-8)
-
-    @given(data=random_fe_problem())
-    @settings(
-        max_examples=10, deadline=30000, suppress_health_check=[HealthCheck.too_slow]
-    )
-    def test_solver_n_dofs_matches_x_length(self, data):
-        """Solver.n_dofs should equal len(result.x)."""
-        categories, y = data
-        solver = Solver(categories)
-        result = solver.solve(y)
-        assert solver.n_dofs == len(result.x)
-
-    @given(data=random_fe_problem())
-    @settings(
-        max_examples=10, deadline=30000, suppress_health_check=[HealthCheck.too_slow]
-    )
-    def test_solver_n_obs_matches_y_length(self, data):
-        """Solver.n_obs should equal len(y)."""
-        categories, y = data
-        solver = Solver(categories)
-        assert solver.n_obs == len(y)
-
-    @given(data=random_fe_problem())
-    @settings(
-        max_examples=10, deadline=30000, suppress_health_check=[HealthCheck.too_slow]
-    )
-    def test_residual_nonnegative(self, data):
-        """The final residual norm must be non-negative."""
-        categories, y = data
-        result = solve(categories, y)
-        assert result.residual >= 0.0
-
-    @given(data=random_fe_problem())
-    @settings(
-        max_examples=10, deadline=30000, suppress_health_check=[HealthCheck.too_slow]
-    )
-    def test_iterations_positive_when_not_trivial(self, data):
-        """Iterations should be >= 1 for non-trivial problems."""
-        categories, y = data
-        if np.allclose(y, 0.0):
-            return
-        result = solve(categories, y)
-        assert result.iterations >= 1
-
-    @given(data=random_fe_problem())
-    @settings(
-        max_examples=10, deadline=30000, suppress_health_check=[HealthCheck.too_slow]
-    )
-    def test_time_fields_nonnegative(self, data):
-        """All timing fields should be non-negative."""
-        categories, y = data
-        result = solve(categories, y)
-        assert result.time_total >= 0.0
-        assert result.time_setup >= 0.0
-        assert result.time_solve >= 0.0
 
 
 class TestAdvancedPreconditioners:


### PR DESCRIPTION
Closes #88.

Removes 32 tests whose failure could not indicate a bug the rest of the suite would miss. Every deleted Python re-test was verified to have a stronger, unguarded Rust twin before removal.

| File | Before → After | Dropped |
|---|---|---|
| `error_paths.rs` | 22 → 9 | Display/`source()`/`From` pinning; kept behavior + one wiring check per enum |
| `test_edge_cases.py` | 26 → 16 | `try/except: pass` and `isinstance(…,bool)` tests that pass regardless of result |
| `test_properties.py` | 21 → 12 | Rust-twin re-tests + cannot-fail invariants (`residual≥0`, `time≥0`) |

Kept intact: the pyfixest external-oracle slope suite, the Rust unit kernel oracles, and the Python binding contracts (dtype/ndim/contiguity/NaN validation, warnings, pickle).

Green: full Rust workspace + 100 Python tests; fmt/clippy/ruff clean.