### PR TITLE
Report preconditioner-build time on batch results (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 - **Varying slopes:** factor effects can carry continuous slope covariates via the new `Effect` term type (level codes, an intercept flag, and zero or more slope columns), accepted anywhere a categories matrix is — Rust `Solver::new` / `solve` / `solve_batch` and the Python first argument (#58–#63).
 - `SolveResult` / `BatchSolveResult` report unidentified directions as `UnidentifiedDirection` records (`term`, `level`, `column`) in both Rust and Python; those coefficient slots hold `0`, never NaN (#69).
+- `BatchSolveResult.time_setup` (Rust and Python) reports the shared per-batch setup time — solver and preconditioner construction (`Solver::new`) — which the free `solve_batch` previously left only in `time_total` (#194).
 - `CoefficientLayout` (Rust and Python), reached via `SolveResult.layout` / `BatchSolveResult.layout`, translates a `(term, level, column)` address to its flat `x` index and back, so callers need not reconstruct term offsets by hand (#99).
 - `SolveResult.x` is term-major — coefficient column `c` of `level` sits at `term_offset + c * n_levels + level`; intercept-only designs keep the 0.2.0 ordering (#71).
 - `ScalingConfig` (in `within.config`) tunes certification of signed-component scaling; `Solver::warnings()` returns non-fatal `BuildWarning`s from the build (#61).

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -49,7 +49,9 @@ fn build_and_solve_batch<'a>(
 ) -> Result<(BatchSolveResult, Vec<BuildWarning>), WithinError> {
     let t_start = Instant::now();
     let solver = Solver::new(design, weights.map(|w| w.to_vec()), precond)?;
+    let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve_batch(ys, lsmr)?;
+    result.time_setup += time_setup;
     result.time_total = t_start.elapsed().as_secs_f64();
     Ok((result, solver.warnings().to_vec()))
 }

--- a/crates/within-py/src/results.rs
+++ b/crates/within-py/src/results.rs
@@ -60,6 +60,8 @@ pub struct PyBatchSolveResult {
     #[pyo3(get)]
     pub time_solve: Vec<f64>,
     #[pyo3(get)]
+    pub time_setup: f64,
+    #[pyo3(get)]
     pub time_total: f64,
 }
 
@@ -210,6 +212,7 @@ pub(crate) fn into_py_batch_result(
         iterations: result.iterations,
         residual: result.residual,
         time_solve: result.time_solve,
+        time_setup: result.time_setup,
         time_total: result.time_total,
     })
 }

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -267,6 +267,10 @@ pub struct BatchSolveResult {
     pub residual: Vec<f64>,
     /// Per-RHS solve times in seconds.
     pub time_solve: Vec<f64>,
+    /// Wall-clock time for the shared batch setup -- solver and preconditioner
+    /// construction (`Solver::new`) -- in seconds; 0 when a pre-built
+    /// preconditioner was reused.
+    pub time_setup: f64,
     /// Total wall-clock time for the entire batch (setup + all solves), in seconds.
     pub time_total: f64,
     /// Number of coefficients per RHS (rows of the underlying design).
@@ -573,6 +577,7 @@ impl<'a> Solver<'a> {
             iterations,
             residual,
             time_solve,
+            time_setup: 0.0,
             time_total: t_start.elapsed().as_secs_f64(),
             n_dofs: self.design.n_dofs,
             n_obs: self.design.n_obs,
@@ -645,7 +650,9 @@ pub fn solve_batch<'a, 'o>(
 ) -> Result<BatchSolveResult, WithinError> {
     let t_start = Instant::now();
     let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
+    let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve_batch(ys, lsmr)?;
+    result.time_setup += time_setup;
     result.time_total = t_start.elapsed().as_secs_f64();
     Ok(result)
 }

--- a/crates/within/tests/orchestrate_high_level.rs
+++ b/crates/within/tests/orchestrate_high_level.rs
@@ -140,6 +140,11 @@ fn test_batch_result_accessors() {
     assert_eq!(batch.time_solve.len(), 2);
     assert!(batch.time_solve.iter().all(|&t| t >= 0.0));
 
+    // The free solve_batch folds the shared preconditioner build into
+    // time_setup; a dropped build cost would read as exactly 0.
+    assert!(batch.time_setup > 0.0);
+    assert!(batch.time_setup <= batch.time_total);
+
     // time_total
     assert!(batch.time_total >= 0.0);
 

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -131,6 +131,10 @@ fn test_solver_batch() {
 
     assert_eq!(batch.converged.len(), 3);
     assert!(batch.converged.iter().all(|&c| c));
+
+    // The method reuses the already-built preconditioner, so it reports no
+    // build cost; the free solve_batch is what folds construction in.
+    assert_eq!(batch.time_setup, 0.0);
 }
 
 #[test]

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -172,6 +172,9 @@ class BatchSolveResult:
         residual: Per-RHS relative normal-equation residual estimate
             (see ``SolveResult.residual``).
         time_solve: Wall-clock solve time for each RHS, in seconds.
+        time_setup: Wall-clock time for the shared setup phase (solver and
+            preconditioner construction), in seconds; 0 when a pre-built
+            preconditioner was reused.
         time_total: Wall-clock time for the entire batch (including shared setup),
             in seconds.
     """
@@ -192,6 +195,8 @@ class BatchSolveResult:
     def residual(self) -> list[float]: ...
     @property
     def time_solve(self) -> list[float]: ...
+    @property
+    def time_setup(self) -> float: ...
     @property
     def time_total(self) -> float: ...
 

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -382,6 +382,8 @@ class TestSolverBatch:
         assert len(batch.iterations) == 2
         assert len(batch.residual) == 2
         assert len(batch.time_solve) == 2
+        # The method reuses the built preconditioner, so it reports no build cost.
+        assert batch.time_setup == 0.0
         assert batch.time_total >= 0
         assert batch.unidentified == []
 
@@ -478,6 +480,10 @@ class TestSolveBatchFreeFunction:
 
         result = solve_batch(categories, Y)
         assert all(result.converged)
+        # The free solve_batch folds the shared preconditioner build into
+        # time_setup; a dropped build cost would read as exactly 0.
+        assert result.time_setup > 0
+        assert result.time_setup <= result.time_total
 
     def test_solve_batch_matches_individual(self, problem):
         cats, y = problem


### PR DESCRIPTION
`BatchSolveResult` gains `time_setup` (Rust and Python), so the shared
preconditioner-build cost is observable on the batch API instead of being
folded away into `time_total` only.

- The free `solve_batch` folds the `Solver::new` build time into `time_setup`,
  mirroring the free `solve`. `Solver::solve_batch` reports `0.0` — it reuses an
  already-built preconditioner, so no build cost is incurred in that call.
- Threaded through the PyO3 binding (`PyBatchSolveResult` getter + `.pyi` stub).
- Tests pin both paths in Rust and Python: free-function `time_setup > 0` and
  `<= time_total` (a dropped build cost reads as exactly `0`), method `== 0.0`.

Note: this reports the *shared* build cost, not the per-RHS operator/gather setup
that single-solve `time_setup` additionally includes — that is inherently per-RHS,
not a shared scalar.

Closes #194
