### PR TITLE
Executable doctests + py.typed marker

### DIFF
--- a/crates/schwarz-precond/src/lib.rs
+++ b/crates/schwarz-precond/src/lib.rs
@@ -8,6 +8,38 @@
 //!
 //! See `examples/` for runnable usage. Reference: Toselli & Widlund (2005).
 //! *Domain Decomposition Methods — Algorithms and Theory*. Springer.
+//!
+//! [`lsmr`] solves `min ‖b − A x‖₂` for any [`Operator`], with no
+//! preconditioner required:
+//!
+//! ```
+//! use schwarz_precond::{lsmr, Operator, SolveError};
+//!
+//! struct Diag(Vec<f64>);
+//! impl Operator for Diag {
+//!     fn nrows(&self) -> usize {
+//!         self.0.len()
+//!     }
+//!     fn ncols(&self) -> usize {
+//!         self.0.len()
+//!     }
+//!     fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), SolveError> {
+//!         for i in 0..self.0.len() {
+//!             y[i] = self.0[i] * x[i];
+//!         }
+//!         Ok(())
+//!     }
+//!     fn apply_adjoint(&self, x: &[f64], y: &mut [f64]) -> Result<(), SolveError> {
+//!         self.apply(x, y)
+//!     }
+//! }
+//!
+//! let a = Diag(vec![2.0, 3.0]);
+//! let r = lsmr(&a, &[4.0, 9.0], 1e-10, 50, None).unwrap();
+//! assert!(r.converged);
+//! assert!((r.x[0] - 2.0).abs() < 1e-6);
+//! assert!((r.x[1] - 3.0).abs() < 1e-6);
+//! ```
 
 #![deny(missing_docs)]
 #![warn(clippy::all)]

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -3,7 +3,7 @@
 //! `G = D^T W D`) for a sparse categorical design `D` via modified LSMR with a
 //! Schwarz preconditioner over factor-pair subdomains.
 //!
-//! ```no_run
+//! ```
 //! use ndarray::Array2;
 //! use within::{solve, LsmrOptions};
 //!


### PR DESCRIPTION
Closes #135, #136.

- `within`: crate example runs for real now (no_run dropped, passes as-is).
- `schwarz-precond`: crate doc gets a small runnable `lsmr` example.
- `python/within/py.typed` added; verified via a maturin wheel build that it (and the existing `_within.pyi`) ship with zero `pyproject.toml` changes, since `python-source = "python"` already bundles the whole package directory.

**within-py intentionally has no Rust doctest.** It's a cdylib-only PyO3 bridge whose public interface is Python, not Rust — its usage examples live in `python/within/__init__.py`. An earlier revision of this PR added `rlib` to its `crate-type` plus a `pub` conversion helper solely to host a Rust doctest; that was reverted because it widens the bridge crate's build/API surface for no real consumer, and `rlib` + `pyo3/extension-module` risks libpython link failures on Linux/Windows CI that weren't exercised here (only macOS was verified). #135 is satisfied by the two crates where Rust doctests are meaningful (`within`, `schwarz-precond`). A tested-Python-examples follow-up, if wanted, would be a `pytest --doctest-modules` addition, not a crate-structure change.

`cargo test --doc --workspace`: 2 passed (schwarz-precond, within), 0 failed; within-py doctests remain unsupported for its cdylib crate type (unchanged from origin/main).
`pixi run test`: 92 passed, 1 skipped.