### PR TITLE
refactor(within): make local-component reduction state unrepresentable

### DIFF
--- a/crates/within/src/block_elim/solver.rs
+++ b/crates/within/src/block_elim/solver.rs
@@ -6,7 +6,7 @@ use schwarz_precond::{LocalSolveError, LocalSolver};
 use crate::config::{LocalSolverConfig, SchurMode};
 use crate::csr_block::{CsrBlock, PAR_SPMV_THRESHOLD};
 use crate::domain::{
-    BlockDiagonals, CoordinateMap, CrossTab, GroundEdges, LocalComponent, SchurReduction,
+    BlockDiagonals, CoordinateMap, CrossTab, GroundEdges, Grounding, LocalComponent, Reduction,
     SolveSpace,
 };
 use crate::BuildError;
@@ -154,12 +154,11 @@ impl BlockRoles<'_> {
 /// Factor one operator's reduced Schur complement, choosing the backend by
 /// size and configuration: an exact dense minor below `dense_threshold`,
 /// otherwise a sparse Schur — sampled unless `approx_schur` is disabled —
-/// factored via `approx_chol`. `solve_space` gauges the reduced system
-/// (`Floating` anchors one node; `Grounded` factors the full complement) and
-/// must not be `Signed` — signed operators reach here only through their cover.
+/// factored via `approx_chol`. `grounding` gauges the reduced system:
+/// `Floating` anchors one node, `Grounded` factors the full complement.
 fn build_reduced_factor(
     elim: &Elimination,
-    solve_space: SolveSpace,
+    grounding: Grounding,
     config: &LocalSolverConfig,
 ) -> Result<ReducedFactor, BuildError> {
     let n_keep = elim.n_keep;
@@ -168,12 +167,9 @@ fn build_reduced_factor(
         // to `x = r/d`; never send an empty system to approx-chol.
         ReducedFactor::try_dense(Vec::new(), 0)
     } else if config.dense_threshold > 0 && n_keep <= config.dense_threshold {
-        let m = match solve_space {
-            SolveSpace::Floating => n_keep - 1,
-            SolveSpace::Grounded => n_keep,
-            SolveSpace::Signed => {
-                unreachable!("signed operators reduce through a cover, not a direct minor")
-            }
+        let m = match grounding {
+            Grounding::Floating => n_keep - 1,
+            Grounding::Grounded => n_keep,
         };
         ReducedFactor::try_dense(schur::dense_minor(elim, m), n_keep)
     } else {
@@ -199,7 +195,7 @@ fn build_reduced_factor(
 /// 2×-sized cover is SDDM and acts on the antisymmetric `[z, -z]` subspace as
 /// the original signed operator. Diagonals (and the caller's ground edges)
 /// duplicate across sheets. Built transiently in [`BlockElimSolver::build`] to
-/// factor a [`SchurReduction::Cover`] reduction, then discarded.
+/// factor a [`Reduction::Cover`] reduction, then discarded.
 fn assemble_bipartite_cover(
     cross_tab: &CrossTab,
     diagonals: &BlockDiagonals,
@@ -288,7 +284,7 @@ impl BlockElimSolver {
     /// Build a `BlockElimSolver` from a [`LocalComponent`] and solver config.
     ///
     /// Pipeline: build the [`Elimination`] on the single stored operator, then
-    /// factor its reduced Schur per [`SchurReduction`]. A `Direct` component
+    /// factor its reduced Schur per [`Reduction`]. A `Direct` component
     /// factors the reduced Schur straight away; a `Cover` (frustrated, signed)
     /// component rebuilds its Gremban double cover transiently, factors the
     /// cover's reduced Schur, and keeps only that factor — the stored operator
@@ -306,14 +302,14 @@ impl BlockElimSolver {
             diagonals,
             ground_edges,
             coordinates,
-            solve_space,
             reduction,
         } = component;
+        let solve_space = reduction.solve_space();
         let elim = Elimination::new(&cross_tab, &diagonals, &ground_edges, solve_space)?;
 
         let factor = match reduction {
-            SchurReduction::Direct => {
-                let factor = build_reduced_factor(&elim, solve_space, config)?;
+            Reduction::Direct(grounding) => {
+                let factor = build_reduced_factor(&elim, grounding, config)?;
                 let reduced_input_dimension = factor.input_dimension();
                 debug_assert!(
                     reduced_input_dimension == elim.n_keep
@@ -323,7 +319,7 @@ impl BlockElimSolver {
                 debug_assert!(factor.factor_dimension() >= reduced_input_dimension);
                 factor
             }
-            SchurReduction::Cover => {
+            Reduction::Cover => {
                 // Cover the single signed operator, factor the cover's reduced
                 // Schur (now SDDM, hence sampleable), then discard the cover —
                 // only the factor is retained.
@@ -334,19 +330,23 @@ impl BlockElimSolver {
                 };
                 // Surplus survives the cover, so the cover grounds exactly when
                 // the signed operator did (its edges are zeroed otherwise).
-                let cover_space = if cover_ground
+                let cover_grounding = if cover_ground
                     .q
                     .iter()
                     .chain(&cover_ground.r)
                     .any(|&surplus| surplus > 0.0)
                 {
-                    SolveSpace::Grounded
+                    Grounding::Grounded
                 } else {
-                    SolveSpace::Floating
+                    Grounding::Floating
                 };
-                let cover_elim =
-                    Elimination::new(&cover_cross, &cover_diag, &cover_ground, cover_space)?;
-                let inner = build_reduced_factor(&cover_elim, cover_space, config)?;
+                let cover_elim = Elimination::new(
+                    &cover_cross,
+                    &cover_diag,
+                    &cover_ground,
+                    cover_grounding.solve_space(),
+                )?;
+                let inner = build_reduced_factor(&cover_elim, cover_grounding, config)?;
                 ReducedFactor::Cover {
                     inner: Box::new(inner),
                     m: elim.n_keep,

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -9,8 +9,8 @@ pub(crate) use cross_tab::{find_all_active_levels, BlockDiagonals, CrossTab};
 pub use effect::Effect;
 
 pub(crate) use factor_pairs::{
-    build_local_domains, CoordinateMap, GroundEdges, LocalComponent, LocalDomain, SchurReduction,
-    SolveSpace,
+    build_local_domains, CoordinateMap, GroundEdges, Grounding, LocalComponent, LocalDomain,
+    Reduction, SolveSpace,
 };
 
 // ===========================================================================

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -15,7 +15,9 @@ use super::{find_all_active_levels, BlockDiagonals, Channel, ChannelPair, CrossT
 
 mod sddm;
 use sddm::{convert, NotScalable};
-pub(crate) use sddm::{CoordinateMap, GroundEdges, LocalComponent, SchurReduction, SolveSpace};
+pub(crate) use sddm::{
+    CoordinateMap, GroundEdges, Grounding, LocalComponent, Reduction, SolveSpace,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ComponentClass {

--- a/crates/within/src/domain/factor_pairs/sddm.rs
+++ b/crates/within/src/domain/factor_pairs/sddm.rs
@@ -40,21 +40,20 @@ pub(crate) enum SolveSpace {
     Floating,
     Grounded,
     /// Signed operator whose reduced Schur self-grounds through its Gremban
-    /// cover ([`SchurReduction::Cover`]): the antisymmetric `[b, -b]` embed
+    /// cover ([`ReductionKind::Cover`]): the antisymmetric `[b, -b]` embed
     /// balances the RHS, so the operator-level solve does no mean-subtraction
     /// and injects no ground current.
     Signed,
 }
 
-/// How a component's reduced Schur complement is factored.
-///
-/// Orthogonal to [`CoordinateMap`] (an operator-level congruence): a frustrated
-/// component keeps its single signed operator and marks the *reduction* as
-/// [`SchurReduction::Cover`], deferring the double-cover construction to factor
-/// time so the stored operator never doubles.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-enum SchurReduction {
-    #[default]
+/// The reduction strategy chosen from a component's signature, before its
+/// grounding is known: `Direct` folds to a Z-matrix and reduces its minor
+/// straight; `Cover` keeps the signed operator and defers a Gremban double
+/// cover to factor time so the stored operator never doubles. Orthogonal to
+/// [`CoordinateMap`] (an operator-level congruence). Resolved into a
+/// [`Reduction`] once the grounding is classified.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReductionKind {
     Direct,
     Cover,
 }
@@ -77,7 +76,7 @@ impl Grounding {
     }
 }
 
-/// Resolved reduction state of a local component: the [`SchurReduction`]
+/// Resolved reduction state of a local component: the [`ReductionKind`]
 /// strategy paired with the solve space it produced. Only these combinations
 /// are reachable, so the illegal signed-with-direct pairing cannot be
 /// constructed.
@@ -239,7 +238,7 @@ fn convert_general(
                 cross_tab,
                 diagonals,
                 factors,
-                SchurReduction::Direct,
+                ReductionKind::Direct,
                 scaling,
             )?
         }
@@ -249,13 +248,7 @@ fn convert_general(
             for factor in &mut factors[n_q..] {
                 *factor = -*factor;
             }
-            assemble(
-                cross_tab,
-                diagonals,
-                factors,
-                SchurReduction::Cover,
-                scaling,
-            )?
+            assemble(cross_tab, diagonals, factors, ReductionKind::Cover, scaling)?
         }
     };
     let violation = relaxation.violation.max(clamped_deficit);
@@ -267,9 +260,9 @@ fn convert_general(
 }
 
 /// Fold the component through `factors` and assemble the validated SDDM form.
-/// The `reduction` fixes the fold contract: a [`SchurReduction::Direct`]
+/// The `reduction` fixes the fold contract: a [`ReductionKind::Direct`]
 /// component must fold to a true Z-matrix, so any off-diagonal the signature
-/// failed to drive nonnegative is an error; a [`SchurReduction::Cover`] component
+/// failed to drive nonnegative is an error; a [`ReductionKind::Cover`] component
 /// keeps its single *signed* operator (negatives retained) and grounds through a
 /// Gremban double cover built at factor time (see [`crate::block_elim`]).
 /// Dominance is classified against *magnitude* row sums either way — after a
@@ -280,11 +273,11 @@ fn assemble(
     mut cross_tab: CrossTab,
     diagonals: BlockDiagonals,
     factors: Vec<f64>,
-    reduction: SchurReduction,
+    reduction: ReductionKind,
     scaling: &ScalingConfig,
 ) -> Result<(LocalComponent, f64), NotScalable> {
     let n_q = cross_tab.n_q();
-    let enforce_z = reduction == SchurReduction::Direct;
+    let enforce_z = reduction == ReductionKind::Direct;
     for i in 0..n_q {
         let start = cross_tab.c.indptr[i] as usize;
         let end = cross_tab.c.indptr[i + 1] as usize;
@@ -361,7 +354,7 @@ fn finalize(
     mut scaled_diagonals: BlockDiagonals,
     row_sums: BlockDiagonals,
     coordinates: CoordinateMap,
-    reduction: SchurReduction,
+    reduction: ReductionKind,
     scaling: &ScalingConfig,
 ) -> Result<(LocalComponent, f64), NotScalable> {
     let n = cross_tab.n_local();
@@ -409,9 +402,9 @@ fn finalize(
         ground_edges.r.fill(0.0);
     }
     let reduction = match reduction {
-        SchurReduction::Cover => Reduction::Cover,
-        SchurReduction::Direct if floats => Reduction::Direct(Grounding::Floating),
-        SchurReduction::Direct => Reduction::Direct(Grounding::Grounded),
+        ReductionKind::Cover => Reduction::Cover,
+        ReductionKind::Direct if floats => Reduction::Direct(Grounding::Floating),
+        ReductionKind::Direct => Reduction::Direct(Grounding::Grounded),
     };
 
     Ok((

--- a/crates/within/src/domain/factor_pairs/sddm.rs
+++ b/crates/within/src/domain/factor_pairs/sddm.rs
@@ -7,7 +7,7 @@
 //! is validated and adopted without sign folding, scaling, or a data rewrite.
 //! Frustrated components — where no signature exists — keep their single
 //! *signed* operator (dominance-scaled but not folded to a Z-matrix) and carry
-//! a [`SchurReduction::Cover`] marker; the Gremban double cover that makes the
+//! a [`Reduction::Cover`] marker; the Gremban double cover that makes the
 //! reduced Schur SDDM is built transiently at factor time (see
 //! [`crate::block_elim`]), so the stored operator stays single-sized.
 
@@ -53,10 +53,50 @@ pub(crate) enum SolveSpace {
 /// [`SchurReduction::Cover`], deferring the double-cover construction to factor
 /// time so the stored operator never doubles.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(crate) enum SchurReduction {
+enum SchurReduction {
     #[default]
     Direct,
     Cover,
+}
+
+/// Grounding of a directly-reduced SDDM minor: `Floating` anchors one node,
+/// `Grounded` factors the full complement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Grounding {
+    Floating,
+    Grounded,
+}
+
+impl Grounding {
+    /// The solve space a floating/grounded minor gauges.
+    pub(crate) fn solve_space(self) -> SolveSpace {
+        match self {
+            Grounding::Floating => SolveSpace::Floating,
+            Grounding::Grounded => SolveSpace::Grounded,
+        }
+    }
+}
+
+/// Resolved reduction state of a local component: the [`SchurReduction`]
+/// strategy paired with the solve space it produced. Only these combinations
+/// are reachable, so the illegal signed-with-direct pairing cannot be
+/// constructed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Reduction {
+    /// Direct Schur factorization of a floating or grounded minor.
+    Direct(Grounding),
+    /// Gremban-cover reduction of a signed operator; solves in [`SolveSpace::Signed`].
+    Cover,
+}
+
+impl Reduction {
+    /// The solve space this reduction gauges.
+    pub(crate) fn solve_space(self) -> SolveSpace {
+        match self {
+            Reduction::Direct(grounding) => grounding.solve_space(),
+            Reduction::Cover => SolveSpace::Signed,
+        }
+    }
 }
 
 /// Map between original and SDDM coordinates, applied to vectors at the
@@ -112,8 +152,7 @@ pub(crate) struct LocalComponent {
     pub(crate) diagonals: BlockDiagonals,
     pub(crate) ground_edges: GroundEdges,
     pub(crate) coordinates: CoordinateMap,
-    pub(crate) solve_space: SolveSpace,
-    pub(crate) reduction: SchurReduction,
+    pub(crate) reduction: Reduction,
 }
 
 /// The component admits no diagonal scaling to weak dominance (Boman); its
@@ -175,8 +214,7 @@ fn convert_known_laplacian(
         diagonals: row_sums,
         ground_edges,
         coordinates: CoordinateMap::default(),
-        solve_space: SolveSpace::Floating,
-        reduction: SchurReduction::Direct,
+        reduction: Reduction::Direct(Grounding::Floating),
     })
 }
 
@@ -312,8 +350,8 @@ fn assemble(
 
 /// Validate weak dominance of an assembled operator against `row_sums` (signed
 /// adjacency for a Z-matrix, magnitudes for a signed operator): clamp roundoff
-/// deficits, retain surplus as ground edges, and classify the solve space.
-/// A `Cover`-reduced component is always [`SolveSpace::Signed`]; the
+/// deficits, retain surplus as ground edges, and resolve the [`Reduction`]
+/// state. A `Cover`-reduced component is always [`SolveSpace::Signed`]; the
 /// float/ground classification only decides whether its surplus is retained
 /// (the cover self-grounds either way). Returns the largest relative deficit
 /// that was clamped; deficits beyond tolerance are errors under
@@ -370,10 +408,10 @@ fn finalize(
         ground_edges.q.fill(0.0);
         ground_edges.r.fill(0.0);
     }
-    let solve_space = match reduction {
-        SchurReduction::Cover => SolveSpace::Signed,
-        SchurReduction::Direct if floats => SolveSpace::Floating,
-        SchurReduction::Direct => SolveSpace::Grounded,
+    let reduction = match reduction {
+        SchurReduction::Cover => Reduction::Cover,
+        SchurReduction::Direct if floats => Reduction::Direct(Grounding::Floating),
+        SchurReduction::Direct => Reduction::Direct(Grounding::Grounded),
     };
 
     Ok((
@@ -382,7 +420,6 @@ fn finalize(
             diagonals: scaled_diagonals,
             ground_edges,
             coordinates,
-            solve_space,
             reduction,
         },
         clamped_deficit,

--- a/crates/within/src/domain/factor_pairs/sddm/tests.rs
+++ b/crates/within/src/domain/factor_pairs/sddm/tests.rs
@@ -36,7 +36,7 @@ impl LocalComponent {
             cross_tab,
             diagonals,
             factors.to_vec(),
-            SchurReduction::Direct,
+            ReductionKind::Direct,
             &ScalingConfig::default(),
         )
         .expect("test factors must fold to SDDM")
@@ -218,7 +218,7 @@ fn large_rescaled_singular_boundary_remains_floating() {
         cross_tab,
         diagonals,
         factors,
-        SchurReduction::Direct,
+        ReductionKind::Direct,
         &ScalingConfig::default(),
     )
     .unwrap();

--- a/crates/within/src/domain/factor_pairs/sddm/tests.rs
+++ b/crates/within/src/domain/factor_pairs/sddm/tests.rs
@@ -85,7 +85,7 @@ fn known_laplacian_has_canonical_coordinates_and_no_ground() {
         &ScalingConfig::default(),
     )
     .unwrap();
-    assert_eq!(component.solve_space, SolveSpace::Floating);
+    assert_eq!(component.reduction.solve_space(), SolveSpace::Floating);
     assert!(matches!(component.coordinates, CoordinateMap::Canonical));
     assert!(uncertified.is_none());
     assert_sddm(&component);
@@ -122,7 +122,7 @@ fn frustrated_component_stores_single_signed_operator() {
     assert!(uncertified.is_none());
     // The operator stays single-sized and signed (M[1,1] = −1): the cover is
     // deferred to factor time via the Cover reduction marker.
-    assert_eq!(component.reduction, SchurReduction::Cover);
+    assert_eq!(component.reduction, Reduction::Cover);
     assert_eq!(component.cross_tab.c.nrows, 2);
     assert_eq!(component.cross_tab.c.ncols, 2);
     let mut dense = [[0.0; 2]; 2];
@@ -135,7 +135,7 @@ fn frustrated_component_stores_single_signed_operator() {
     // Magnitude dominance with zero surplus: the operator is Signed (the cover
     // self-grounds). Its congruence is exactly the canonical bipartite sign flip
     // (`+1` on q, `−1` on r), so no explicit factor map is stored.
-    assert_eq!(component.solve_space, SolveSpace::Signed);
+    assert_eq!(component.reduction.solve_space(), SolveSpace::Signed);
     assert!(component.ground_edges.q.iter().all(|&s| s == 0.0));
     assert!(component.ground_edges.r.iter().all(|&s| s == 0.0));
     assert!(matches!(component.coordinates, CoordinateMap::Canonical));
@@ -162,7 +162,7 @@ fn scalable_signed_component_produces_valid_grounded_sddm() {
         &ScalingConfig::default(),
     )
     .unwrap();
-    assert_eq!(component.solve_space, SolveSpace::Grounded);
+    assert_eq!(component.reduction.solve_space(), SolveSpace::Grounded);
     assert!(uncertified.is_none());
     assert_sddm(&component);
 }
@@ -179,7 +179,7 @@ fn singular_signed_boundary_remains_floating() {
         &ScalingConfig::default(),
     )
     .unwrap();
-    assert_eq!(component.solve_space, SolveSpace::Floating);
+    assert_eq!(component.reduction.solve_space(), SolveSpace::Floating);
     assert_sddm(&component);
 }
 
@@ -223,7 +223,7 @@ fn large_rescaled_singular_boundary_remains_floating() {
     )
     .unwrap();
 
-    assert_eq!(component.solve_space, SolveSpace::Floating);
+    assert_eq!(component.reduction.solve_space(), SolveSpace::Floating);
     assert_sddm(&component);
 }
 
@@ -281,7 +281,7 @@ fn barely_pd_surplus_is_structural() {
         &ScalingConfig::default(),
     )
     .unwrap();
-    assert_eq!(component.solve_space, SolveSpace::Grounded);
+    assert_eq!(component.reduction.solve_space(), SolveSpace::Grounded);
     assert!((component.ground_edges.q[0] - surplus).abs() < 1e-15);
     assert_sddm(&component);
 }

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -32,7 +32,7 @@ fn positive_slope_only_pair_grounds_beyond_dense_threshold() {
     assert!(
         domains.iter().any(|ld| {
             let ct = &ld.component.cross_tab;
-            ld.component.solve_space == SolveSpace::Grounded
+            ld.component.reduction.solve_space() == SolveSpace::Grounded
                 && ct.n_q().min(ct.n_r()) > DEFAULT_DENSE_SCHUR_THRESHOLD
         }),
         "fixture must ground a component past the dense threshold (warnings: {warnings:?})"


### PR DESCRIPTION
Closes #128.

Collapses `LocalComponent`'s independent `solve_space`/`reduction` fields into a single `Reduction` sum type (`Direct(Grounding)` | `Cover`) whose variants are exactly the three legal states, making the illegal signed-with-direct pairing unconstructible. `build_reduced_factor` now takes a two-variant `Grounding`, so the defensive `unreachable!` it relied on is deleted. Pure type-safety refactor — no numerical or solver-behavior change; all tests pass unchanged.