### PR TITLE
docs: kernel-scope statement + config #[non_exhaustive] policy (#159, #163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ By the Frisch-Waugh-Lovell theorem, estimating a regression of the form *y = Xβ
 
 ## Scope
 
-`within` is a low-level fixed-effects kernel. Callers pass pre-factorized categorical codes: contiguous 0-based `uint32` level codes in F-order (column-major) arrays. Formula-level convenience — DataFrames, string/object categoricals, `pandas.factorize`, and formula parsing — is intentionally out of scope and belongs to a frontend layer built on top. The pyfixest/fixest-style workflow is served by such a frontend calling `within` underneath.
+`within` is a low-level fixed-effects kernel. Callers pass pre-factorized categorical codes: contiguous 0-based `uint32` level codes in F-order (column-major) arrays. Formula-level convenience — DataFrames, string/object categoricals, `pandas.factorize`, and formula parsing — is intentionally out of scope and belongs to a frontend layer built on top. The pyfixest-style workflow is served by such a frontend calling `within` underneath.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ By the Frisch-Waugh-Lovell theorem, estimating a regression of the form *y = Xβ
 
 `within`'s solvers are tailored to the structure of fixed effects problems, which can be represented as a graph (as first noted by Correia, 2016). Concretely, `within` uses modified LSMR with a domain decomposition (Schwarz) preconditioner, backed by approximate Cholesky local solvers (Gao et al, 2025).
 
+## Scope
+
+`within` is a low-level fixed-effects kernel. Callers pass pre-factorized categorical codes: contiguous 0-based `uint32` level codes in F-order (column-major) arrays. Formula-level convenience — DataFrames, string/object categoricals, `pandas.factorize`, and formula parsing — is intentionally out of scope and belongs to a frontend layer built on top. The pyfixest/fixest-style workflow is served by such a frontend calling `within` underneath.
+
 ## Installation
 
 You can install Python bindings from PyPi by running 

--- a/crates/within/src/config.rs
+++ b/crates/within/src/config.rs
@@ -3,6 +3,13 @@
 //! `Option<&PreconditionerConfig>` accepts `None` (default Additive Schwarz),
 //! `Some(Off)` (identity), `Some(Additive(_))` (tuned), or
 //! `Some(Diagonal)` (Jacobi).
+//!
+//! Stability policy: enums that may gain variants (the preconditioner strategy
+//! set) stay `#[non_exhaustive]`, so adding a variant is non-breaking — external
+//! `match` sites already carry a wildcard arm. Option structs commit to public
+//! fields and literal construction; adding a field is a deliberate breaking
+//! change, caught mechanically by the cargo-semver-checks CI gate rather than
+//! slipping through silently.
 
 pub use schwarz_precond::ReductionStrategy;
 


### PR DESCRIPTION
Documents two deliberate decisions. Doc-only — no code changes.

- **#159**: adds a "Scope" section to the README positioning `within` as a low-level fixed-effects kernel. Callers pass pre-factorized 0-based `uint32` F-order codes; formula-level convenience (DataFrames, `pandas.factorize`, formula parsing) is intentionally out of scope and belongs to a frontend layer above.
- **#163**: records the config-surface stability policy as a module-doc in `crates/within/src/config.rs`. Extensible strategy enums stay `#[non_exhaustive]`; option structs commit to public-field literal construction, so field additions are deliberate breaking changes caught by the cargo-semver-checks gate (#156).

Verified the code already matches the #163 policy: `PreconditionerConfig` is a `#[non_exhaustive]` enum; the five option structs have public fields and no `#[non_exhaustive]`.

Closes #159, closes #163.