### PR TITLE
ci: platform tests on PRs + drop debug info (Windows speedup experiment)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,13 @@ jobs:
 
   platform:
     name: Tests (${{ matrix.os }})
-    if: github.ref == 'refs/heads/main' || github.event_name == 'push'
     runs-on: ${{ matrix.os }}
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
+      # CI only needs pass/fail: dropping debug info shrinks artifacts (faster
+      # Windows linking) and the target cache (faster restore).
+      RUSTFLAGS: "-C debuginfo=0"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Measuring whether `-C debuginfo=0` on the platform job brings Windows PR time down enough to justify running mac/Windows on every PR. Gate temporarily removed to measure on this PR.