### PR TITLE
test(within): drop vacuous if-converged guards

### DIFF
--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -79,8 +79,8 @@ class TestDegenerateY:
         )
         y = np.full(100, 5.0)
         result = solve(cats, y)
-        if result.converged:
-            np.testing.assert_allclose(result.demeaned, 0.0, atol=1e-4)
+        assert result.converged
+        np.testing.assert_allclose(result.demeaned, 0.0, atol=1e-4)
 
     def test_all_same_category_assignments(self):
         """All observations in one group per factor leaves no variation to explain."""
@@ -185,10 +185,8 @@ class TestNonContiguousInputs:
         result_contiguous = solve(cats, y_direct)
         result_strided = solve(cats, y_strided)
 
-        if result_contiguous.converged and result_strided.converged:
-            np.testing.assert_allclose(
-                result_contiguous.x, result_strided.x, atol=1e-12
-            )
+        assert result_contiguous.converged and result_strided.converged
+        np.testing.assert_allclose(result_contiguous.x, result_strided.x, atol=1e-12)
 
     def test_non_contiguous_weights_gives_same_result_as_contiguous(self):
         """Non-contiguous weights should give the same result as contiguous."""
@@ -206,10 +204,8 @@ class TestNonContiguousInputs:
         result_contiguous = solve(cats, y, weights=w_direct)
         result_strided = solve(cats, y, weights=w_strided)
 
-        if result_contiguous.converged and result_strided.converged:
-            np.testing.assert_allclose(
-                result_contiguous.x, result_strided.x, atol=1e-12
-            )
+        assert result_contiguous.converged and result_strided.converged
+        np.testing.assert_allclose(result_contiguous.x, result_strided.x, atol=1e-12)
 
     def test_c_contiguous_categories_emits_warning(self):
         """C-contiguous (row-major) categories should emit a UserWarning."""

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -136,8 +136,8 @@ class TestAdvancedPreconditioners:
                 reduction=ReductionStrategy.ParallelReduction
             ),
         )
-        if r_atomic.converged and r_parallel.converged:
-            np.testing.assert_allclose(r_atomic.x, r_parallel.x, atol=1e-4)
+        assert r_atomic.converged and r_parallel.converged
+        np.testing.assert_allclose(r_atomic.x, r_parallel.x, atol=1e-4)
 
 
 class TestBatchProperties:
@@ -171,8 +171,8 @@ class TestBatchProperties:
         solver = Solver(categories)
         batch = solver.solve_batch(Y)
         single = solver.solve(y)
-        if batch.converged[0] and single.converged:
-            np.testing.assert_allclose(batch.x[:, 0], single.x, atol=1e-12)
+        assert batch.converged[0] and single.converged
+        np.testing.assert_allclose(batch.x[:, 0], single.x, atol=1e-12)
 
     def test_batch_x_shape(self):
         """batch.x should have shape (n_dofs, k) where k is the number of columns."""
@@ -232,5 +232,5 @@ class TestBatchProperties:
         solver = Solver(categories)
         batch = solver.solve_batch(Y)
         for col in range(k):
-            if batch.converged[col]:
-                np.testing.assert_allclose(batch.x[:, col], 0.0, atol=1e-10)
+            assert batch.converged[col]
+            np.testing.assert_allclose(batch.x[:, col], 0.0, atol=1e-10)


### PR DESCRIPTION
Six correctness tests wrapped their equality assertion in `if <result>.converged:`, so a convergence regression would silently skip the assertion and let the test pass green.

Each of these six sites is an expected-convergence case. Replaced the guard with an explicit `assert ...converged` followed by the equality assertion run unconditionally, so a solve that fails to converge now fails the test instead of skipping it.

Sites:
- `tests/test_properties.py`: atomic-vs-parallel agreement, batch-vs-single equivalence, zero-response coefficients
- `tests/test_edge_cases.py`: degenerate-y demeaning, contiguous-vs-strided y, contiguous-vs-strided weights

All 32 tests in both files still pass.

Closes #178