### PR TITLE
fix(within): reject non-finite slope loadings and response values

### DIFF
--- a/crates/within/src/domain/effect.rs
+++ b/crates/within/src/domain/effect.rs
@@ -29,6 +29,13 @@ impl<'a> Effect<'a> {
                     got: s.len(),
                 });
             }
+            if let Some((index, &value)) = s.iter().enumerate().find(|&(_, &v)| !v.is_finite()) {
+                return Err(BuildError::InvalidLoading {
+                    slope,
+                    index,
+                    value,
+                });
+            }
         }
         Ok(Self {
             levels,
@@ -75,5 +82,21 @@ mod tests {
         let levels = [0u32, 1, 0, 1];
         let err = Effect::new(&levels, false, []).unwrap_err();
         assert!(matches!(err, BuildError::EmptyEffect));
+    }
+
+    #[test]
+    fn new_rejects_non_finite_slope_loading_naming_the_offending_slope() {
+        let levels = [0u32, 1, 0, 1];
+        let ok = [1.0, 2.0, 3.0, 4.0];
+        let bad = [1.0, f64::NAN, 3.0, 4.0];
+        let err = Effect::new(&levels, true, [&ok[..], &bad[..]]).unwrap_err();
+        assert!(matches!(
+            err,
+            BuildError::InvalidLoading {
+                slope: 1,
+                index: 1,
+                ..
+            }
+        ));
     }
 }

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -34,6 +34,18 @@ pub enum BuildError {
         /// Actual length.
         got: usize,
     },
+    /// A slope loading is not finite. A NaN/∞ loading makes its level-Gram
+    /// diagonal non-finite, so reparameterization silently drops the column and
+    /// misreports it as an unidentified direction; loadings must be finite.
+    #[error("slope {slope} loading at index {index} must be finite, got {value}")]
+    InvalidLoading {
+        /// Index of the offending slope covariate within its effect.
+        slope: usize,
+        /// Index of the offending loading value.
+        index: usize,
+        /// The offending value.
+        value: f64,
+    },
     /// Weight vector does not match the number of observations.
     #[error("weights has length {got}, expected {expected}")]
     WeightCountMismatch {
@@ -48,6 +60,16 @@ pub enum BuildError {
     #[error("weight at index {index} must be finite and non-negative, got {value}")]
     InvalidWeight {
         /// Index of the offending weight.
+        index: usize,
+        /// The offending value.
+        value: f64,
+    },
+    /// A response value is not finite. A NaN/∞ entry propagates through the
+    /// weighted right-hand side and silently corrupts the solution; responses
+    /// must be finite.
+    #[error("response at index {index} must be finite, got {value}")]
+    InvalidResponse {
+        /// Index of the offending response value.
         index: usize,
         /// The offending value.
         value: f64,

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -64,16 +64,6 @@ pub enum BuildError {
         /// The offending value.
         value: f64,
     },
-    /// A response value is not finite. A NaN/∞ entry propagates through the
-    /// weighted right-hand side and silently corrupts the solution; responses
-    /// must be finite.
-    #[error("response at index {index} must be finite, got {value}")]
-    InvalidResponse {
-        /// Index of the offending response value.
-        index: usize,
-        /// The offending value.
-        value: f64,
-    },
     /// A signed component could not be certified as diagonally scalable to an
     /// SDDM operator.
     #[error("signed component between {pair} is not diagonally scalable to SDDM form")]

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -404,6 +404,12 @@ impl<'a> Solver<'a> {
                 ),
             });
         }
+        if let Some((index, &value)) = y.iter().enumerate().find(|&(_, &v)| !v.is_finite()) {
+            return Err(SolveError::InvalidInput {
+                context: "Solver::solve",
+                message: format!("response at index {index} must be finite, got {value}"),
+            });
+        }
 
         let t_start = Instant::now();
 
@@ -571,9 +577,6 @@ pub fn solve<'a, 'o>(
     lsmr: impl Into<Option<&'o LsmrOptions>>,
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<SolveResult, WithinError> {
-    if let Some((index, &value)) = y.iter().enumerate().find(|&(_, &v)| !v.is_finite()) {
-        return Err(BuildError::InvalidResponse { index, value }.into());
-    }
     let t_start = Instant::now();
     let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
@@ -595,11 +598,6 @@ pub fn solve_batch<'a, 'o>(
     lsmr: impl Into<Option<&'o LsmrOptions>>,
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<BatchSolveResult, WithinError> {
-    for y in ys {
-        if let Some((index, &value)) = y.iter().enumerate().find(|&(_, &v)| !v.is_finite()) {
-            return Err(BuildError::InvalidResponse { index, value }.into());
-        }
-    }
     let t_start = Instant::now();
     let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
     let mut result = solver.solve_batch(ys, lsmr)?;

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -571,6 +571,9 @@ pub fn solve<'a, 'o>(
     lsmr: impl Into<Option<&'o LsmrOptions>>,
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<SolveResult, WithinError> {
+    if let Some((index, &value)) = y.iter().enumerate().find(|&(_, &v)| !v.is_finite()) {
+        return Err(BuildError::InvalidResponse { index, value }.into());
+    }
     let t_start = Instant::now();
     let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
@@ -592,6 +595,11 @@ pub fn solve_batch<'a, 'o>(
     lsmr: impl Into<Option<&'o LsmrOptions>>,
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<BatchSolveResult, WithinError> {
+    for y in ys {
+        if let Some((index, &value)) = y.iter().enumerate().find(|&(_, &v)| !v.is_finite()) {
+            return Err(BuildError::InvalidResponse { index, value }.into());
+        }
+    }
     let t_start = Instant::now();
     let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
     let mut result = solver.solve_batch(ys, lsmr)?;

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -109,22 +109,40 @@ fn test_non_finite_response_rejected() {
 
     let y = [1.0, f64::NAN, 3.0];
     match solve(cats.view(), &y, None, &params, &precond).unwrap_err() {
-        WithinError::Build(BuildError::InvalidResponse { index: 1, .. }) => {}
-        other => panic!(
-            "Expected Build(InvalidResponse) via solve(), got: {:?}",
-            other
-        ),
+        WithinError::Solve(SolveError::InvalidInput { message, .. }) => {
+            assert!(
+                message.contains("index 1"),
+                "message names the index: {message}"
+            );
+        }
+        other => panic!("Expected Solve(InvalidInput) via solve(), got: {other:?}"),
     }
 
-    // solve_batch scans every column: the offending value is in the 2nd RHS.
+    // The persistent Solver API funnels through the same Solver::solve guard, so
+    // the check cannot be bypassed by constructing a Solver and solving in place.
+    let solver = Solver::new(cats.view(), None, &precond).expect("solver");
+    match solver.solve(&y, &params).unwrap_err() {
+        SolveError::InvalidInput { message, .. } => {
+            assert!(
+                message.contains("index 1"),
+                "message names the index: {message}"
+            );
+        }
+        other => panic!("Expected InvalidInput via Solver::solve(), got: {other:?}"),
+    }
+
+    // solve_batch funnels every column through Solver::solve; the bad value is
+    // in the 2nd RHS.
     let good = [1.0, 2.0, 3.0];
     let bad = [1.0, 2.0, f64::INFINITY];
     match solve_batch(cats.view(), &[&good[..], &bad[..]], None, &params, &precond).unwrap_err() {
-        WithinError::Build(BuildError::InvalidResponse { index: 2, .. }) => {}
-        other => panic!(
-            "Expected Build(InvalidResponse) via solve_batch(), got: {:?}",
-            other
-        ),
+        WithinError::Solve(SolveError::InvalidInput { message, .. }) => {
+            assert!(
+                message.contains("index 2"),
+                "message names the index: {message}"
+            );
+        }
+        other => panic!("Expected Solve(InvalidInput) via solve_batch(), got: {other:?}"),
     }
 }
 

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -3,7 +3,10 @@ use std::error::Error;
 use ndarray::Array2;
 use schwarz_precond::SolveError;
 use within::observation::ObservationFrame;
-use within::{solve, BuildError, Design, LsmrOptions, PreconditionerConfig, Solver, WithinError};
+use within::{
+    solve, solve_batch, BuildError, Design, Effect, LsmrOptions, PreconditionerConfig, Solver,
+    WithinError,
+};
 
 // Behavior: a malformed input produces the right typed error. The Display /
 // source() / From plumbing is covered by a single wiring check per enum below,
@@ -96,6 +99,52 @@ fn test_preconditioner_dimension_mismatch_error() {
         }
         other => panic!("Expected PreconditionerDimensionMismatch, got: {:?}", other),
     }
+}
+
+#[test]
+fn test_non_finite_response_rejected() {
+    let cats = Array2::from_shape_vec((3, 1), vec![0u32, 1, 2]).expect("cats");
+    let params = LsmrOptions::default();
+    let precond = PreconditionerConfig::default();
+
+    let y = [1.0, f64::NAN, 3.0];
+    match solve(cats.view(), &y, None, &params, &precond).unwrap_err() {
+        WithinError::Build(BuildError::InvalidResponse { index: 1, .. }) => {}
+        other => panic!(
+            "Expected Build(InvalidResponse) via solve(), got: {:?}",
+            other
+        ),
+    }
+
+    // solve_batch scans every column: the offending value is in the 2nd RHS.
+    let good = [1.0, 2.0, 3.0];
+    let bad = [1.0, 2.0, f64::INFINITY];
+    match solve_batch(cats.view(), &[&good[..], &bad[..]], None, &params, &precond).unwrap_err() {
+        WithinError::Build(BuildError::InvalidResponse { index: 2, .. }) => {}
+        other => panic!(
+            "Expected Build(InvalidResponse) via solve_batch(), got: {:?}",
+            other
+        ),
+    }
+}
+
+#[test]
+fn test_collinear_finite_slope_is_unidentified_not_rejected() {
+    // A duplicated (collinear) but FINITE slope is genuine rank deficiency, not
+    // malformed input: it must resolve to an UnidentifiedDirection, never an
+    // InvalidLoading. Guards against conflating the two (#122).
+    let levels = [0u32, 0, 1, 1];
+    let z = [1.0, 3.0, 2.0, 5.0];
+    let y = [1.0, 2.0, 3.0, 4.0];
+    let effects = vec![Effect::new(&levels, true, [&z[..], &z[..]]).expect("effect")];
+    let params = LsmrOptions::default();
+    let precond = PreconditionerConfig::default();
+
+    let r = solve(effects, &y, None, &params, &precond).expect("collinear-but-finite must solve");
+    assert!(
+        !r.unidentified.is_empty(),
+        "a duplicated finite slope must report an unidentified direction"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #122.

Non-finite slope loadings and response values are now rejected at the input boundary instead of being silently absorbed into a zeroed, "unidentified" coefficient.

- `BuildError::InvalidLoading { slope, index, value }` — validated in `Effect::new`, the single funnel through which all live slope loadings pass.
- A non-finite `y` is rejected in `Solver::solve` (as `SolveError::InvalidInput`, beside the existing length guard) — the choke point that both the free `solve`/`solve_batch` wrappers and the persistent `Solver` API funnel through, so it cannot be bypassed.

A duplicated-but-finite slope still resolves to an `UnidentifiedDirection`, keeping genuine rank deficiency distinct from malformed input; a direct-`Solver::solve` test pins the no-bypass guarantee.
