### PR TITLE
ci: cancel superseded PR runs via concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Cancel superseded PR runs; let every push to main run to completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     name: Check + Coverage (Linux)


### PR DESCRIPTION
Adds a `concurrency` group so new pushes to a PR cancel its stale in-progress runs. Scoped by ref, and `cancel-in-progress` only for `pull_request` events so every push to main runs to completion.