### PR TITLE
hardening: pin mutation survivors + de-duplicate batch-solve worker

### DIFF
--- a/crates/within/src/block_elim.rs
+++ b/crates/within/src/block_elim.rs
@@ -30,3 +30,6 @@ pub(crate) fn compensated_sum(values: &[f64]) -> f64 {
     }
     sum + compensation
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/within/src/block_elim/tests.rs
+++ b/crates/within/src/block_elim/tests.rs
@@ -1,0 +1,34 @@
+use super::compensated_sum;
+
+// A naive left-to-right fold drops the small middle term (`1e16 + 1.0` rounds
+// back to `1e16`), returning 0.0; Neumaier compensation recovers the dropped
+// bits and returns exactly 1.0. The two orderings exercise both dominance
+// branches of the running compensation (`sum.abs() >= value.abs()` and `else`),
+// so each carried term is pinned rather than the naive and compensated results
+// coinciding.
+#[test]
+fn recovers_catastrophic_cancellation_in_both_branches() {
+    // Large value first: the `sum.abs() >= value.abs()` branch carries the 1.0.
+    let big_first = [1e16, 1.0, -1e16];
+    assert_eq!(
+        big_first.iter().sum::<f64>(),
+        0.0,
+        "naive fold loses the term"
+    );
+    assert_eq!(compensated_sum(&big_first), 1.0);
+
+    // Small value first: the `else` branch carries the 1.0.
+    let small_first = [1.0, 1e16, -1e16];
+    assert_eq!(
+        small_first.iter().sum::<f64>(),
+        0.0,
+        "naive fold loses the term"
+    );
+    assert_eq!(compensated_sum(&small_first), 1.0);
+}
+
+#[test]
+fn handles_empty_and_singleton() {
+    assert_eq!(compensated_sum(&[]), 0.0);
+    assert_eq!(compensated_sum(&[42.0]), 42.0);
+}

--- a/crates/within/src/csr_block.rs
+++ b/crates/within/src/csr_block.rs
@@ -354,4 +354,49 @@ mod tests {
         assert_eq!(bt.ncols, 2);
         assert_eq!(bt.nnz(), 0);
     }
+
+    // Above PAR_SPMV_THRESHOLD the parallel path must reproduce the sequential
+    // result exactly: each chunk reconstructs its global rows as
+    // `chunk_idx * chunk + local_i`, so a wrong reconstruction (or a no-op body)
+    // yields wrong output. Chunk *sizing* is a perf knob that cannot change the
+    // result — it is used consistently for both the split and the row offset —
+    // so it is deliberately not asserted.
+    #[test]
+    fn par_spmv_matches_seq_above_threshold() {
+        let nrows = PAR_SPMV_THRESHOLD + 2_000;
+        let ncols = 64;
+        let half = ncols / 2;
+
+        // Two nonzeros per row, columns kept distinct and ascending so the block
+        // is structurally valid; values vary with the row so a misindexed row is
+        // observable.
+        let mut indptr = vec![0u32; nrows + 1];
+        let mut indices = Vec::with_capacity(2 * nrows);
+        let mut data = Vec::with_capacity(2 * nrows);
+        for i in 0..nrows {
+            indices.push((i % half) as u32);
+            data.push(i as f64 * 0.5 + 1.0);
+            indices.push((half + i % half) as u32);
+            data.push(i as f64 * -0.25 - 2.0);
+            indptr[i + 1] = indptr[i] + 2;
+        }
+        let block = CsrBlock {
+            indptr,
+            indices,
+            data,
+            nrows,
+            ncols,
+        };
+
+        let x: Vec<f64> = (0..ncols).map(|j| (j as f64).sin()).collect();
+        let base: Vec<f64> = (0..nrows).map(|i| i as f64 * 1e-3).collect();
+
+        let mut y_par = vec![0.0; nrows];
+        block.par_spmv_assign_add(&x, &base, &mut y_par);
+
+        let mut y_seq = vec![0.0; nrows];
+        block.seq_spmv_assign_add(&x, &base, &mut y_seq);
+
+        assert_eq!(y_par, y_seq);
+    }
 }

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -323,6 +323,21 @@ impl std::fmt::Debug for Solver<'_> {
     }
 }
 
+/// Per-RHS solve output shared by [`Solver::solve`] and [`Solver::solve_batch`].
+///
+/// The design-level fields (`layout`, `warnings`, `unidentified`) are identical
+/// across RHS, so the batch path attaches them once instead of cloning them per
+/// RHS as it would if each worker returned a full [`SolveResult`].
+struct RhsSolution {
+    x: Vec<f64>,
+    demeaned: Vec<f64>,
+    converged: bool,
+    iterations: usize,
+    residual: f64,
+    time_setup: f64,
+    time_solve: f64,
+}
+
 impl<'a> Solver<'a> {
     /// Construct a solver.
     ///
@@ -401,14 +416,11 @@ impl<'a> Solver<'a> {
         &self.warnings
     }
 
-    /// Solve for a single RHS vector with the given LSMR tuning.
-    pub fn solve<'o>(
-        &self,
-        y: &[f64],
-        lsmr: impl Into<Option<&'o LsmrOptions>>,
-    ) -> Result<SolveResult, SolveError> {
-        let default = LsmrOptions::default();
-        let lsmr = lsmr.into().unwrap_or(&default);
+    /// Shared per-RHS solve: validate `y`, run (m)lsmr, demean, and
+    /// back-transform slopes. Excludes the design-level `layout` / `warnings` /
+    /// `unidentified`, which the public entry points attach once (see
+    /// [`RhsSolution`]).
+    fn solve_rhs(&self, y: &[f64], lsmr: &LsmrOptions) -> Result<RhsSolution, SolveError> {
         // Guard the silent-truncation hole: weighted_rhs zips y with sqrt-weights,
         // which would otherwise discard trailing values when y.len() > n_rows.
         if y.len() != self.design.n_obs {
@@ -460,32 +472,58 @@ impl<'a> Solver<'a> {
             *d = yi - *d;
         }
 
-        // Relative normal-equation residual estimate, read from the LSMR
-        // recurrence at no extra cost; see `SolveResult::residual`.
-        let residual = r.normal_eq_residual;
-
         let mut x = r.x;
-        let unidentified = match &self.reparam {
-            Some(rp) => {
-                rp.back_transform(&mut x);
-                rp.unidentified.clone()
-            }
-            None => Vec::new(),
-        };
+        if let Some(rp) = &self.reparam {
+            rp.back_transform(&mut x);
+        }
 
-        Ok(SolveResult {
+        Ok(RhsSolution {
             x,
-            unidentified,
-            warnings: self.warnings.clone(),
-            layout: CoefficientLayout::from_design(&self.design),
             // Back to the caller's observation order (no-op if not reordered).
             demeaned: self.design.permute_obs_out(demeaned),
             converged: r.converged,
             iterations: r.iterations,
-            residual,
-            time_total: t_start.elapsed().as_secs_f64(),
+            // Relative normal-equation residual estimate, read from the LSMR
+            // recurrence at no extra cost; see `SolveResult::residual`.
+            residual: r.normal_eq_residual,
             time_setup,
             time_solve,
+        })
+    }
+
+    /// Per-level directions the data cannot identify, shared across all RHS:
+    /// identification depends only on the design and weights, never on `y`.
+    fn unidentified(&self) -> Vec<UnidentifiedDirection> {
+        self.reparam
+            .as_ref()
+            .map(|rp| rp.unidentified.clone())
+            .unwrap_or_default()
+    }
+
+    /// Solve for a single RHS vector with the given LSMR tuning.
+    pub fn solve<'o>(
+        &self,
+        y: &[f64],
+        lsmr: impl Into<Option<&'o LsmrOptions>>,
+    ) -> Result<SolveResult, SolveError> {
+        let default = LsmrOptions::default();
+        let lsmr = lsmr.into().unwrap_or(&default);
+
+        let t_start = Instant::now();
+        let solution = self.solve_rhs(y, lsmr)?;
+
+        Ok(SolveResult {
+            x: solution.x,
+            unidentified: self.unidentified(),
+            warnings: self.warnings.clone(),
+            layout: CoefficientLayout::from_design(&self.design),
+            demeaned: solution.demeaned,
+            converged: solution.converged,
+            iterations: solution.iterations,
+            residual: solution.residual,
+            time_total: t_start.elapsed().as_secs_f64(),
+            time_setup: solution.time_setup,
+            time_solve: solution.time_solve,
         })
     }
 
@@ -500,11 +538,13 @@ impl<'a> Solver<'a> {
         let lsmr = lsmr.into().unwrap_or(&default);
         let n_rhs = ys.len();
 
-        // Fail fast on the first per-RHS error rather than materializing a
-        // `Vec<Result<..>>` and only surfacing the failure during the fold.
-        let results: Vec<SolveResult> = ys
+        // Each worker returns only the per-RHS fields; the design-level `layout`
+        // / `warnings` / `unidentified` are built once below, not once per RHS.
+        // Collecting into `Result` fails fast on the first per-RHS error rather
+        // than surfacing it during the fold.
+        let solutions: Vec<RhsSolution> = ys
             .par_iter()
-            .map(|y| self.solve(y, lsmr))
+            .map(|y| self.solve_rhs(y, lsmr))
             .collect::<Result<Vec<_>, _>>()?;
 
         let mut x = Vec::with_capacity(self.design.n_dofs * n_rhs);
@@ -514,25 +554,18 @@ impl<'a> Solver<'a> {
         let mut residual = Vec::with_capacity(n_rhs);
         let mut time_solve = Vec::with_capacity(n_rhs);
 
-        // Identical for every RHS: identification depends only on the design
-        // and weights, never on `y`.
-        let unidentified = results
-            .first()
-            .map(|r| r.unidentified.clone())
-            .unwrap_or_default();
-
-        for r in results {
-            x.extend_from_slice(&r.x);
-            demeaned.extend_from_slice(&r.demeaned);
-            converged.push(r.converged);
-            iterations.push(r.iterations);
-            residual.push(r.residual);
-            time_solve.push(r.time_solve);
+        for solution in solutions {
+            x.extend_from_slice(&solution.x);
+            demeaned.extend_from_slice(&solution.demeaned);
+            converged.push(solution.converged);
+            iterations.push(solution.iterations);
+            residual.push(solution.residual);
+            time_solve.push(solution.time_solve);
         }
 
         Ok(BatchSolveResult {
             x,
-            unidentified,
+            unidentified: self.unidentified(),
             warnings: self.warnings.clone(),
             layout: CoefficientLayout::from_design(&self.design),
             demeaned,


### PR DESCRIPTION
Two independent quality changes from a fresh-eyes review, one commit each.

**Pin mutation survivors** — `cargo-mutants` had live survivors in `compensated_sum`'s Neumaier compensation branch and `par_spmv_assign_add`'s row-index reconstruction (naive and compensated summation agreed on tested inputs; no test drove a block past `PAR_SPMV_THRESHOLD`). Adds two targeted tests: catastrophic-cancellation orderings for the former (one per dominance branch), parallel-vs-sequential equality above the threshold for the latter. Kills all 8 `compensated_sum` mutants and the correctness-threatening spmv mutants (whole-body no-op, `row_start`, `i` reconstruction). The remaining spmv survivors are **equivalent** — path selection and chunk sizing cannot change the result.

**De-duplicate batch solve** — `solve_batch` reused the public `solve` as its per-RHS worker, so each of `n_rhs` parallel tasks built a full `SolveResult` (an `n_terms` `CoefficientLayout`, a warnings clone, a unidentified clone) of which the batch kept one and rebuilt the rest once. Extracts a private `SolveCore` with only the per-RHS fields; `solve`/`solve_batch` attach the design-level fields once. `unidentified` now comes straight from the reparam, so an empty batch reports the design's directions rather than an empty list.

No public API change. `cargo clippy -D warnings`, the full `within` Rust suite, and the Python solve/batch tests pass; a scoped `cargo mutants` confirms the kills (39 caught / 8 equivalent).