### PR TITLE
chore(workspace): forbid unsafe_code via workspace lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - Corrected published examples and type stubs: `PreconditionerConfig` / `ReductionStrategy` are documented as (non-iterable) attribute holders rather than `IntEnum`, examples use the current argument order and `Schur` / `split_merge` spellings, and the varying-slopes workflow and minimal-norm normalization convention are documented (#102).
 - `SolveResult.residual` / `BatchSolveResult.residual` now report the LSMR recurrence's normal-equation residual *estimate* instead of recomputing it exactly, saving two passes per solve; exact when unpreconditioned, in the preconditioner's metric otherwise (#149).
 - **BREAKING (`schwarz-precond`):** `LsmrResult` gains a public `normal_eq_residual` field, the relative normal-equation residual estimate (#149).
+- All crates declare `#![forbid(unsafe_code)]` via workspace lints; the workspace is unsafe-free and reintroducing `unsafe` is now a compile error (#183).
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ serde = { version = "1", features = ["derive"] }
 postcard = { version = "1", features = ["use-std"] }
 thiserror = "2"
 
+[workspace.lints.rust]
+unsafe_code = "forbid"
+
 [profile.release]
 opt-level = 3
 lto = "fat"

--- a/crates/schwarz-precond/Cargo.toml
+++ b/crates/schwarz-precond/Cargo.toml
@@ -19,3 +19,6 @@ faer.workspace = true
 serde = { workspace = true, optional = true }
 thiserror.workspace = true
 thread_local = "1.1"
+
+[lints]
+workspace = true

--- a/crates/within-py/Cargo.toml
+++ b/crates/within-py/Cargo.toml
@@ -15,3 +15,6 @@ within = { path = "../within" }
 postcard.workspace = true
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }
 numpy = "0.29"
+
+[lints]
+workspace = true

--- a/crates/within/Cargo.toml
+++ b/crates/within/Cargo.toml
@@ -37,3 +37,6 @@ harness = false
 [[bench]]
 name = "wallclock_1m3fe"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/within/tests/ingest.rs
+++ b/crates/within/tests/ingest.rs
@@ -1,7 +1,7 @@
 //! Ingest boundary: `ArrayView2<u32>` categories arrays of any layout
 //! normalize to the same contiguous-column frame.
 
-use ndarray::{array, s, Array2, ShapeBuilder};
+use ndarray::{array, Array2, Axis, ShapeBuilder, Slice};
 use within::{solve, LsmrOptions, PreconditionerConfig};
 
 #[path = "common/orchestrate_helpers.rs"]
@@ -101,7 +101,7 @@ fn column_reversed_view_ingests_in_logical_order() {
         f.assign(&cats);
         f
     };
-    let reversed = cats_f.slice(s![.., ..;-1]);
+    let reversed = cats_f.slice_axis(Axis(1), Slice::new(0, None, -1));
     assert!(reversed.strides()[1] < 1, "column stride must be negative");
 
     let y = vec![1.0, 2.0, 3.0, 4.0, 5.0];


### PR DESCRIPTION
Makes the workspace's zero-`unsafe` property compiler-enforced instead of incidental.

`[workspace.lints.rust] unsafe_code = "forbid"` in the root, opted into by every crate via `[lints] workspace = true`. All three crates (`schwarz-precond`, `within`, `within-py`) get `forbid` — including `within-py`, whose PyO3 macros compiled cleanly under it. `forbid` cannot be locally silenced with `#[allow]`, so reintroducing `unsafe` is a hard compile error, not a silent regression.

One ingest test used ndarray's `s!` macro, which expands to `#[allow(unsafe_code)]` and is therefore incompatible with `forbid`; swapped it for the equivalent `slice_axis(Axis(1), Slice::new(0, None, -1))`, which injects no `allow`.

Verified `cargo build --workspace --all-targets` and `cargo test --workspace` pass, and that a scratch `unsafe fn` in `within` fails to compile under the new lint.

Closes #183
