### PR TITLE
ci(perf): non-blocking wall-clock perf alert (#147)

### DIFF
--- a/.github/workflows/perf-alert.yml
+++ b/.github/workflows/perf-alert.yml
@@ -1,0 +1,65 @@
+name: Perf Alert
+
+# Tier-2 wall-clock alert (#147): times the large 1M-row 3FE multi-threaded
+# solve on every merge to main and compares the best of N runs against a
+# committed, FIXED reference. NON-blocking by design — it raises a job-summary
+# alert but never fails the build (it runs post-merge, so it cannot block a
+# merge). Supersedes the rolling-baseline bench workflow from #139.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      update-reference:
+        description: "Bootstrap/refresh the committed wall-clock reference from this run (on CI hardware)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  wallclock:
+    name: Wall-clock 1M 3FE (alert only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: prefix-dev/setup-pixi@v0.8.8
+        with:
+          cache: true
+      - uses: Swatinem/rust-cache@v2
+
+      # Multi-threaded on purpose (default Rayon width = all runner cores): this
+      # tier is the multi-threaded safety net, not the deterministic path. The
+      # harness prints WALLCLOCK_BEST_NS=<ns> (best of N runs).
+      - name: Time 1M-row 3FE solve (release, best-of-N)
+        id: bench
+        run: |
+          out="$(pixi run -e default cargo bench -p within --bench wallclock_1m3fe)"
+          echo "$out"
+          best="$(printf '%s\n' "$out" | grep -oE 'WALLCLOCK_BEST_NS=[0-9]+' | tail -n1 | cut -d= -f2)"
+          echo "best_ns=${best:-}" >> "$GITHUB_OUTPUT"
+
+      - name: Bootstrap reference
+        if: github.event_name == 'workflow_dispatch' && inputs.update-reference && steps.bench.outputs.best_ns != ''
+        run: python3 scripts/check-wallclock-reference.py --measured-ns "${{ steps.bench.outputs.best_ns }}" --update
+
+      - name: Compare against committed reference (alert only)
+        if: steps.bench.outputs.best_ns != '' && !(github.event_name == 'workflow_dispatch' && inputs.update-reference)
+        run: python3 scripts/check-wallclock-reference.py --measured-ns "${{ steps.bench.outputs.best_ns }}" --commit "${{ github.sha }}"
+
+      - name: Commit refreshed reference
+        if: github.event_name == 'workflow_dispatch' && inputs.update-reference
+        run: |
+          if ! git diff --quiet -- benches/wallclock_reference.json; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add benches/wallclock_reference.json
+            git commit -m "chore(perf): bootstrap wall-clock reference (#147) [skip ci]"
+            git push
+          fi

--- a/benches/wallclock_reference.json
+++ b/benches/wallclock_reference.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Fixed (NOT rolling) wall-clock reference for the Tier-2 non-blocking perf alert (#147). best_ns is a PLACEHOLDER (null) until CI bootstraps it: the reference MUST be measured on CI hardware (ubuntu-latest), not a maintainer's machine, so run the perf-alert workflow via workflow_dispatch with update-reference=true on first setup. An intentional, accepted slowdown is recorded by re-running that dispatch, so drift shows up as a reviewable diff to this file. threshold_pct is set well above the repo's documented +-2-9% runner noise so only genuine sustained regressions alert (and the alert is non-blocking regardless).",
+  "threshold_pct": 25.0,
+  "best_ns": null
+}

--- a/crates/within/Cargo.toml
+++ b/crates/within/Cargo.toml
@@ -33,3 +33,7 @@ harness = false
 [[bench]]
 name = "store_backend"
 harness = false
+
+[[bench]]
+name = "wallclock_1m3fe"
+harness = false

--- a/crates/within/benches/wallclock_1m3fe.rs
+++ b/crates/within/benches/wallclock_1m3fe.rs
@@ -1,0 +1,50 @@
+//! Tier-2 wall-clock harness (#147): times the large 1M-row 3-way-FE solve and
+//! prints the best of N runs. `best-of-N` rejects one-sided contention noise —
+//! runner contention can only slow a run, so the minimum is the cleanest
+//! throughput estimate. Multi-threaded on purpose (default Rayon width): this
+//! tier is the multi-threaded safety net, not the deterministic path.
+//!
+//! Mirrors the `LSMR-AC` variant of the `fixest` Criterion smoke bench so the
+//! committed reference stays comparable. Prints `WALLCLOCK_BEST_NS=<ns>` for
+//! `scripts/check-wallclock-reference.py` to consume.
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use within::config::{LocalSolverConfig, LsmrOptions, PreconditionerConfig, ReductionStrategy};
+use within::Solver;
+
+#[path = "shared/fixest_dgp.rs"]
+mod fixest_dgp;
+use fixest_dgp::generate_fixest_like_case;
+
+const N_OBS: usize = 1_000_000;
+const N_FE: usize = 3;
+const SEED: u64 = 42;
+const RUNS: usize = 5;
+const MAXITER: usize = 200;
+const TOL: f64 = 1e-6;
+
+fn main() {
+    let (design, y) = generate_fixest_like_case(N_OBS, N_FE, true, SEED);
+    let params = LsmrOptions {
+        tol: TOL,
+        maxiter: MAXITER,
+        ..Default::default()
+    };
+    let precond = PreconditionerConfig::Additive {
+        local_solver: LocalSolverConfig::default(),
+        reduction: ReductionStrategy::Auto,
+    };
+
+    let mut best = u128::MAX;
+    for _ in 0..RUNS {
+        let start = Instant::now();
+        let solver = Solver::new(design.clone(), None, &precond).expect("solver build");
+        let result = solver.solve(&y, &params).expect("solve");
+        best = best.min(start.elapsed().as_nanos());
+        black_box(&result);
+    }
+
+    println!("WALLCLOCK_BEST_NS={best}");
+}

--- a/scripts/check-wallclock-reference.py
+++ b/scripts/check-wallclock-reference.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Tier-2 wall-clock perf alert (#147), NON-blocking.
+
+Compares the best wall-clock time of the 1M-row 3FE solve (from the
+`wallclock_1m3fe` bench harness) against a committed, FIXED reference. A
+regression beyond the reference's threshold raises a GitHub job-summary alert
+naming the merge. This script NEVER exits nonzero: a wall-clock signal on shared
+CI runners is advisory, not a build gate. Use --update to bootstrap/refresh the
+committed reference on CI hardware.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+DEFAULT_REFERENCE = "benches/wallclock_reference.json"
+
+
+def emit(markdown: str) -> None:
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as fh:
+            fh.write(markdown + "\n")
+    print(markdown)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--reference", default=DEFAULT_REFERENCE)
+    p.add_argument(
+        "--measured-ns",
+        type=float,
+        required=True,
+        help="best wall-clock nanoseconds emitted by the wallclock_1m3fe harness",
+    )
+    p.add_argument("--commit", default=os.environ.get("GITHUB_SHA", "(local run)"))
+    p.add_argument(
+        "--update",
+        action="store_true",
+        help="write the measured time into the reference file and exit",
+    )
+    args = p.parse_args()
+
+    ref_path = Path(args.reference)
+    reference = json.loads(ref_path.read_text())
+    measured = args.measured_ns
+    measured_ms = measured / 1e6
+
+    if args.update:
+        reference["best_ns"] = round(measured, 3)
+        ref_path.write_text(json.dumps(reference, indent=2) + "\n")
+        emit(f"Updated wall-clock reference to {measured_ms:.1f} ms (best of runs).")
+        return 0
+
+    baseline = reference.get("best_ns")
+    if not baseline:
+        emit(
+            f"⚠️ **Perf reference not bootstrapped.** Measured {measured_ms:.1f} ms. "
+            f"Run the perf-alert workflow via `workflow_dispatch` with "
+            f"`update-reference=true` to seed it on CI hardware."
+        )
+        return 0
+
+    threshold_pct = float(reference.get("threshold_pct", 25.0))
+    delta_pct = (measured - baseline) / baseline * 100.0
+    baseline_ms = baseline / 1e6
+
+    if delta_pct > threshold_pct:
+        emit(
+            f"## 🚨 Wall-clock perf regression (non-blocking)\n\n"
+            f"Merge `{args.commit}` slowed the 1M-row 3FE solve.\n\n"
+            f"| metric | value |\n|---|---|\n"
+            f"| best (this merge) | {measured_ms:.1f} ms |\n"
+            f"| reference | {baseline_ms:.1f} ms |\n"
+            f"| change | +{delta_pct:.1f}% |\n"
+            f"| threshold | +{threshold_pct:.1f}% |\n\n"
+            f"If this cost is expected, refresh the reference via the perf-alert "
+            f"`workflow_dispatch` (`update-reference=true`)."
+        )
+    else:
+        emit(
+            f"✅ Wall-clock within reference: {measured_ms:.1f} ms vs "
+            f"{baseline_ms:.1f} ms ({delta_pct:+.1f}%, threshold +{threshold_pct:.1f}%)."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a Tier-2 **non-blocking** wall-clock perf alert on every merge to `main`.

- `perf-alert.yml` (`push: main` + `workflow_dispatch` bootstrap) times the
  1M-row 3FE multi-threaded solve via a thin **best-of-5** harness
  (`benches/wallclock_1m3fe.rs`), which rejects one-sided contention noise.
- Compares the best run to a **fixed, committed** reference
  (`benches/wallclock_reference.json`) — not a rolling baseline, so drift shows
  up as a reviewable diff.
- On a breach beyond the threshold (**25%**, well above the repo's documented
  ±2–9% runner noise) it writes a job-summary alert naming the merge, and
  **never fails the build**.
- The reference ships as a `null` placeholder; CI bootstraps the real number on
  runner hardware via the `workflow_dispatch` `update-reference` mode (a
  maintainer's macOS time is not a valid ubuntu-latest reference).

Supersedes the rolling-baseline bench workflow from #139. Refs #137, #147.

Scope note: #146 (iai-callgrind cachegrind gate) was dropped — this PR is #147 only.