### PR TITLE
fix(within-py): release the GIL during Preconditioner.apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Python `Preconditioner.apply` releases the GIL around the native Schwarz apply, matching the rest of the binding surface (#180).
 - Python `solve_batch` no longer emits the F-contiguity `UserWarning` twice for a C-order categories array.
 
 ### Removed

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -13,6 +13,8 @@ use within::config::{
 };
 use within::{Preconditioner, PreconditionerInput};
 
+use crate::convert::IntoPyErr;
+
 // ---------------------------------------------------------------------------
 // Low-level config classes (available via `_within` for benchmarks)
 // ---------------------------------------------------------------------------
@@ -345,12 +347,12 @@ impl PyPreconditioner {
                 self.inner.ncols()
             )));
         }
-        let mut y = vec![0.0; self.inner.nrows()];
-        self.inner
-            .apply(x_slice, &mut y)
-            .map_err(|e: within::SolveError| {
-                pyo3::exceptions::PyValueError::new_err(e.to_string())
-            })?;
+        let y = py
+            .detach(|| {
+                let mut y = vec![0.0; self.inner.nrows()];
+                self.inner.apply(x_slice, &mut y).map(|()| y)
+            })
+            .map_err(IntoPyErr::into_py_err)?;
         Ok(numpy::PyArray1::from_vec(py, y))
     }
     /// Number of rows (DOFs).


### PR DESCRIPTION
Wraps the native (Rayon) Schwarz apply in `py.detach`, so `Preconditioner.apply` releases the GIL like the rest of the binding surface — the input borrow and output/error construction stay on-GIL.

Also routes `apply`'s `SolveError` through the shared `IntoPyErr` classifier (introduced in #179) instead of a blanket `ValueError`, so a diverged subdomain solve or poisoned lock surfaces as `RuntimeError` here too — consistent with the solve paths.

**Stacked on #179** (base = `hardening/179-runtime-error-class`, which provides `IntoPyErr`). Merge #179 first.

Closes #180