### PR TITLE
chore(deps): upgrade pyo3/numpy/ndarray, bump setup-pixi to v0.10.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.8
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           cache: true
       - uses: Swatinem/rust-cache@v2
@@ -52,7 +52,7 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.8
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           cache: true
       - uses: Swatinem/rust-cache@v2
@@ -67,7 +67,7 @@ jobs:
     needs: check
     steps:
       - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.8
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           cache: true
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/perf-alert.yml
+++ b/.github/workflows/perf-alert.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.8.8
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           cache: true
       - uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,15 +811,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "interpol"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,15 +941,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "nano-gemm"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
  "matrixmultiply",
  "num-complex",
@@ -1115,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.25.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1dee9aa8d3f6f8e8b9af3803006101bb3653866ef056d530d53ae68587191"
+checksum = "6a5b15d63a5ff39e378daed0e1340d3a5964703ea9712eb09a0dc66fade996f4"
 dependencies = [
  "libc",
  "ndarray",
@@ -1353,36 +1335,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1390,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1402,13 +1380,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]
@@ -1844,7 +1821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1987,12 +1964,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "valuable"

--- a/crates/within-py/Cargo.toml
+++ b/crates/within-py/Cargo.toml
@@ -13,5 +13,5 @@ crate-type = ["cdylib"]
 [dependencies]
 within = { path = "../within" }
 postcard.workspace = true
-pyo3 = { version = "0.25", features = ["extension-module", "abi3-py39"] }
-numpy = "0.25"
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }
+numpy = "0.29"

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -160,7 +160,7 @@ fn validate_batch_rows(y_rows: usize, n_obs: usize) -> PyResult<()> {
 ///
 /// Holds its columns natively (copied out of numpy) so the borrowed [`Effect`]
 /// it lowers to can be rebuilt off-GIL, where `Py` handles can't reach.
-#[pyclass(frozen, module = "within._within")]
+#[pyclass(frozen, skip_from_py_object, module = "within._within")]
 #[pyo3(name = "Effect")]
 #[derive(Clone)]
 pub struct PyEffect {
@@ -218,7 +218,7 @@ enum DesignSource<'py> {
 /// Interpret the Python `design` argument: a 2-D `uint32` categories matrix
 /// (borrowed) or a list of [`Effect`] terms (cloned out of Python).
 fn extract_design<'py>(py: Python<'_>, design: &Bound<'py, PyAny>) -> PyResult<DesignSource<'py>> {
-    if design.downcast::<PyUntypedArray>().is_ok() {
+    if design.cast::<PyUntypedArray>().is_ok() {
         let categories = readonly_u32_2d("design", design)?;
         warn_c_contiguous(py, &categories.as_array())?;
         return Ok(DesignSource::Categories(categories));
@@ -269,12 +269,12 @@ impl PySolver {
         let solver = match extract_design(py, design)? {
             DesignSource::Categories(categories) => {
                 let cats = categories.as_array();
-                py.allow_threads(move || -> Result<Solver<'static>, BuildError> {
+                py.detach(move || -> Result<Solver<'static>, BuildError> {
                     Solver::new(cats.into_design()?.into_owned(), weights_vec, precond)
                 })
             }
             DesignSource::Effects(terms) => {
-                py.allow_threads(move || -> Result<Solver<'static>, BuildError> {
+                py.detach(move || -> Result<Solver<'static>, BuildError> {
                     let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                     // The design borrows the terms' buffers; the solver outlives
                     // them, so lower to owned columns first.

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -79,7 +79,7 @@ impl PyApproxSchurConfig {
 /// Schur-complement reduction mode for `LocalSolverConfig`: approximate (the
 /// library default) or exact. Build via `Schur.approximate(...)` or
 /// `Schur.exact()`.
-#[pyclass(frozen, module = "within._within")]
+#[pyclass(frozen, skip_from_py_object, module = "within._within")]
 #[pyo3(name = "Schur")]
 #[derive(Clone)]
 pub struct PySchur {
@@ -195,7 +195,7 @@ impl PyScalingConfig {
 /// - ``PreconditionerConfig.Additive`` — additive Schwarz (default)
 /// - ``PreconditionerConfig.Off`` — no preconditioner
 /// - ``PreconditionerConfig.Diagonal`` — diagonal/Jacobi preconditioner
-#[pyclass(frozen, eq, eq_int, module = "within._within")]
+#[pyclass(frozen, eq, eq_int, from_py_object, module = "within._within")]
 #[pyo3(name = "PreconditionerConfig")]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum PyPreconditionerConfig {
@@ -204,7 +204,7 @@ pub enum PyPreconditionerConfig {
     Diagonal = 2,
 }
 
-#[pyclass(frozen, eq, eq_int, module = "within._within")]
+#[pyclass(frozen, eq, eq_int, from_py_object, module = "within._within")]
 #[pyo3(name = "ReductionStrategy")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PyReductionStrategy {
@@ -268,7 +268,7 @@ impl PyLocalSolverConfig {
 #[pyo3(name = "AdditiveSchwarz")]
 pub struct PyAdditiveSchwarz {
     #[pyo3(get)]
-    pub local_solver: Option<PyObject>,
+    pub local_solver: Option<Py<PyAny>>,
     #[pyo3(get)]
     pub reduction: PyReductionStrategy,
 }
@@ -277,7 +277,7 @@ pub struct PyAdditiveSchwarz {
 impl PyAdditiveSchwarz {
     #[new]
     #[pyo3(signature = (local_solver=None, reduction=PyReductionStrategy::Auto))]
-    fn new(local_solver: Option<PyObject>, reduction: PyReductionStrategy) -> Self {
+    fn new(local_solver: Option<Py<PyAny>>, reduction: PyReductionStrategy) -> Self {
         Self {
             local_solver,
             reduction,
@@ -432,7 +432,7 @@ pub(crate) fn resolve_precond_input(
     preconditioner: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<PrecondInput> {
     if let Some(obj) = preconditioner {
-        if let Ok(built) = obj.downcast::<PyPreconditioner>() {
+        if let Ok(built) = obj.cast::<PyPreconditioner>() {
             return Ok(PrecondInput::Prebuilt(built.get().inner.clone()));
         }
     }
@@ -460,13 +460,13 @@ fn extract_preconditioner_config(
     }
 
     // Advanced: AdditiveSchwarz object
-    if let Ok(schwarz) = obj.downcast::<PyAdditiveSchwarz>() {
+    if let Ok(schwarz) = obj.cast::<PyAdditiveSchwarz>() {
         let s = schwarz.get();
         let local = match &s.local_solver {
             None => LocalSolverConfig::default(),
             Some(obj) => {
                 let obj = obj.bind(py);
-                let Ok(sc) = obj.downcast::<PyLocalSolverConfig>() else {
+                let Ok(sc) = obj.cast::<PyLocalSolverConfig>() else {
                     return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
                         "local_solver must be LocalSolverConfig or None",
                     ));
@@ -512,7 +512,7 @@ pub(crate) fn resolve_lsmr_config(config: Option<&Bound<'_, PyAny>>) -> PyResult
     let Some(c) = config else {
         return Ok(LsmrOptions::default());
     };
-    if let Ok(lsmr) = c.downcast::<PyLsmrOptions>() {
+    if let Ok(lsmr) = c.cast::<PyLsmrOptions>() {
         let lsmr = lsmr.get();
         return Ok(LsmrOptions {
             tol: lsmr.tol,

--- a/crates/within-py/src/lib.rs
+++ b/crates/within-py/src/lib.rs
@@ -3,7 +3,7 @@
 
 //! Thin PyO3 bridge exposing the [`within`] crate to Python as `within._within`.
 //! Converts Python/numpy types to the native API and delegates all computation
-//! to [`within`]; every heavy call releases the GIL via [`Python::allow_threads`].
+//! to [`within`]; every heavy call releases the GIL via [`Python::detach`].
 //! Usage docs live in `python/within/` and the `within._within.pyi` stub.
 
 use pyo3::prelude::*;

--- a/crates/within-py/src/results.rs
+++ b/crates/within-py/src/results.rs
@@ -64,7 +64,7 @@ pub struct PyBatchSolveResult {
 }
 
 /// A per-level design direction the data cannot identify.
-#[pyclass(frozen, eq, hash, module = "within._within")]
+#[pyclass(frozen, eq, hash, skip_from_py_object, module = "within._within")]
 #[pyo3(name = "UnidentifiedDirection")]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PyUnidentifiedDirection {
@@ -88,7 +88,7 @@ impl PyUnidentifiedDirection {
 
 /// Translates a ``(term, level, column)`` coefficient address to its flat
 /// index in ``SolveResult.x`` and back.
-#[pyclass(frozen, module = "within._within")]
+#[pyclass(frozen, skip_from_py_object, module = "within._within")]
 #[pyo3(name = "CoefficientLayout")]
 #[derive(Clone)]
 pub struct PyCoefficientLayout {
@@ -228,7 +228,7 @@ where
     E: std::fmt::Display + Send,
     F: Send + FnOnce() -> Result<SolveResult, E>,
 {
-    let result = py.allow_threads(solve).map_err(value_err)?;
+    let result = py.detach(solve).map_err(value_err)?;
     Ok(into_py_result(py, result))
 }
 
@@ -241,7 +241,7 @@ where
     E: std::fmt::Display + Send,
     F: Send + FnOnce() -> Result<BatchSolveResult, E>,
 {
-    let result = py.allow_threads(solve).map_err(value_err)?;
+    let result = py.detach(solve).map_err(value_err)?;
     into_py_batch_result(py, result)
 }
 
@@ -263,7 +263,7 @@ where
     E: std::fmt::Display + Send,
     F: Send + FnOnce() -> Result<(SolveResult, Vec<BuildWarning>), E>,
 {
-    let (result, warnings) = py.allow_threads(solve).map_err(value_err)?;
+    let (result, warnings) = py.detach(solve).map_err(value_err)?;
     emit_build_warnings(py, &warnings)?;
     Ok(into_py_result(py, result))
 }
@@ -277,7 +277,7 @@ where
     E: std::fmt::Display + Send,
     F: Send + FnOnce() -> Result<(BatchSolveResult, Vec<BuildWarning>), E>,
 {
-    let (result, warnings) = py.allow_threads(solve).map_err(value_err)?;
+    let (result, warnings) = py.detach(solve).map_err(value_err)?;
     emit_build_warnings(py, &warnings)?;
     into_py_batch_result(py, result)
 }

--- a/crates/within/Cargo.toml
+++ b/crates/within/Cargo.toml
@@ -15,7 +15,7 @@ schwarz-precond = { workspace = true, features = ["serde"] }
 approx-chol = { version = "0.3.1", features = ["serde"] }
 serde = { workspace = true, features = ["rc"] }
 postcard.workspace = true
-ndarray = "0.16"
+ndarray = "0.17"
 portable-atomic = { version = "1", features = ["float"] }
 rayon.workspace = true
 faer.workspace = true


### PR DESCRIPTION
Updates the outdated dependency cluster and CI action.

**Rust cluster** (coupled — rust-numpy is version-locked to pyo3, and ndarray is shared):
- pyo3 0.25 → 0.29, numpy 0.25 → 0.29, ndarray 0.16 → 0.17
- Binding migration in `within-py`, behavior preserved: `allow_threads`→`detach`, `downcast`→`cast`, `PyObject`→`Py<PyAny>`, and the now-opt-in `FromPyObject` derive (`from_py_object` on the two extracted types, `skip_from_py_object` on the four Rust-only ones).

**CI**: `setup-pixi` v0.8.8 → v0.10.0 across `ci.yml` + `perf-alert.yml`.

Verified: `cargo build/test --workspace` clean, `pixi run test` 97 passed, and the cp39-abi3 wheel still audits clean (0 ABI violations) under pyo3 0.29.

Note: ndarray 0.17 changes `within`'s public `ArrayView2` signatures (breaking) — covered by the 0.3.0 bump in #169, which must merge after this.