### PR TITLE
Harden duplicated numeric helpers and right-size the preconditioner-input API

### DIFF
--- a/crates/schwarz-precond/src/lsmr.rs
+++ b/crates/schwarz-precond/src/lsmr.rs
@@ -15,13 +15,15 @@ use bidiag::{BidiagStep, Bidiagonalization, GolubKahan, ModifiedGolubKahan};
 use recurrence::{ConvergenceState, LsmrRecurrenceState, RotationStep, SolutionState, Stop};
 
 /// Euclidean norm of a vector.
+///
+/// Max-scaled so the squared sum can't overflow for large-magnitude vectors.
 #[inline]
 pub(crate) fn vec_norm(v: &[f64]) -> f64 {
-    let mut s = 0.0f64;
-    for &x in v {
-        s += x * x;
+    let scale = v.iter().fold(0.0f64, |m, &x| m.max(x.abs()));
+    if scale == 0.0 {
+        return 0.0;
     }
-    s.sqrt()
+    scale * v.iter().map(|&x| (x / scale).powi(2)).sum::<f64>().sqrt()
 }
 
 /// Result of an LSMR solve.

--- a/crates/schwarz-precond/src/lsmr.rs
+++ b/crates/schwarz-precond/src/lsmr.rs
@@ -21,7 +21,13 @@ use recurrence::{ConvergenceState, LsmrRecurrenceState, RotationStep, SolutionSt
 pub(crate) fn vec_norm(v: &[f64]) -> f64 {
     let scale = v.iter().fold(0.0f64, |m, &x| m.max(x.abs()));
     if scale == 0.0 {
-        return 0.0;
+        // f64::max ignores NaN, so all-{zero,NaN} vectors land here: propagate
+        // NaN instead of laundering it into a finite-looking zero norm.
+        return if v.iter().any(|x| x.is_nan()) {
+            f64::NAN
+        } else {
+            0.0
+        };
     }
     scale * v.iter().map(|&x| (x / scale).powi(2)).sum::<f64>().sqrt()
 }

--- a/crates/schwarz-precond/src/lsmr/tests.rs
+++ b/crates/schwarz-precond/src/lsmr/tests.rs
@@ -6,6 +6,17 @@ use super::vec_norm;
 use super::*;
 use crate::{Operator, SolveError};
 
+#[test]
+fn vec_norm_is_overflow_safe_and_propagates_nan() {
+    assert_eq!(vec_norm(&[]), 0.0);
+    assert_eq!(vec_norm(&[3.0, 4.0]), 5.0);
+    // Scaling keeps the squared sum finite where a naive Σx² would overflow.
+    assert!(vec_norm(&[1e300, 1e300]).is_finite());
+    // f64::max ignores NaN, so an all-{zero,NaN} vector must still report NaN.
+    assert!(vec_norm(&[f64::NAN]).is_nan());
+    assert!(vec_norm(&[0.0, f64::NAN]).is_nan());
+}
+
 /// Identity operator used by mlsmr equivalence tests.
 struct IdentityOp {
     n: usize,

--- a/crates/within/src/block_elim/schur.rs
+++ b/crates/within/src/block_elim/schur.rs
@@ -11,15 +11,8 @@ use rayon::prelude::*;
 
 use super::elimination::{Edge, Elimination};
 use crate::config::ApproxSchurConfig;
+use crate::csr_block::to_u32;
 use crate::domain::SolveSpace;
-
-/// Checked `usize -> u32` for CSR indptr/index values. A silent `as u32`
-/// truncation above `u32::MAX` would corrupt the factorization with no
-/// diagnostic; these are build-path invariants, so panic loudly instead.
-#[inline]
-fn to_u32(x: usize) -> u32 {
-    u32::try_from(x).expect("CSR index exceeds u32::MAX")
-}
 
 /// Build the exact Schur complement via row-workspace accumulation.
 ///

--- a/crates/within/src/csr_block.rs
+++ b/crates/within/src/csr_block.rs
@@ -5,6 +5,14 @@ pub(crate) const PAR_SPMV_THRESHOLD: usize = 10_000;
 /// Target number of non-zeros per parallel chunk.
 const TARGET_NNZ_PER_CHUNK: usize = 32_768;
 
+/// Checked `usize -> u32` for CSR index / compact-level values: a silent
+/// `as u32` truncation above `u32::MAX` would corrupt the structure with no
+/// diagnostic, and these are build-path invariants, so panic loudly instead.
+#[inline]
+pub(crate) fn to_u32(x: usize) -> u32 {
+    u32::try_from(x).expect("CSR index exceeds u32::MAX")
+}
+
 /// Rectangular CSR matrix used as the off-diagonal block in bipartite Gramians.
 ///
 /// Stores C (n_q × n_r) or C^T (n_r × n_q). All column indices within each

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -5,20 +5,11 @@
 //! supports bipartite connected-components splitting and per-component extraction.
 //! Levels are stored compactly with a `local_to_global` map for active levels only.
 
-use crate::csr_block::CsrBlock;
+use crate::csr_block::{to_u32, CsrBlock};
 use crate::domain::{ChannelPair, Design};
 
 mod accumulate;
 use accumulate::accumulate_cross_block;
-
-/// Checked `usize -> u32` for CSR indptr/index and compact-level values. A
-/// silent `as u32` truncation above `u32::MAX` would corrupt the assembled
-/// cross-tab with no diagnostic; these are build-path invariants, so panic
-/// loudly instead.
-#[inline]
-fn to_u32(x: usize) -> u32 {
-    u32::try_from(x).expect("CSR index exceeds u32::MAX")
-}
 
 // ---------------------------------------------------------------------------
 // BipartiteComponent / SchurData — supporting types for CrossTab

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -144,6 +144,9 @@ impl Preconditioner {
         }
     }
 
+    // nrows/ncols/apply mirror the `Operator` impl deliberately: `within` does
+    // not re-export `schwarz_precond::Operator`, so these are the only public
+    // way to query or apply a `Preconditioner` returned by the API.
     /// Number of rows of the underlying linear operator.
     pub fn nrows(&self) -> usize {
         <Self as schwarz_precond::Operator>::nrows(self)

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -26,7 +26,13 @@ use reparam::SlopeReparam;
 fn norm(v: &[f64]) -> f64 {
     let scale = v.iter().fold(0.0_f64, |m, &x| m.max(x.abs()));
     if scale == 0.0 {
-        return 0.0;
+        // f64::max ignores NaN, so all-{zero,NaN} vectors land here: propagate
+        // NaN instead of laundering it into a finite-looking zero norm.
+        return if v.iter().any(|x| x.is_nan()) {
+            f64::NAN
+        } else {
+            0.0
+        };
     }
     scale * v.iter().map(|&x| (x / scale).powi(2)).sum::<f64>().sqrt()
 }

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -22,8 +22,13 @@ mod reparam;
 mod tests;
 use reparam::SlopeReparam;
 
+// Max-scaled so the squared sum can't overflow for large-magnitude vectors.
 fn norm(v: &[f64]) -> f64 {
-    v.iter().map(|x| x * x).sum::<f64>().sqrt()
+    let scale = v.iter().fold(0.0_f64, |m, &x| m.max(x.abs()));
+    if scale == 0.0 {
+        return 0.0;
+    }
+    scale * v.iter().map(|&x| (x / scale).powi(2)).sum::<f64>().sqrt()
 }
 
 /// Fallible conversion into a [`Design`] for [`Solver::new`]: a categories


### PR DESCRIPTION
Closes #130, #131.

#130 — one `to_u32` CSR-index narrowing shared from `csr_block`; `norm` (within) and `vec_norm` (schwarz-precond) are now max-scaled so the squared sum can't overflow for large-magnitude vectors. Both norm sites are called once per solve (residual check / setup), not per iteration, so scaling costs nothing on the hot path. Hardened in place rather than unified: `vec_norm` is `pub(crate)`, and sharing it across the crate boundary would force it public on schwarz-precond.

#131 — reviewed and kept, no removals. `Preconditioner`'s inherent `nrows`/`ncols`/`apply` are the only public accessor surface (within does not re-export `schwarz_precond::Operator`) and are relied on by within-py; a one-line comment now records that the `Operator`-impl duplication is deliberate. The five `From<…>` impls each map to a distinct documented input form and are public conversions, so removing any would break the public API.