### PR TITLE
Guard doubled cover dimensions against u32 overflow; correct observation-count docs (#192, #193)

### DIFF
--- a/crates/within/src/block_elim/solver.rs
+++ b/crates/within/src/block_elim/solver.rs
@@ -300,6 +300,11 @@ fn assemble_bipartite_cover(
     let n_q = c.nrows;
     let n_r = c.ncols;
     let n_r_u32 = u32::try_from(n_r).expect("cover columns exceed u32::MAX");
+    // The cover doubles both dimensions: transpose stores source rows (0..2*n_q)
+    // as u32 indices and the cross-sheet shift emits columns up to 2*n_r - 1, so
+    // both doubled sizes — not just n_r — must fit the u32 index.
+    u32::try_from(2 * n_q).expect("doubled cover rows exceed u32::MAX");
+    u32::try_from(2 * n_r).expect("doubled cover columns exceed u32::MAX");
 
     let mut indptr = Vec::with_capacity(2 * n_q + 1);
     let mut indices = Vec::with_capacity(2 * c.nnz());

--- a/crates/within/src/domain/effect.rs
+++ b/crates/within/src/domain/effect.rs
@@ -1,7 +1,7 @@
 use crate::BuildError;
 
 /// One factor's contribution to a design: level codes, an optional per-level
-/// intercept, and per-level slope covariates.
+/// intercept, and per-observation slope covariates.
 #[derive(Clone, Debug)]
 pub struct Effect<'a> {
     levels: &'a [u32],
@@ -10,7 +10,7 @@ pub struct Effect<'a> {
 }
 
 impl<'a> Effect<'a> {
-    /// Validates the effect is non-empty and every slope matches the level count.
+    /// Validates the effect is non-empty and every slope has one value per observation.
     pub fn new(
         levels: &'a [u32],
         intercept: bool,

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -24,12 +24,12 @@ pub enum BuildError {
     /// An effect with neither an intercept nor a slope.
     #[error("an effect must have an intercept or at least one slope")]
     EmptyEffect,
-    /// A slope covariate's length does not match the effect's level count.
+    /// A slope covariate's length does not match the observation count.
     #[error("slope {slope} has {got} values, expected {expected}")]
     SlopeLengthMismatch {
         /// Index of the slope covariate within its effect.
         slope: usize,
-        /// Expected length (the effect's level count).
+        /// Expected length (the observation count — one value per row).
         expected: usize,
         /// Actual length.
         got: usize,


### PR DESCRIPTION
Two audit good-first-issues, batched.

**#192** — `assemble_bipartite_cover` doubles both dimensions but bounded only
`n_r`; the doubled row and column widths now both get the u32 guard, so a signed
component in the (2^31, 2^32] window is rejected instead of wrapping (column
shift) or silently truncating (`transpose`'s `as u32`). Unreachable at real data
sizes — triggering it needs a ~16 GB diagonal before the guard is reached — so no
test, like every sibling u32 guard.

**#193** — slope covariates are validated per observation (`levels.len()`), not
per distinct level; corrected the `SlopeLengthMismatch` variant/field docs and
the `Effect` docs.

Closes #192, closes #193
