### PR TITLE
refactor(within): dedupe backsub kernel, inline single-use ctor, assert positive pivot

### DIFF
--- a/crates/within/src/block_elim/factor.rs
+++ b/crates/within/src/block_elim/factor.rs
@@ -199,6 +199,10 @@ impl DenseCholesky {
             }
             // SAFETY: i<m -> diagonal index and write index are in bounds.
             let lii = unsafe { *l.get_unchecked(i * m + i) };
+            debug_assert!(
+                lii.is_finite() && lii != 0.0,
+                "Cholesky diagonal must be a finite nonzero pivot"
+            );
             unsafe { *x.get_unchecked_mut(i) = s / lii };
         }
 
@@ -215,6 +219,10 @@ impl DenseCholesky {
             }
             // SAFETY: i<m -> diagonal index and write index are in bounds.
             let lii = unsafe { *l.get_unchecked(i * m + i) };
+            debug_assert!(
+                lii.is_finite() && lii != 0.0,
+                "Cholesky diagonal must be a finite nonzero pivot"
+            );
             unsafe { *x.get_unchecked_mut(i) = s / lii };
         }
 

--- a/crates/within/src/block_elim/solver.rs
+++ b/crates/within/src/block_elim/solver.rs
@@ -55,6 +55,16 @@ fn backsub_block_from_scaled_rhs(
 ) {
     let n = sol_output.len();
     debug_assert!(scaled_rhs.len() >= n);
+    let recover = |i: usize| -> f64 {
+        let start = cross_matrix.indptr[i] as usize;
+        let end = cross_matrix.indptr[i + 1] as usize;
+        let mut sum = 0.0;
+        for idx in start..end {
+            let j = cross_matrix.indices[idx] as usize;
+            sum += cross_matrix.data[idx] * sol_source[j];
+        }
+        scaled_rhs[i] + (inv_diag[i] * sum)
+    };
     if n > PAR_BACKSUB_THRESHOLD && allow_inner_parallelism {
         sol_output
             .par_chunks_mut(PAR_BACKSUB_CHUNK)
@@ -62,27 +72,12 @@ fn backsub_block_from_scaled_rhs(
             .for_each(|(chunk_idx, chunk)| {
                 let row_start = chunk_idx * PAR_BACKSUB_CHUNK;
                 for (local_i, si) in chunk.iter_mut().enumerate() {
-                    let i = row_start + local_i;
-                    let start = cross_matrix.indptr[i] as usize;
-                    let end = cross_matrix.indptr[i + 1] as usize;
-                    let mut sum = 0.0;
-                    for idx in start..end {
-                        let j = cross_matrix.indices[idx] as usize;
-                        sum += cross_matrix.data[idx] * sol_source[j];
-                    }
-                    *si = scaled_rhs[i] + (inv_diag[i] * sum);
+                    *si = recover(row_start + local_i);
                 }
             });
     } else {
-        for i in 0..n {
-            let start = cross_matrix.indptr[i] as usize;
-            let end = cross_matrix.indptr[i + 1] as usize;
-            let mut sum = 0.0;
-            for idx in start..end {
-                let j = cross_matrix.indices[idx] as usize;
-                sum += cross_matrix.data[idx] * sol_source[j];
-            }
-            sol_output[i] = scaled_rhs[i] + (inv_diag[i] * sum);
+        for (i, out) in sol_output.iter_mut().enumerate() {
+            *out = recover(i);
         }
     }
 }

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -48,14 +48,6 @@ struct DiagonalPreconditioner {
     inv_diag: Arc<[f64]>,
 }
 
-impl DiagonalPreconditioner {
-    fn new(inv_diag: Vec<f64>) -> Self {
-        Self {
-            inv_diag: Arc::from(inv_diag),
-        }
-    }
-}
-
 impl Operator for DiagonalPreconditioner {
     fn nrows(&self) -> usize {
         self.inv_diag.len()
@@ -250,7 +242,9 @@ fn build_diagonal(
         *d = inv;
     }
 
-    Ok(DiagonalPreconditioner::new(diag))
+    Ok(DiagonalPreconditioner {
+        inv_diag: Arc::from(diag),
+    })
 }
 
 /// Build a [`Preconditioner`] from a design and optional observation weights,


### PR DESCRIPTION
Closes #124.

Three code-quality cleanups in the numerical core, no behavior change:

- `backsub_block_from_scaled_rhs` shares one per-row recovery closure across the parallel and serial arms (the arm split itself is kept).
- `DiagonalPreconditioner::new` is inlined at its one call site.
- `debug_assert!` pins the positive-pivot invariant in the dense triangular solve.
