### PR TITLE
refactor(within): enforce block-elim eliminate/recover overlap contract (#191)

### DIFF
--- a/crates/within/src/block_elim/solver.rs
+++ b/crates/within/src/block_elim/solver.rs
@@ -517,9 +517,23 @@ impl BlockElimSolver {
             SolveSpace::Signed => {}
         }
 
-        // Solve the reduced system in place. The `rhs` tail past the reduced
-        // block is the reduced factor's embed scratch (empty unless Cover).
+        // Anchored at the kept block, the reduced solve spills past it into the
+        // eliminated block (eliminate-r) or scratch tail (eliminate-q); those slots
+        // are dead except the grounded gauge slot, a transient the subtraction below
+        // consumes. The `rhs` tail is the factor's embed scratch (unused unless Cover).
         let reduced = roles.keep.start..roles.keep.start + self.n_reduced;
+        debug_assert!(
+            n_keep <= self.n_reduced,
+            "reduced region must cover the kept block",
+        );
+        debug_assert!(
+            reduced.end <= sol.len() && n + self.n_reduced <= rhs.len(),
+            "reduced solve and its RHS copy must fit sol and rhs",
+        );
+        debug_assert!(
+            explicit_ground.is_none_or(|g| n_keep <= g && g < self.n_reduced),
+            "grounded gauge slot must spill past the kept block into a solved slot",
+        );
         sol[reduced.clone()].copy_from_slice(&rhs[n..n + self.n_reduced]);
         let embed = &mut rhs[n + self.n_reduced..];
         self.reduced_factor
@@ -531,7 +545,8 @@ impl BlockElimSolver {
             }
         }
 
-        // Back-substitute to recover the eliminated block.
+        // Back-substitute for the eliminated block; it reads the gauged kept block,
+        // so the gauge subtraction above must run first.
         let (sol_output, sol_source) = roles.split_sol(sol);
         backsub_block_from_scaled_rhs(
             sol_output,

--- a/crates/within/src/block_elim/solver/tests.rs
+++ b/crates/within/src/block_elim/solver/tests.rs
@@ -91,6 +91,70 @@ fn test_block_elim_solver_eliminate_q_false() {
 }
 
 #[test]
+fn eliminate_r_explicit_ground_overlap_is_consumed_not_leaked() {
+    // Eliminate-r + grounded sparse factor: the reduced solve spills past the kept
+    // q-block into the eliminated r-block, landing the gauge in the first eliminated
+    // slot. Pins no-leak (pre-dirtying must not move the result) and A·x = r.
+    let (cross_tab, diagonals) = make_cross_tab_q_lt_r();
+    let config = LocalSolverConfig {
+        approx_chol: ApproxCholConfig::default(),
+        schur: SchurMode::Exact,
+        dense_threshold: 0, // force the sparse grounded path → explicit ground vertex
+        scaling: Default::default(),
+    };
+    let component = LocalComponent::general_for_test(cross_tab, diagonals);
+    let solver = BlockElimSolver::build(component, &config).expect("block-elim build failed");
+    let n_q = solver.cross_tab.n_q();
+    assert!(
+        !solver.eliminate_q,
+        "expected eliminate_q=false when n_q < n_r"
+    );
+    assert_eq!(
+        solver.explicit_ground_index(n_q),
+        Some(n_q),
+        "test must drive the eliminate-r explicit-ground overlap path",
+    );
+
+    // Original bipartite Gram A the solver inverts (diagonals + the two cross entries).
+    let n = solver.n_local();
+    let mut a = vec![vec![0.0; n]; n];
+    for (i, d) in [2.0, 3.0, 2.0, 3.0, 1.0, 1.0, 1.0].into_iter().enumerate() {
+        a[i][i] = d;
+    }
+    for (i, j) in [(0, 2), (1, 3)] {
+        a[i][j] = 1.0;
+        a[j][i] = 1.0;
+    }
+
+    let r = [1.0, -2.0, 0.5, 3.0, -1.25, 0.75, 2.0];
+    let solve_with_dirty = |dirty: f64| {
+        let mut rhs = vec![dirty; solver.scratch_size()];
+        rhs[..n].copy_from_slice(&r);
+        let mut sol = vec![dirty; solver.scratch_size()];
+        solver
+            .solve_local(&mut rhs, &mut sol, false)
+            .expect("solve_local failed");
+        sol
+    };
+    let clean = solve_with_dirty(0.0);
+    let dirty = solve_with_dirty(1e6);
+    assert_eq!(
+        clean[..n],
+        dirty[..n],
+        "pre-dirtied overlap/scratch slots leaked into the solution",
+    );
+
+    for i in 0..n {
+        let ax: f64 = (0..n).map(|j| a[i][j] * clean[j]).sum();
+        assert!(
+            (ax - r[i]).abs() < 1e-9,
+            "row {i}: A·x = {ax}, expected {}",
+            r[i],
+        );
+    }
+}
+
+#[test]
 fn trivial_singleton_component_solves_r_over_d() {
     // Live 1×1 components (positive diagonal, cancelled cross row) keep
     // n_keep = 0: the whole solve must degenerate to x = r/d exactly, in


### PR DESCRIPTION
Closes #191.

`eliminate_and_recover` places the reduced solve at `sol[keep.start .. keep.start + n_reduced]`, anchored at the kept block. In the eliminate-r orientation it spills past the kept block into the eliminated block, and the grounded gauge potential lands in the first eliminated slot. Correct, but the overlap invariant was implicit and untested.

- Three `debug_assert!` contract checks at the reduced solve: the region covers the kept block, the solve and its RHS copy fit both buffers, and the grounded gauge slot spills into a slot the reduced solve actually wrote.
- Document the gauge-before-backsub ordering dependency (back-sub reads the gauged kept block).
- New regression test `eliminate_r_explicit_ground_overlap_is_consumed_not_leaked`: pins the eliminate-r + explicit-ground path via an `A·x = r` oracle plus a pre-dirtied-buffer no-leak check.

Verified by deliberately reordering gauge/back-sub: the new oracle test fails loudly, while the pre-existing finiteness-only test still passed — confirming the gap this closes.