### PR TITLE
harden core: typed DOF-space error, overflow-safe b-norm, surfaced build warnings

### DIFF
--- a/crates/schwarz-precond/src/lsmr/bidiag.rs
+++ b/crates/schwarz-precond/src/lsmr/bidiag.rs
@@ -398,8 +398,9 @@ impl<'a, A: Operator + ?Sized> GolubKahan<'a, A> {
         let n = operator.ncols();
         let mut bufs = GolubKahanBuffers::new(m, n, local_size);
 
-        // β₁ = ‖b‖, u₁ = b / β₁
-        let beta = par_dot(b, b).sqrt();
+        // β₁ = ‖b‖ via the max-scaled norm: par_dot(b, b).sqrt() overflows to ∞
+        // for large-magnitude b, zeroing u₁ into a silent x = 0 result.
+        let beta = super::vec_norm(b);
         if beta > 0.0 {
             let inv = 1.0 / beta;
             for (ui, &bi) in bufs.u.iter_mut().zip(b) {
@@ -489,8 +490,9 @@ impl<'a, A: Operator + ?Sized, M: Operator + ?Sized> ModifiedGolubKahan<'a, A, M
         let n = operator.ncols();
         let mut bufs = ModifiedGolubKahanBuffers::new(m, n, local_size);
 
-        // β₁ = ‖b‖, u₁ = b / β₁
-        let beta = par_dot(b, b).sqrt();
+        // β₁ = ‖b‖ via the max-scaled norm: par_dot(b, b).sqrt() overflows to ∞
+        // for large-magnitude b, zeroing u₁ into a silent x = 0 result.
+        let beta = super::vec_norm(b);
         if beta > 0.0 {
             let inv = 1.0 / beta;
             for (ui, &bi) in bufs.u.iter_mut().zip(b) {

--- a/crates/schwarz-precond/src/lsmr/tests.rs
+++ b/crates/schwarz-precond/src/lsmr/tests.rs
@@ -17,6 +17,27 @@ fn vec_norm_is_overflow_safe_and_propagates_nan() {
     assert!(vec_norm(&[0.0, f64::NAN]).is_nan());
 }
 
+/// Regression: a finite but large-magnitude RHS must not overflow β₁ = ‖b‖ to
+/// ∞ inside `init` (unscaled Σb²), which zeroed u₁ and α₁ and returned a silent
+/// converged x = 0.
+#[test]
+fn test_lsmr_large_magnitude_rhs_not_silently_zero() {
+    // Entries ~1e155: the unscaled Σb² = 1e310 overflows f64, but the
+    // max-scaled ‖b‖ stays finite. A = I, so the exact solution is x = b.
+    let b = vec![1e155, 2e155, 3e155];
+    let result = lsmr(&IdentityOp { n: 3 }, &b, 1e-10, 100, None).expect("lsmr solve");
+
+    let all_zero = result.x.iter().all(|&xi| xi == 0.0);
+    assert!(
+        !(all_zero && result.converged),
+        "large-magnitude b silently returned the all-zero solution as converged",
+    );
+
+    let diff: Vec<f64> = result.x.iter().zip(&b).map(|(x, bi)| x - bi).collect();
+    let rel_err = vec_norm(&diff) / vec_norm(&b);
+    assert!(rel_err < 1e-6, "relative solution error: {rel_err}");
+}
+
 /// Identity operator used by mlsmr equivalence tests.
 struct IdentityOp {
     n: usize,

--- a/crates/schwarz-precond/src/lsmr/tests.rs
+++ b/crates/schwarz-precond/src/lsmr/tests.rs
@@ -38,6 +38,33 @@ fn test_lsmr_large_magnitude_rhs_not_silently_zero() {
     assert!(rel_err < 1e-6, "relative solution error: {rel_err}");
 }
 
+/// Companion for the preconditioned path: within's default solve runs `mlsmr`
+/// → `ModifiedGolubKahan::init`, which carries the same β₁ = ‖b‖ fix. With
+/// A = I and M = I the exact solution is again x = b.
+#[test]
+fn test_mlsmr_large_magnitude_rhs_not_silently_zero() {
+    let b = vec![1e155, 2e155, 3e155];
+    let result = mlsmr(
+        &IdentityOp { n: 3 },
+        &b,
+        &IdentityOp { n: 3 },
+        1e-10,
+        100,
+        None,
+    )
+    .expect("preconditioned mlsmr solve");
+
+    let all_zero = result.x.iter().all(|&xi| xi == 0.0);
+    assert!(
+        !(all_zero && result.converged),
+        "large-magnitude b silently returned the all-zero solution as converged",
+    );
+
+    let diff: Vec<f64> = result.x.iter().zip(&b).map(|(x, bi)| x - bi).collect();
+    let rel_err = vec_norm(&diff) / vec_norm(&b);
+    assert!(rel_err < 1e-6, "relative solution error: {rel_err}");
+}
+
 /// Identity operator used by mlsmr equivalence tests.
 struct IdentityOp {
     n: usize,

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -149,6 +149,12 @@ impl<'a> Design<'a> {
             terms.push(meta);
         }
 
+        // DOFs index CSR columns as u32; a raw entity ID (or otherwise oversized
+        // level space) is rejected here rather than left to panic in to_u32.
+        if u32::try_from(offset).is_err() {
+            return Err(BuildError::DofSpaceExceedsU32 { n_dofs: offset });
+        }
+
         // Sort by the term contributing the most DOFs (for plain factors, the
         // highest-cardinality one) so its gather/scatter runs sequentially.
         // `obs_perm` indexes observations as u32; beyond u32::MAX rows skip
@@ -282,6 +288,18 @@ mod tests {
             continuous.into_iter().map(Into::into).collect(),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn build_rejects_dof_space_exceeding_u32() {
+        // A single code of u32::MAX implies u32::MAX + 1 levels — one past the
+        // CSR column-index width — the shape a raw entity ID takes. Rejected
+        // before any to_u32 conversion can panic.
+        let err = Design::from_frame(frame(vec![vec![u32::MAX]], vec![])).unwrap_err();
+        assert!(matches!(
+            err,
+            BuildError::DofSpaceExceedsU32 { n_dofs } if n_dofs == u32::MAX as usize + 1
+        ));
     }
 
     #[test]

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -97,6 +97,15 @@ pub enum BuildError {
         /// Actual column count of the supplied preconditioner.
         actual_cols: usize,
     },
+    /// The design's total degrees of freedom exceed `u32::MAX`, the width of the
+    /// CSR column index; the coefficient structure cannot be represented. The
+    /// usual cause is raw entity IDs passed as factor codes (`n_levels = max
+    /// code + 1`), which inflates the level space past what the solver indexes.
+    #[error("design has {n_dofs} degrees of freedom, exceeding the u32 column-index limit")]
+    DofSpaceExceedsU32 {
+        /// Total degrees of freedom implied by the design.
+        n_dofs: usize,
+    },
 }
 
 /// The channel pair whose signed cross-factor component an error or warning

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -210,6 +210,9 @@ pub struct SolveResult {
     pub x: Vec<f64>,
     /// Per-level directions the data cannot identify.
     pub unidentified: Vec<UnidentifiedDirection>,
+    /// Non-fatal preconditioner-build warnings (see [`Solver::warnings`]);
+    /// empty when a pre-built preconditioner was reused.
+    pub warnings: Vec<BuildWarning>,
     /// Address ↔ flat-`x`-index translation for this design's coefficients.
     pub layout: CoefficientLayout,
     /// Demeaned response: `y - D x` (length = n_obs), in caller order.
@@ -248,6 +251,9 @@ pub struct BatchSolveResult {
     /// Per-level directions the data cannot identify, shared across all RHS:
     /// identification depends only on the design and weights, never on `y`.
     pub unidentified: Vec<UnidentifiedDirection>,
+    /// Non-fatal preconditioner-build warnings, shared across all RHS; see
+    /// [`SolveResult::warnings`].
+    pub warnings: Vec<BuildWarning>,
     /// Address ↔ flat-`x`-index translation for this design's coefficients.
     pub layout: CoefficientLayout,
     /// All demeaned responses concatenated (length = n_obs * n_rhs).
@@ -470,6 +476,7 @@ impl<'a> Solver<'a> {
         Ok(SolveResult {
             x,
             unidentified,
+            warnings: self.warnings.clone(),
             layout: CoefficientLayout::from_design(&self.design),
             // Back to the caller's observation order (no-op if not reordered).
             demeaned: self.design.permute_obs_out(demeaned),
@@ -526,6 +533,7 @@ impl<'a> Solver<'a> {
         Ok(BatchSolveResult {
             x,
             unidentified,
+            warnings: self.warnings.clone(),
             layout: CoefficientLayout::from_design(&self.design),
             demeaned,
             converged,

--- a/crates/within/tests/warnings.rs
+++ b/crates/within/tests/warnings.rs
@@ -1,0 +1,75 @@
+//! One-shot `solve`/`solve_batch` entry points surface preconditioner
+//! [`BuildWarning`]s, not just [`Solver::warnings`] (#165).
+
+use within::{
+    solve, solve_batch, BuildWarning, Effect, LocalSolverConfig, PreconditionerConfig,
+    ReductionStrategy, ScalingConfig, ScalingFailure, Solver,
+};
+
+// Two crossed slope-only factors: their signed slope cross-block is not
+// diagonally dominant. A zero-tolerance / zero-sweep scaling policy reports
+// that as an uncertified-scaling warning deterministically, without relying on
+// the (deliberately rare) default-tolerance path.
+const LA: [u32; 4] = [0, 0, 1, 1];
+const LB: [u32; 4] = [0, 1, 0, 1];
+const ZA: [f64; 4] = [1.0, 1.0, 1.0, 1.0];
+const ZB: [f64; 4] = [1.0, -1.0, 2.0, -2.0];
+
+fn warning_effects() -> Vec<Effect<'static>> {
+    vec![
+        Effect::new(&LA, false, [&ZA[..]]).unwrap(),
+        Effect::new(&LB, false, [&ZB[..]]).unwrap(),
+    ]
+}
+
+fn strict_scaling() -> PreconditionerConfig {
+    PreconditionerConfig::Additive {
+        local_solver: LocalSolverConfig {
+            scaling: ScalingConfig {
+                tolerance: 0.0,
+                max_sweeps: 0,
+                on_failure: ScalingFailure::Warn,
+            },
+            ..LocalSolverConfig::default()
+        },
+        reduction: ReductionStrategy::default(),
+    }
+}
+
+fn has_scaling_warning(warnings: &[BuildWarning]) -> bool {
+    warnings
+        .iter()
+        .any(|w| matches!(w, BuildWarning::UnscalableComponent { .. }))
+}
+
+#[test]
+fn free_solve_surfaces_build_warnings() {
+    let y = [1.0, 2.0, 0.5, -1.0];
+    let cfg = strict_scaling();
+
+    let result = solve(warning_effects(), &y, None, None, &cfg).expect("solve");
+    assert!(
+        has_scaling_warning(&result.warnings),
+        "free solve dropped the preconditioner build warning: {:?}",
+        result.warnings,
+    );
+
+    // The result field mirrors the solver accessor exactly.
+    let solver = Solver::new(warning_effects(), None, &cfg).expect("solver");
+    assert_eq!(result.warnings.as_slice(), solver.warnings());
+}
+
+#[test]
+fn free_solve_batch_surfaces_build_warnings() {
+    let y0 = [1.0, 2.0, 0.5, -1.0];
+    let y1 = [0.2, -0.7, 1.3, 0.4];
+    let ys: [&[f64]; 2] = [&y0, &y1];
+    let cfg = strict_scaling();
+
+    let result = solve_batch(warning_effects(), &ys, None, None, &cfg).expect("solve_batch");
+    assert!(
+        has_scaling_warning(&result.warnings),
+        "free solve_batch dropped the preconditioner build warning: {:?}",
+        result.warnings,
+    );
+}

--- a/crates/within/tests/warnings.rs
+++ b/crates/within/tests/warnings.rs
@@ -72,4 +72,8 @@ fn free_solve_batch_surfaces_build_warnings() {
         "free solve_batch dropped the preconditioner build warning: {:?}",
         result.warnings,
     );
+
+    // The result field mirrors the solver accessor exactly.
+    let solver = Solver::new(warning_effects(), None, &cfg).expect("solver");
+    assert_eq!(result.warnings.as_slice(), solver.warnings());
 }


### PR DESCRIPTION
Three independent core-correctness fixes (file-disjoint from the other hardening PRs).

**#160** — a design whose total DOFs exceed `u32::MAX` (the CSR column-index width) now fails with a typed `BuildError::DofSpaceExceedsU32` instead of panicking in `to_u32`. This is the failure mode when raw entity IDs are passed as factor codes (`n_levels = max_code + 1`). Scoping: a *representable* but large level space is intentionally NOT rejected — within supports unobserved levels as unidentified directions, so any size heuristic would false-positive on legitimate sparse-sample designs.

**#164** — the initial β₁ = ‖b‖ in both bidiagonalization inits now uses the max-scaled `vec_norm`; the previous `par_dot(b,b).sqrt()` overflowed to ∞ for |b| ≳ 1e155, zeroing u₁/α₁ and returning a silent `x = 0` as `converged`. Regression test drives an actual solve at 1e155.

**#165** — `SolveResult`/`BatchSolveResult` carry a `warnings` field, so preconditioner build warnings are observable from the free `solve`/`solve_batch` (previously only via `Solver::warnings()`).

Closes #160, #164, #165.