### PR TITLE
refactor(within): drop unused serde derive on CsrMatrix

### DIFF
--- a/crates/within/src/block_elim/csr_matrix.rs
+++ b/crates/within/src/block_elim/csr_matrix.rs
@@ -20,7 +20,7 @@
 ///
 /// Block elimination produces these by construction, so [`CsrMatrix::new`] is
 /// infallible and the invariants are guarded only in debug builds.
-#[derive(Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Clone)]
 pub(crate) struct CsrMatrix {
     indptr: Vec<u32>,
     indices: Vec<u32>,


### PR DESCRIPTION
`CsrMatrix` is built transiently by Schur assembly and consumed by the sparse factor backend (`factor_sparse` turns it into a `CsrRef`, never storing it). No serialized type holds a `CsrMatrix` field, and it is never (de)serialized anywhere, so the derived `Deserialize` was a latent footgun: it would admit a structurally-invalid matrix, bypassing the CSR invariants `new` guards. Removing the unused `Serialize`/`Deserialize` derive compiles cleanly across the workspace.

Closes #182