### PR TITLE
ci(perf): rebase-retry the wall-clock reference push (#147)

### DIFF
--- a/.github/workflows/perf-alert.yml
+++ b/.github/workflows/perf-alert.yml
@@ -56,10 +56,20 @@ jobs:
       - name: Commit refreshed reference
         if: github.event_name == 'workflow_dispatch' && inputs.update-reference
         run: |
-          if ! git diff --quiet -- benches/wallclock_reference.json; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add benches/wallclock_reference.json
-            git commit -m "chore(perf): bootstrap wall-clock reference (#147) [skip ci]"
-            git push
+          if git diff --quiet -- benches/wallclock_reference.json; then
+            exit 0
           fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add benches/wallclock_reference.json
+          git commit -m "chore(perf): bootstrap wall-clock reference (#147) [skip ci]"
+          # The bench takes minutes; a merge to main can land in that window and
+          # make the push a non-fast-forward. Rebase our single-file commit onto
+          # the new tip (no concurrent merge touches this file) and retry.
+          for attempt in 1 2 3 4 5; do
+            git push && exit 0
+            echo "push rejected (raced a merge to main); rebasing and retrying ($attempt)…"
+            git pull --rebase origin main
+          done
+          echo "::error::could not push refreshed wall-clock reference after retries"
+          exit 1


### PR DESCRIPTION
The manual bootstrap dispatch (`update-reference=true`) writes the refreshed reference back to `main`. The bench takes minutes, so any merge that lands in that window makes the push a non-fast-forward and fails the job — which is exactly what killed the last dispatch (it raced PR #167's merge), leaving `best_ns` still `null`.

Fix: rebase the single-file reference commit onto the new tip and retry the push (up to 5×). No concurrent merge touches `wallclock_reference.json`, so the rebase is conflict-free. Still fails loudly if all retries are exhausted.

Once merged, re-dispatch the workflow with `update-reference=true` to seed the (still-null) reference.