### PR TITLE
ci: MSRV/locked/deny contract, Miri over block_elim, coverage floor + mutants (#132, #133, #134)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,6 @@
+# cargo-mutants configuration: `cargo mutants`, https://mutants.rs/.
+# Scoped to the `within` core solver (sign conventions, compensated
+# summation, block elimination) — not schwarz-precond or the PyO3 glue.
+examine_globs = ["crates/within/src/**/*.rs"]
+exclude_globs = ["crates/within/src/**/tests.rs"]
+test_package = ["within"]

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -3,4 +3,3 @@
 # summation, block elimination) — not schwarz-precond or the PyO3 glue.
 examine_globs = ["crates/within/src/**/*.rs"]
 exclude_globs = ["crates/within/src/**/tests.rs"]
-test_package = ["within"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,23 @@ jobs:
       - name: cargo fmt
         run: pixi run -e default cargo fmt --all -- --check
       - name: cargo clippy
-        run: pixi run -e default cargo clippy --workspace --all-targets --all-features -- -D warnings
+        run: pixi run -e default cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
       - name: cargo test
-        run: pixi run -e default cargo test --workspace --all-features
+        run: pixi run -e default cargo test --workspace --all-features --locked
+      - name: cargo deny
+        run: pixi run -e default cargo deny --locked check
       - name: pytest
         run: pixi run test
+
+  msrv:
+    name: MSRV (1.84.0)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.84.0
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo check (workspace, all features, at the declared MSRV)
+        run: cargo check --workspace --all-features --locked
 
   platform:
     name: Tests (${{ matrix.os }})
@@ -45,7 +57,7 @@ jobs:
           cache: true
       - uses: Swatinem/rust-cache@v2
       - name: cargo test
-        run: pixi run -e default cargo test --workspace --all-features
+        run: pixi run -e default cargo test --workspace --all-features --locked
       - name: pytest
         run: pixi run test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
         run: pixi run test
 
   msrv:
-    name: MSRV (1.84.0)
+    name: MSRV (1.85.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.84.0
+      - uses: dtolnay/rust-toolchain@1.85.0
       - uses: Swatinem/rust-cache@v2
       - name: cargo check (workspace, all features, at the declared MSRV)
         run: cargo check --workspace --all-features --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run coverage
         run: pixi run coverage
+
+  miri:
+    name: Miri (block elimination unsafe)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo miri test
+        # Only unsafe in the crate: the dense triangular solve kernel, see
+        # crates/within/src/block_elim/factor.rs.
+        run: cargo miri test -p within --locked --lib block_elim::factor::tests

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,0 +1,31 @@
+name: Mutation testing
+
+# Scheduled/manual only — a full pass over the `within` core is ~1300
+# mutants, each a build+test cycle, so this never gates a PR.
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  mutants:
+    name: cargo mutants (within core)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-mutants
+        run: cargo install cargo-mutants --locked
+      - name: cargo mutants
+        run: cargo mutants -C --locked
+      - name: Upload mutants report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutants-report
+          path: mutants.out

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -17,12 +17,12 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: prefix-dev/setup-pixi@v0.8.8
+        with:
+          cache: true
       - uses: Swatinem/rust-cache@v2
-      - name: Install cargo-mutants
-        run: cargo install cargo-mutants --locked
       - name: cargo mutants
-        run: cargo mutants -C --locked
+        run: pixi run mutants
       - name: Upload mutants report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ target
 .hypothesis/
 .pytest_cache/
 .ruff_cache/
+mutants.out/
+*.profraw

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.84"
+rust-version = "1.85"
 license = "MIT"
 repository = "https://github.com/py-econometrics/within"
 categories = ["mathematics", "science", "algorithms"]

--- a/crates/within-py/Cargo.toml
+++ b/crates/within-py/Cargo.toml
@@ -3,6 +3,8 @@ name = "within-py"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
+publish = false
 
 [lib]
 name = "_within"

--- a/deny.toml
+++ b/deny.toml
@@ -26,8 +26,6 @@ ignore = [
 ]
 
 [licenses]
-version = 2
-confidence-threshold = 0.8
 allow = [
     "MIT",
     "Apache-2.0",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,70 @@
+# cargo-deny configuration: run via `cargo deny check` (advisories, licenses,
+# bans, sources). See https://embarkstudios.github.io/cargo-deny/ for the
+# full schema; unset fields fall back to cargo-deny's defaults.
+
+[graph]
+# Matches the platforms declared in pixi.toml so target-only crates (e.g.
+# r-efi, only pulled in for UEFI targets) don't spuriously appear in the
+# license/bans graph.
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+]
+all-features = true
+
+[advisories]
+# Each entry is a pre-existing, transitive advisory that isn't fixable by a
+# lockfile bump alone (unlike crossbeam-epoch, resolved instead by updating
+# past 0.9.18); tracked to revisit, not silently accepted.
+ignore = [
+    { id = "RUSTSEC-2024-0436", reason = "transitive `paste` dep is unmaintained (no vulnerability); no drop-in replacement upstream" },
+    { id = "RUSTSEC-2026-0176", reason = "pyo3 0.25.1 PyList/PyTuple::nth overflow; we don't call nth/nth_back on these iterators. Fix needs pyo3 >=0.29, an API-breaking bump out of scope here" },
+    { id = "RUSTSEC-2026-0177", reason = "pyo3 0.25.1 PyCFunction::new_closure missing Sync bound; within-py never calls new_closure. Fix needs pyo3 >=0.29, out of scope here" },
+    { id = "RUSTSEC-2026-0097", reason = "rand unsound only with the `log` feature plus a custom logger reading rand::rng(); within-py enables neither" },
+]
+
+[licenses]
+version = 2
+confidence-threshold = 0.8
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+
+[licenses.private]
+ignore = true
+
+[bans]
+# "deny" plus an explicit `skip` grandfathering list: any *new* duplicate
+# crate/version pulled in by a future change still fails the check.
+multiple-versions = "deny"
+wildcards = "deny"
+allow-wildcard-paths = true
+skip = [
+    { crate = "cpufeatures@0.2.17", reason = "pre-existing transitive duplicate (sha2 vs chacha20 chains)" },
+    { crate = "equator@0.2.2", reason = "pre-existing transitive duplicate within faer's nano-gemm chain" },
+    { crate = "equator@0.4.2", reason = "pre-existing transitive duplicate within faer's nano-gemm chain" },
+    { crate = "equator-macro@0.2.1", reason = "pre-existing transitive duplicate within faer's nano-gemm chain" },
+    { crate = "equator-macro@0.4.2", reason = "pre-existing transitive duplicate within faer's nano-gemm chain" },
+    { crate = "getrandom@0.3.4", reason = "pre-existing transitive duplicate (rand 0.9 vs 0.10 chains)" },
+    { crate = "rand@0.8.5", reason = "pre-existing transitive duplicate (criterion vs faer/approx-chol chains)" },
+    { crate = "rand@0.9.2", reason = "pre-existing transitive duplicate (criterion vs faer/approx-chol chains)" },
+    { crate = "rand_core@0.6.4", reason = "pre-existing transitive duplicate (criterion vs faer/approx-chol chains)" },
+    { crate = "rand_core@0.9.5", reason = "pre-existing transitive duplicate (criterion vs faer/approx-chol chains)" },
+    { crate = "syn@1.0.109", reason = "pre-existing transitive duplicate (older proc-macro crates not yet on syn 2)" },
+    { crate = "thiserror@1.0.69", reason = "pre-existing transitive duplicate; workspace itself is on thiserror 2" },
+    { crate = "thiserror-impl@1.0.69", reason = "pre-existing transitive duplicate; workspace itself is on thiserror 2" },
+    { crate = "windows-sys@0.42.0", reason = "pre-existing transitive duplicate (older Windows-target crates)" },
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/pixi.lock
+++ b/pixi.lock
@@ -16,6 +16,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-audit-0.22.1-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-deny-0.20.2-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-llvm-cov-0.8.7-hdab8a38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-mutants-27.1.0-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.0-py314h4a8dc5f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
@@ -88,6 +89,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-audit-0.22.1-ha9c3995_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-deny-0.20.2-h19f9e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-llvm-cov-0.8.7-h009cd8f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-mutants-27.1.0-h19f9e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-2.1.0-py314hb60be56_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
@@ -151,6 +153,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-audit-0.22.1-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-deny-0.20.2-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-llvm-cov-0.8.7-h748bcf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-mutants-27.1.0-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.1.0-py314h7bede21_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
@@ -213,6 +216,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/cargo-audit-0.22.1-h18a1a76_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cargo-deny-0.20.2-h18a1a76_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cargo-llvm-cov-0.8.7-h77a83cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cargo-mutants-27.1.0-h18a1a76_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.1.0-py314h5a2d7ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyh6dadd2b_0.conda
@@ -497,6 +501,55 @@ packages:
   purls: []
   size: 1295216
   timestamp: 1778642257194
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-mutants-27.1.0-hb17b654_0.conda
+  sha256: 68aff97b51f92ad97c0cfc36594dfd6c3cac3ce57d64657186305d2b36680b35
+  md5: 250be425416861b37c11bff9f5a93113
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 2355029
+  timestamp: 1782316935671
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-mutants-27.1.0-h19f9e61_0.conda
+  sha256: 5bd7134fb987d1da2ca19c25d415696accbc7e8179c9e9cacaefaa69d98a730b
+  md5: 0dda179dfb99db261fda7a185cc3a85c
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 2299144
+  timestamp: 1782317256934
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-mutants-27.1.0-h6fdd925_0.conda
+  sha256: d53122b60de7bc10e415d7ef5618a07ad2bc152a17900cc3d47e7da5edfd3a1b
+  md5: 5c96bbcb1ebfc2799c8301cb640f0555
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 2145537
+  timestamp: 1782318245952
+- conda: https://conda.anaconda.org/conda-forge/win-64/cargo-mutants-27.1.0-h18a1a76_0.conda
+  sha256: 4b88d6aaa18ada65f3f4b714af37b9e87c870d44b02bc06f0f3289e5598d5ada
+  md5: 6da6beea5994eee7e53e3a931ffe761c
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 2501815
+  timestamp: 1782317004665
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.0-py314h4a8dc5f_0.conda
   sha256: 39d0d45c4c73162c0aadd0b1bce6ce42ca354da65979f49d6084ff00ed5c26b4
   md5: 26f3b9c52441a170b2008cbc227f740a

--- a/pixi.lock
+++ b/pixi.lock
@@ -14,6 +14,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-audit-0.22.1-hb17b654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-deny-0.20.2-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-llvm-cov-0.8.7-hdab8a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.0-py314h4a8dc5f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
@@ -85,6 +86,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-audit-0.22.1-ha9c3995_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-deny-0.20.2-h19f9e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-llvm-cov-0.8.7-h009cd8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-2.1.0-py314hb60be56_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
@@ -147,6 +149,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-audit-0.22.1-h6fdd925_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-deny-0.20.2-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-llvm-cov-0.8.7-h748bcf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.1.0-py314h7bede21_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
@@ -208,6 +211,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cargo-audit-0.22.1-h18a1a76_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cargo-deny-0.20.2-h18a1a76_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cargo-llvm-cov-0.8.7-h77a83cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.1.0-py314h5a2d7ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
@@ -399,6 +403,51 @@ packages:
   purls: []
   size: 5445585
   timestamp: 1771402801201
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-deny-0.20.2-hb17b654_0.conda
+  sha256: 98d4e0adbb07cff3891078d411c7b7871508c03c1830ba9be2e8c835529bc36a
+  md5: 0b977c2b9739d1c0cc3e6b0621934191
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 OR MIT
+  purls: []
+  size: 4507012
+  timestamp: 1783637133529
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cargo-deny-0.20.2-h19f9e61_0.conda
+  sha256: 26ff479fd59b70c113c0d4f5be41175dfbab944479420950a2f9205992083aab
+  md5: 66331eae9cf7d3bb4e33b048d05d9afc
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 OR MIT
+  purls: []
+  size: 4469654
+  timestamp: 1783637279645
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cargo-deny-0.20.2-h6fdd925_0.conda
+  sha256: a203c9ae4a5381a34ac3c49263e468eb8d74c76456d2fce82e5e5bc1b457b4a2
+  md5: 871cae6343e8d8cede5914a3cd4939be
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 OR MIT
+  purls: []
+  size: 4267267
+  timestamp: 1783637237465
+- conda: https://conda.anaconda.org/conda-forge/win-64/cargo-deny-0.20.2-h18a1a76_0.conda
+  sha256: 8fe6a2e7393e0e649758ee66154392459cd55661b79633859c75178d9b9f0be8
+  md5: 570feb51cd39cee7d3feccd1616be4e6
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: Apache-2.0 OR MIT
+  purls: []
+  size: 4465031
+  timestamp: 1783637161792
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cargo-llvm-cov-0.8.7-hdab8a38_0.conda
   sha256: 53c56b26634f024bb0f5959a74a246f1d6636e55153822c36d200f262e8d6a2c
   md5: 111b31aa6e7d28827526d4e4ce904710

--- a/pixi.toml
+++ b/pixi.toml
@@ -24,6 +24,7 @@ pre-commit = ">=4.0"
 ruff = ">=0.9"
 hypothesis = ">=6.0"
 samply = ">=0.13"
+cargo-mutants = ">=27.1,<28"
 
 [environments]
 default = { features = ["build", "dev"], solve-group = "default" }
@@ -33,3 +34,4 @@ test = "maturin develop --uv --locked && pytest tests/ -v --cov=within --cov-rep
 develop = "maturin develop --uv --release"
 coverage-rust = "cargo llvm-cov --workspace --all-features --summary-only"
 coverage = "./scripts/coverage-with-python.sh"
+mutants = "cargo mutants -C --locked"

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,6 +6,7 @@ platforms = ["linux-64", "win-64", "osx-arm64", "osx-64"]
 python = ">=3.9"
 pixi-pycharm = ">=0.0.10,<0.0.11"
 cargo-audit = ">=0.22.1,<0.23"
+cargo-deny = ">=0.20.2,<0.21"
 
 [pypi-dependencies]
 within-py = { path = ".", editable = true }
@@ -28,7 +29,7 @@ samply = ">=0.13"
 default = { features = ["build", "dev"], solve-group = "default" }
 
 [tasks]
-test = "maturin develop --uv && pytest tests/ -v --cov=within --cov-report=term-missing"
+test = "maturin develop --uv --locked && pytest tests/ -v --cov=within --cov-report=term-missing"
 develop = "maturin develop --uv --release"
 coverage-rust = "cargo llvm-cov --workspace --all-features --summary-only"
 coverage = "./scripts/coverage-with-python.sh"

--- a/scripts/coverage-with-python.sh
+++ b/scripts/coverage-with-python.sh
@@ -4,11 +4,11 @@ set -euo pipefail
 cargo llvm-cov clean --workspace
 source <(cargo llvm-cov show-env --sh)
 
-cargo test --workspace --all-features
+cargo test --workspace --all-features --locked
 if python -m pip --version >/dev/null 2>&1; then
-    maturin develop
+    maturin develop --locked
 else
-    maturin develop --uv
+    maturin develop --uv --locked
 fi
 pytest tests/ -v
 

--- a/scripts/coverage-with-python.sh
+++ b/scripts/coverage-with-python.sh
@@ -12,4 +12,6 @@ else
 fi
 pytest tests/ -v
 
-cargo llvm-cov report --summary-only
+# Floor set just below the measured total (94.99% lines); only lower it
+# deliberately, never raise it above what's actually measured.
+cargo llvm-cov report --summary-only --fail-under-lines 94


### PR DESCRIPTION
Closes #132, #133, #134 — three CI-hardening pieces, all touching `ci.yml`.

- **#132 — MSRV + `--locked` + deny contract.** MSRV job pinned to `1.85.0` (raised from 1.84: `approx-chol`'s `rand 0.10` requires edition2024, i.e. Rust ≥1.85), `--locked` on every CI cargo/maturin invocation, and `cargo-deny` (`deny.toml`) wired as a check step. Fixed one real gap it caught (`within-py` missing `license`/`publish=false`) and one advisory via a lockfile-only bump (`crossbeam-epoch`); every remaining pre-existing advisory/duplicate carries a reason in `ignore`/`skip`, not silently dropped.
- **#133 — Miri.** Nightly + miri job over the crate's only `unsafe` (`block_elim::factor`, the dense triangular-solve kernel). Clean, no UB.
- **#134 — coverage floor + mutants.** `--fail-under-lines 94` (just below the measured 94.99%) on the coverage job, plus `cargo-mutants` scoped to the `within` core as a separate scheduled/dispatch-only, non-blocking job.

## Test plan
- [x] `cargo check --workspace --all-features --locked` at Rust 1.85.0 — clean
- [x] `cargo clippy/test --locked` at ambient toolchain — clean
- [x] `cargo deny check` — advisories/bans/licenses/sources all ok
- [x] `cargo miri test -p within --locked --lib block_elim::factor::tests` — 7/7 pass, no UB
- [x] `pixi run coverage` with `--fail-under-lines 94` — passes (94.99% measured)
- [x] `cargo mutants` config resolves to the `within` crate only
- [ ] Full CI run (msrv/miri/coverage jobs first-executed by GitHub Actions)
