### PR TITLE
fix: resolve code-audit findings (#149, #150, #152, #153)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,17 +73,3 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run coverage
         run: pixi run coverage
-
-  miri:
-    name: Miri (block elimination unsafe)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: miri
-      - uses: Swatinem/rust-cache@v2
-      - name: cargo miri test
-        # Only unsafe in the crate: the dense triangular solve kernel, see
-        # crates/within/src/block_elim/factor.rs.
-        run: cargo miri test -p within --locked --lib block_elim::factor::tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - The one-shot Python `solve` / `solve_batch` re-emit build warnings as `UserWarning`s (e.g. uncertified signed-component scaling), matching the persistent `Solver`; previously they were discarded (#103).
 - Wrong-dtype input arrays raise a `TypeError` naming the expected dtype (design → `uint32`, response and weights → `float64`) and the dtype received, instead of an opaque PyO3 conversion error (#100).
 - Corrected published examples and type stubs: `PreconditionerConfig` / `ReductionStrategy` are documented as (non-iterable) attribute holders rather than `IntEnum`, examples use the current argument order and `Schur` / `split_merge` spellings, and the varying-slopes workflow and minimal-norm normalization convention are documented (#102).
+- `SolveResult.residual` / `BatchSolveResult.residual` now report the LSMR recurrence's normal-equation residual *estimate* instead of recomputing it exactly, saving two passes per solve; exact when unpreconditioned, in the preconditioner's metric otherwise (#149).
+- **BREAKING (`schwarz-precond`):** `LsmrResult` gains a public `normal_eq_residual` field, the relative normal-equation residual estimate (#149).
 
 ### Removed
 

--- a/crates/schwarz-precond/src/lsmr.rs
+++ b/crates/schwarz-precond/src/lsmr.rs
@@ -43,6 +43,11 @@ pub struct LsmrResult {
     pub iterations: usize,
     /// Final residual norm estimate `‖b − A x‖`.
     pub residual_norm: f64,
+    /// Relative normal-equation residual estimate `‖Aᵀrₖ‖ / ‖Aᵀb‖`, recovered
+    /// from the recurrence scalars (`|ζ̄ₖ| / |ζ̄₀|`, Fong & Saunders) at no extra
+    /// cost. For a preconditioned solve (via [`mlsmr`]) this is measured in the
+    /// preconditioner's metric.
+    pub normal_eq_residual: f64,
     /// Reason the solver stopped.
     pub stop_reason: LsmrStopReason,
 }
@@ -83,6 +88,7 @@ pub fn lsmr<A: Operator + ?Sized>(
             converged: true,
             iterations: 0,
             residual_norm: 0.0,
+            normal_eq_residual: 0.0,
             stop_reason: LsmrStopReason::ZeroRhs,
         });
     }
@@ -124,6 +130,7 @@ pub fn mlsmr<A: Operator + ?Sized, M: Operator + ?Sized>(
             converged: true,
             iterations: 0,
             residual_norm: 0.0,
+            normal_eq_residual: 0.0,
             stop_reason: LsmrStopReason::ZeroRhs,
         });
     }
@@ -150,6 +157,7 @@ fn lsmr_from_bidiag<B: Bidiagonalization>(
             converged: true,
             iterations: 0,
             residual_norm: b_norm,
+            normal_eq_residual: 0.0,
             stop_reason: LsmrStopReason::InitialNormalEquationResidualZero,
         });
     }
@@ -180,6 +188,7 @@ fn lsmr_from_bidiag<B: Bidiagonalization>(
                 converged: true,
                 iterations: itn,
                 residual_norm: recurrence.residual_estimate(),
+                normal_eq_residual: recurrence.relative_normal_eq_residual(),
                 stop_reason,
             });
         }
@@ -191,6 +200,7 @@ fn lsmr_from_bidiag<B: Bidiagonalization>(
         converged: false,
         iterations: maxiter,
         residual_norm: recurrence.residual_estimate(),
+        normal_eq_residual: recurrence.relative_normal_eq_residual(),
         stop_reason: LsmrStopReason::MaxIterations,
     })
 }

--- a/crates/schwarz-precond/src/lsmr/bidiag.rs
+++ b/crates/schwarz-precond/src/lsmr/bidiag.rs
@@ -276,9 +276,8 @@ impl<A: Operator + ?Sized> Bidiagonalization for GolubKahan<'_, A> {
             self.alpha = 0.0;
             return Ok(BidiagStep { alpha: 0.0, beta });
         }
-        if beta > 0.0 {
-            scale_in_place(&mut self.bufs.u, 1.0 / beta);
-        }
+        // beta > 0 here: the beta == 0 lucky breakdown returned above.
+        scale_in_place(&mut self.bufs.u, 1.0 / beta);
 
         // α_{k+1} v_{k+1} = Aᵀ u_{k+1} − β_{k+1} v_k
         self.operator
@@ -330,7 +329,8 @@ impl<A: Operator + ?Sized, M: Operator + ?Sized> Bidiagonalization
             self.beta_prev_inv = 0.0;
             return Ok(BidiagStep { alpha: 0.0, beta });
         }
-        let beta_inv = if beta > 0.0 { 1.0 / beta } else { 0.0 };
+        // beta > 0 here: the beta == 0 lucky breakdown returned above.
+        let beta_inv = 1.0 / beta;
 
         // Phase 2 — fold the adjoint matvec into the p̃ recurrence.
         self.update_p_tilde(beta, beta_inv)?;

--- a/crates/schwarz-precond/src/lsmr/recurrence.rs
+++ b/crates/schwarz-precond/src/lsmr/recurrence.rs
@@ -71,16 +71,20 @@ pub(super) struct LsmrRecurrenceState {
     c_bar: f64,
     s_bar: f64,
     zeta_bar: f64,
+    // |ζ̄₀| snapshot (clamped), relativizes the reported normal-eq residual.
+    zeta0: f64,
 }
 
 impl LsmrRecurrenceState {
     pub(super) fn init(s1: BidiagStep) -> Self {
+        let zeta_bar = s1.alpha * s1.beta;
         Self {
             alpha_bar: s1.alpha,
             phi_bar: s1.beta,
             c_bar: 1.0,
             s_bar: 0.0,
-            zeta_bar: s1.alpha * s1.beta,
+            zeta_bar,
+            zeta0: zeta_bar.abs().max(f64::MIN_POSITIVE),
         }
     }
 
@@ -142,6 +146,12 @@ impl LsmrRecurrenceState {
     /// `|ζ̄|` — running estimate of `‖Aᵀ r_k‖` (Fong & Saunders).
     fn normal_eq_residual_estimate(&self) -> f64 {
         self.zeta_bar.abs()
+    }
+
+    /// `|ζ̄ₖ| / |ζ̄₀|` — normal-equation residual relative to its initial value
+    /// `‖Aᵀb‖` (Fong & Saunders); the clamp on `ζ̄₀` guards the ratio.
+    pub(super) fn relative_normal_eq_residual(&self) -> f64 {
+        self.normal_eq_residual_estimate() / self.zeta0
     }
 }
 

--- a/crates/within/src/block_elim/factor.rs
+++ b/crates/within/src/block_elim/factor.rs
@@ -7,7 +7,10 @@
 
 use approx_chol::low_level::Builder;
 use approx_chol::{CsrRef, Factor};
-use faer::{MatRef, Side};
+use faer::linalg::triangular_solve::{
+    solve_lower_triangular_in_place, solve_upper_triangular_in_place,
+};
+use faer::{MatMut, MatRef, Par, Side};
 use schwarz_precond::LocalSolveError;
 
 use super::csr_matrix::CsrMatrix;
@@ -178,52 +181,27 @@ impl DenseCholesky {
     /// anchored gauge and are written as zero.
     fn solve_in_place(&self, x: &mut [f64]) {
         debug_assert_eq!(x.len(), self.n);
-        let l = &self.l_row_major;
-        let m = if l.len() == self.n * self.n {
+        let m = if self.l_row_major.len() == self.n * self.n {
             self.n
         } else {
             self.n.saturating_sub(1)
         };
-        debug_assert_eq!(l.len(), m * m);
+        debug_assert_eq!(self.l_row_major.len(), m * m);
 
-        // Forward solve on the minor: L y = b.
-        for i in 0..m {
-            // SAFETY: i<m, row bounds and triangular-access bounds are validated by loop limits.
-            let mut s = unsafe { *x.get_unchecked(i) };
-            for j in 0..i {
-                // SAFETY: i<m, j<i<m -> indices are in bounds.
-                let lij = unsafe { *l.get_unchecked(i * m + j) };
-                // SAFETY: j<i<m -> in bounds.
-                let xj = unsafe { *x.get_unchecked(j) };
-                s -= lij * xj;
-            }
-            // SAFETY: i<m -> diagonal index and write index are in bounds.
-            let lii = unsafe { *l.get_unchecked(i * m + i) };
-            debug_assert!(
-                lii.is_finite() && lii != 0.0,
-                "Cholesky diagonal must be a finite nonzero pivot"
+        if m > 0 {
+            // Delegate both substitutions to faer's blocked kernels, viewing
+            // the stored factor and `x` in place: L y = b then Lᵀ x = y.
+            let l = MatRef::from_row_major_slice(&self.l_row_major, m, m);
+            solve_lower_triangular_in_place(
+                l,
+                MatMut::from_column_major_slice_mut(&mut x[..m], m, 1),
+                Par::Seq,
             );
-            unsafe { *x.get_unchecked_mut(i) = s / lii };
-        }
-
-        // Backward solve on the minor: L^T x = y.
-        for i in (0..m).rev() {
-            // SAFETY: i<m -> in bounds.
-            let mut s = unsafe { *x.get_unchecked(i) };
-            for j in (i + 1)..m {
-                // SAFETY: j<m, i<j -> in bounds.
-                let lji = unsafe { *l.get_unchecked(j * m + i) };
-                // SAFETY: j<m -> in bounds.
-                let xj = unsafe { *x.get_unchecked(j) };
-                s -= lji * xj;
-            }
-            // SAFETY: i<m -> diagonal index and write index are in bounds.
-            let lii = unsafe { *l.get_unchecked(i * m + i) };
-            debug_assert!(
-                lii.is_finite() && lii != 0.0,
-                "Cholesky diagonal must be a finite nonzero pivot"
+            solve_upper_triangular_in_place(
+                l.transpose(),
+                MatMut::from_column_major_slice_mut(&mut x[..m], m, 1),
+                Par::Seq,
             );
-            unsafe { *x.get_unchecked_mut(i) = s / lii };
         }
 
         for v in &mut x[m..] {

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 
 use ndarray::{ArrayView2, Axis};
 use rayon::prelude::*;
-use schwarz_precond::{lsmr as lsmr_solve, mlsmr, Operator as _};
+use schwarz_precond::{lsmr as lsmr_solve, mlsmr};
 
 use crate::config::{LsmrOptions, PreconditionerConfig};
 use crate::domain::{Design, Effect};
@@ -21,21 +21,6 @@ mod reparam;
 #[cfg(test)]
 mod tests;
 use reparam::SlopeReparam;
-
-// Max-scaled so the squared sum can't overflow for large-magnitude vectors.
-fn norm(v: &[f64]) -> f64 {
-    let scale = v.iter().fold(0.0_f64, |m, &x| m.max(x.abs()));
-    if scale == 0.0 {
-        // f64::max ignores NaN, so all-{zero,NaN} vectors land here: propagate
-        // NaN instead of laundering it into a finite-looking zero norm.
-        return if v.iter().any(|x| x.is_nan()) {
-            f64::NAN
-        } else {
-            0.0
-        };
-    }
-    scale * v.iter().map(|&x| (x / scale).powi(2)).sum::<f64>().sqrt()
-}
 
 /// Fallible conversion into a [`Design`] for [`Solver::new`]: a categories
 /// matrix (`ArrayView2<u32>`), a list of [`Effect`] terms, or a pass-through
@@ -237,7 +222,11 @@ pub struct SolveResult {
     pub converged: bool,
     /// Number of LSMR iterations used.
     pub iterations: usize,
-    /// Final relative residual norm `‖r‖ / ‖b‖`.
+    /// Relative normal-equation residual `||D^T W (y - Dx)|| / ||D^T W y||`,
+    /// estimated from the LSMR recurrence (Fong & Saunders) at no extra cost.
+    /// Exact for an unpreconditioned solve; for a preconditioned solve it is
+    /// measured in the preconditioner's metric and typically sits a modest
+    /// factor below the true-metric value.
     pub residual: f64,
     /// Wall-clock time for the entire solve (setup + LSMR), in seconds.
     pub time_total: f64,
@@ -267,7 +256,8 @@ pub struct BatchSolveResult {
     pub converged: Vec<bool>,
     /// Per-RHS iteration counts.
     pub iterations: Vec<usize>,
-    /// Per-RHS final relative residual norms.
+    /// Per-RHS relative normal-equation residual estimate; see
+    /// [`SolveResult::residual`].
     pub residual: Vec<f64>,
     /// Per-RHS solve times in seconds.
     pub time_solve: Vec<f64>,
@@ -454,16 +444,9 @@ impl<'a> Solver<'a> {
             *d = yi - *d;
         }
 
-        // Relative normal-equation residual: ||D^T W (y - Dx)|| / ||D^T W y||.
-        // Compute D^T W v as rect_op.apply_adjoint(W^{1/2} v): apply_adjoint
-        // delivers D^T W^{1/2} (·), so feeding W^{1/2} v gives D^T W v.
-        let mut rhs = vec![0.0; self.design.n_dofs];
-        rect_op.apply_adjoint(b, &mut rhs)?;
-        let rhs_norm = norm(&rhs).max(1e-15);
-        let weighted_demeaned = rect_op.weighted_rhs(&demeaned);
-        let mut residual_dof = vec![0.0; self.design.n_dofs];
-        rect_op.apply_adjoint(weighted_demeaned.as_ref(), &mut residual_dof)?;
-        let residual = norm(&residual_dof) / rhs_norm;
+        // Relative normal-equation residual estimate, read from the LSMR
+        // recurrence at no extra cost; see `SolveResult::residual`.
+        let residual = r.normal_eq_residual;
 
         let mut x = r.x;
         let unidentified = match &self.reparam {

--- a/crates/within/tests/common/orchestrate_helpers.rs
+++ b/crates/within/tests/common/orchestrate_helpers.rs
@@ -1,10 +1,25 @@
 #![allow(dead_code)]
 
+use ndarray::Array2;
 use within::observation::ObservationFrame;
 use within::{Design, SolveResult};
 
+/// The canonical 2-factor, 5-observation categorical structure used across the
+/// orchestration tests. `categories[f][i]` is observation `i`'s level in factor `f`.
+pub fn test_categories() -> Vec<Vec<u32>> {
+    vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]
+}
+
+/// [`test_categories`] as the observation-major `(n_obs, n_factors)` matrix the
+/// high-level `solve` / `solve_batch` entry points consume.
+pub fn test_categories_array() -> Array2<u32> {
+    let cats = test_categories();
+    let (n_factors, n_obs) = (cats.len(), cats[0].len());
+    Array2::from_shape_fn((n_obs, n_factors), |(i, f)| cats[f][i])
+}
+
 pub fn make_test_design() -> Design<'static> {
-    make_design(vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]).expect("valid test design")
+    make_design(test_categories()).expect("valid test design")
 }
 
 pub fn make_design(categories: Vec<Vec<u32>>) -> Result<Design<'static>, within::BuildError> {
@@ -27,6 +42,44 @@ pub fn assert_converged_with_small_residual(result: &SolveResult, tol: f64) {
         result.residual < tol,
         "residual too large: {}",
         result.residual
+    );
+}
+
+/// Independent optimality oracle for a purely categorical fixed-effects design:
+/// recomputes the relative normal-equation residual `‖DᵀW(y−Dx)‖ / ‖DᵀWy‖` from
+/// `result.demeaned` (`y − Dx`, produced by a matvec separate from the LSMR
+/// recurrence) and the raw categories. Unlike `result.residual`, which is now the
+/// solver's own stopping estimate, this cannot be satisfied by the solver merely
+/// reporting convergence. `categories[f][i]` is observation `i`'s level in factor `f`.
+pub fn assert_normal_equations_satisfied(
+    categories: &[Vec<u32>],
+    weights: Option<&[f64]>,
+    y: &[f64],
+    result: &SolveResult,
+    tol: f64,
+) {
+    // ‖DᵀW v‖² = Σ_f Σ_level (Σ_{i in level} w_i v_i)²  for a categorical D.
+    let dtw_sq_norm = |v: &[f64]| -> f64 {
+        let mut acc = 0.0;
+        for levels in categories {
+            let n_levels = levels.iter().copied().max().map_or(0, |m| m as usize + 1);
+            let mut sums = vec![0.0f64; n_levels];
+            for (i, &level) in levels.iter().enumerate() {
+                let w = weights.map_or(1.0, |ws| ws[i]);
+                sums[level as usize] += w * v[i];
+            }
+            acc += sums.iter().map(|s| s * s).sum::<f64>();
+        }
+        acc
+    };
+
+    let numerator = dtw_sq_norm(&result.demeaned).sqrt();
+    let denominator = dtw_sq_norm(y).sqrt().max(1e-15);
+    let relative = numerator / denominator;
+    assert!(
+        relative < tol,
+        "independent normal-equation residual {relative} exceeds {tol} \
+         (‖DᵀW(y−Dx)‖ = {numerator}, ‖DᵀWy‖ = {denominator})"
     );
 }
 

--- a/crates/within/tests/orchestrate_high_level.rs
+++ b/crates/within/tests/orchestrate_high_level.rs
@@ -1,4 +1,3 @@
-use ndarray::array;
 use within::{solve, solve_batch, LsmrOptions, PreconditionerConfig};
 
 #[path = "common/orchestrate_helpers.rs"]
@@ -6,7 +5,7 @@ mod common;
 
 #[test]
 fn test_high_level_solve() {
-    let categories = array![[0u32, 0], [1, 0], [0, 1], [1, 1], [2, 0]];
+    let categories = common::test_categories_array();
     let y = [1.0, 2.0, 3.0, 4.0, 5.0];
 
     let params = LsmrOptions::default();
@@ -14,11 +13,12 @@ fn test_high_level_solve() {
     let result = solve(categories.view(), &y, None, &params, &precond).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_solution_finite(&result);
+    common::assert_normal_equations_satisfied(&common::test_categories(), None, &y, &result, 1e-6);
 }
 
 #[test]
 fn test_high_level_solve_weighted() {
-    let categories = array![[0u32, 0], [1, 0], [0, 1], [1, 1], [2, 0]];
+    let categories = common::test_categories_array();
     let y = [1.0, 2.0, 3.0, 4.0, 5.0];
     let weights = vec![1.0, 2.0, 1.5, 0.5, 3.0];
 
@@ -28,11 +28,18 @@ fn test_high_level_solve_weighted() {
         solve(categories.view(), &y, Some(&weights), &params, &precond).expect("solve weighted");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_solution_finite(&result);
+    common::assert_normal_equations_satisfied(
+        &common::test_categories(),
+        Some(weights.as_slice()),
+        &y,
+        &result,
+        1e-6,
+    );
 }
 
 #[test]
 fn test_solve_batch_matches_individual() {
-    let categories = array![[0u32, 0], [1, 0], [0, 1], [1, 1], [2, 0]];
+    let categories = common::test_categories_array();
     let y1 = vec![1.0, 2.0, 3.0, 4.0, 5.0];
     let y2 = vec![5.0, 4.0, 3.0, 2.0, 1.0];
 
@@ -56,7 +63,7 @@ fn test_solve_batch_matches_individual() {
 
 #[test]
 fn test_solve_batch_single_rhs() {
-    let categories = array![[0u32, 0], [1, 0], [0, 1], [1, 1], [2, 0]];
+    let categories = common::test_categories_array();
     let y = [1.0, 2.0, 3.0, 4.0, 5.0];
 
     let params = LsmrOptions::default();
@@ -72,7 +79,7 @@ fn test_solve_batch_single_rhs() {
 
 #[test]
 fn test_solve_batch_weighted() {
-    let categories = array![[0u32, 0], [1, 0], [0, 1], [1, 1], [2, 0]];
+    let categories = common::test_categories_array();
     let y1 = vec![1.0, 2.0, 3.0, 4.0, 5.0];
     let y2 = vec![5.0, 4.0, 3.0, 2.0, 1.0];
     let weights = vec![1.0, 2.0, 1.5, 0.5, 3.0];
@@ -95,7 +102,7 @@ fn test_solve_batch_weighted() {
 
 #[test]
 fn test_batch_result_accessors() {
-    let categories = array![[0u32, 0], [1, 0], [0, 1], [1, 1], [2, 0]];
+    let categories = common::test_categories_array();
     let y1 = vec![1.0, 2.0, 3.0, 4.0, 5.0];
     let y2 = vec![5.0, 4.0, 3.0, 2.0, 1.0];
 

--- a/crates/within/tests/orchestrate_solve.rs
+++ b/crates/within/tests/orchestrate_solve.rs
@@ -17,6 +17,7 @@ fn test_lsmr_unpreconditioned() {
     let solver = Solver::new(design, None, None).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
+    common::assert_normal_equations_satisfied(&common::test_categories(), None, &y, &result, 1e-6);
 }
 
 #[test]
@@ -36,6 +37,7 @@ fn test_lsmr_preconditioned() {
     let solver = Solver::new(design, None, &precond).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
+    common::assert_normal_equations_satisfied(&common::test_categories(), None, &y, &result, 1e-6);
 }
 
 #[test]
@@ -53,6 +55,7 @@ fn test_lsmr_diagonal_preconditioned() {
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_solution_finite(&result);
+    common::assert_normal_equations_satisfied(&common::test_categories(), None, &y, &result, 1e-6);
 }
 
 #[test]
@@ -69,6 +72,7 @@ fn test_lsmr_least_squares() {
     let result = solver.solve(&y, &params).expect("solve");
     assert!(result.converged, "LSMR LS did not converge");
     common::assert_solution_finite(&result);
+    common::assert_normal_equations_satisfied(&common::test_categories(), None, &y, &result, 1e-6);
 }
 
 #[test]
@@ -84,8 +88,15 @@ fn test_lsmr_least_squares_weighted_preconditioned() {
         ..Default::default()
     };
     let precond = PreconditionerConfig::default();
-    let solver = Solver::new(design, Some(weights), &precond).expect("build solver");
+    let solver = Solver::new(design, Some(weights.clone()), &precond).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_solution_finite(&result);
+    common::assert_normal_equations_satisfied(
+        &common::test_categories(),
+        Some(weights.as_slice()),
+        &y,
+        &result,
+        1e-6,
+    );
 }

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -120,7 +120,10 @@ class SolveResult:
             shape ``(n_obs,)``.
         converged: Whether the LSMR solver met the convergence tolerance.
         iterations: Total number of LSMR iterations performed.
-        residual: Final relative residual norm.
+        residual: Relative normal-equation residual
+            ``||D^T W (y - Dx)|| / ||D^T W y||`` estimated from the LSMR
+            recurrence at no extra cost. Exact for an unpreconditioned solve;
+            measured in the preconditioner's metric otherwise.
         time_total: Wall-clock time for the entire solve (setup + solve), in seconds.
         time_setup: Wall-clock time for the setup phase (operator + preconditioner
             construction), in seconds.
@@ -163,7 +166,8 @@ class BatchSolveResult:
         demeaned: Demeaned responses, shape ``(n_obs, k)`` (column-major).
         converged: Whether each RHS converged.
         iterations: Total LSMR iterations for each RHS.
-        residual: Final relative residual norm for each RHS.
+        residual: Per-RHS relative normal-equation residual estimate
+            (see ``SolveResult.residual``).
         time_solve: Wall-clock solve time for each RHS, in seconds.
         time_total: Wall-clock time for the entire batch (including shared setup),
             in seconds.

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -24,6 +24,29 @@ def as_solver_categories(cats):
     return np.asfortranarray(np.column_stack(cats).astype(np.uint32))
 
 
+def assert_normal_equations_satisfied(cats, y, result, tol, weights=None):
+    """Independent optimality oracle for a categorical fixed-effects design.
+
+    Recomputes the relative normal-equation residual
+    ``||D^T W (y - Dx)|| / ||D^T W y||`` from ``result.demeaned`` (``y - Dx``,
+    produced separately from the LSMR recurrence) and the raw categories. Unlike
+    ``result.residual`` -- now the solver's own stopping estimate -- this cannot
+    be satisfied by the solver merely reporting convergence.
+    """
+    y = np.asarray(y, dtype=np.float64)
+    demeaned = np.asarray(result.demeaned, dtype=np.float64)
+    w = np.ones_like(y) if weights is None else np.asarray(weights, dtype=np.float64)
+    num_sq = den_sq = 0.0
+    for c in cats:
+        c = np.asarray(c)
+        num_sq += np.square(np.bincount(c, weights=w * demeaned)).sum()
+        den_sq += np.square(np.bincount(c, weights=w * y)).sum()
+    relative = num_sq**0.5 / max(den_sq**0.5, 1e-15)
+    assert relative < tol, (
+        f"independent normal-equation residual {relative} exceeds {tol}"
+    )
+
+
 def test_coefficient_layout_locates_unidentified_and_round_trips():
     # firm level 2 is a singleton in the (non-first) slope term, so its slope
     # direction is unidentified.
@@ -123,6 +146,7 @@ class TestSolveDefaults:
         assert result.converged
         assert result.iterations > 0
         assert result.residual < 1e-6
+        assert_normal_equations_satisfied(cats, y, result, 1e-6)
 
     def test_unpreconditioned(self, problem):
         cats, y = problem


### PR DESCRIPTION
Resolves the four code-audit findings from the review, one commit each.

- **#153** — removes the workspace's only `unsafe` (unchecked indexing in the dense triangular solve). Switched to checked indexing; measured no end-to-end cost, since the kernel only runs on tiny (≤ `dense_threshold`) minors and fires <50×/solve.
- **#152** — deletes the unreachable `beta > 0.0` guards in the bidiagonalization step (`beta` is a sqrt and the `beta == 0.0` breakdown returns early).
- **#150 + #149** — `SolveResult.residual` / `BatchSolveResult.residual` now report the LSMR recurrence's normal-equation residual *estimate* instead of recomputing it exactly via two adjoint passes per solve (a fixed ~1-iteration tax: ~7–9% of a typical solve, up to ~30% of a fast one, paid per RHS in `solve_batch`). Exact for an unpreconditioned solve; in the preconditioner's metric otherwise — the scipy/PETSc convention. Docstrings and CHANGELOG updated to describe it correctly.

Incidentally removes within's duplicate `norm` helper (the dead copy flagged in #151), leaving `schwarz-precond::vec_norm` as the single implementation.

clippy `-D warnings` clean; 227 Rust + 100 Python tests green.

Closes #149. Closes #150. Closes #152. Closes #153.