### PR TITLE
build: adopt workspace metadata inheritance, declaring MSRV 1.84

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,22 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+version = "0.2.0"
+edition = "2021"
+rust-version = "1.84"
+license = "MIT"
+repository = "https://github.com/py-econometrics/within"
+categories = ["mathematics", "science", "algorithms"]
+
+[workspace.dependencies]
+schwarz-precond = { version = "0.2.0", path = "crates/schwarz-precond" }
+faer = "0.24.0"
+rayon = "1.10"
+serde = { version = "1", features = ["derive"] }
+postcard = { version = "1", features = ["use-std"] }
+thiserror = "2"
+
 [profile.release]
 opt-level = 3
 lto = "fat"

--- a/crates/schwarz-precond/Cargo.toml
+++ b/crates/schwarz-precond/Cargo.toml
@@ -1,20 +1,21 @@
 [package]
 name = "schwarz-precond"
-version = "0.2.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Schwarz domain decomposition preconditioner"
-license = "MIT"
+license.workspace = true
 readme = "README.md"
-repository = "https://github.com/py-econometrics/within"
+repository.workspace = true
 keywords = ["schwarz", "preconditioner", "domain-decomposition", "sparse", "iterative-solver"]
-categories = ["mathematics", "science", "algorithms"]
+categories.workspace = true
 
 [features]
 serde = ["dep:serde"]
 
 [dependencies]
-rayon = "1.10"
-faer = "0.24.0"
-serde = { version = "1", features = ["derive"], optional = true }
-thiserror = "2"
+rayon.workspace = true
+faer.workspace = true
+serde = { workspace = true, optional = true }
+thiserror.workspace = true
 thread_local = "1.1"

--- a/crates/within-py/Cargo.toml
+++ b/crates/within-py/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "within-py"
-version = "0.2.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "_within"
@@ -9,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 within = { path = "../within" }
-schwarz-precond = { path = "../schwarz-precond" }
-postcard = { version = "1", features = ["use-std"] }
+schwarz-precond.workspace = true
+postcard.workspace = true
 pyo3 = { version = "0.25", features = ["extension-module"] }
 numpy = "0.25"

--- a/crates/within/Cargo.toml
+++ b/crates/within/Cargo.toml
@@ -1,24 +1,25 @@
 [package]
 name = "within"
-version = "0.2.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 description = "Fixed-effects normal equation solver with Schwarz preconditioning"
-license = "MIT"
+license.workspace = true
 readme = "README.md"
-repository = "https://github.com/py-econometrics/within"
+repository.workspace = true
 keywords = ["fixed-effects", "least-squares", "preconditioner", "schwarz", "econometrics"]
-categories = ["mathematics", "science", "algorithms"]
+categories.workspace = true
 
 [dependencies]
-schwarz-precond = { version = "0.2.0", path = "../schwarz-precond", features = ["serde"] }
+schwarz-precond = { workspace = true, features = ["serde"] }
 approx-chol = { version = "0.3.1", features = ["serde"] }
-serde = { version = "1", features = ["derive", "rc"] }
-postcard = { version = "1", features = ["use-std"] }
+serde = { workspace = true, features = ["rc"] }
+postcard.workspace = true
 ndarray = "0.16"
 portable-atomic = { version = "1", features = ["float"] }
-rayon = "1.10"
-faer = "0.24.0"
-thiserror = "2"
+rayon.workspace = true
+faer.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,7 +11,7 @@ cargo-audit = ">=0.22.1,<0.23"
 within-py = { path = ".", editable = true }
 
 [feature.build.dependencies]
-rust = ">=1.75"
+rust = ">=1.84"
 maturin = ">=1.7"
 uv = ">=0.4"
 


### PR DESCRIPTION
Closes #123.

Adopts Cargo workspace metadata inheritance as the single source of truth.

- `[workspace.package]` holds `version`, `edition`, `rust-version = "1.84"`, `license`, `repository`, `categories`; members inherit via `.workspace = true`. Fields that genuinely differ per crate (`name`, `description`, `keywords`, and `readme` — whose inherited path would resolve against the workspace root) stay inline.
- `[workspace.dependencies]` holds the versions shared by 2+ crates (`faer`, `rayon`, `serde`, `postcard`, `thiserror`, and the internal `schwarz-precond`); members inherit and layer on their own features, e.g. `serde = { workspace = true, features = ["rc"] }`.

The MSRV of 1.84 is the floor enforced by faer 0.24 (within's own code needs only 1.82, via `Option::is_none_or`); clippy's `incompatible_msrv` lint verifies it in CI. `Cargo.lock` is unchanged — no dependency drift.
