### PR TITLE
ci: MSRV dev-deps, least-privilege perf alert, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,5 @@
 version: 2
 
-# pixi.lock has no Dependabot ecosystem, so the conda-side toolchain and test
-# deps (rust, maturin, pytest, uv) stay manual.
 updates:
   - package-ecosystem: github-actions
     directory: "/"
@@ -11,21 +9,13 @@ updates:
       actions:
         patterns: ["*"]
     ignore:
-      # @1.85.0 asserts the declared rust-version; bumping it would leave a
-      # green MSRV check that no longer tests the MSRV.
       - dependency-name: dtolnay/rust-toolchain
 
-  # Requirements are ranges, so most releases need no manifest change:
-  # lockfile-only makes this a scheduled `cargo update` that CI validates (every
-  # step runs --locked). Grouped so a bump that strands an exact crate@version
-  # in deny.toml's skip list costs one edit, not one per PR.
   - package-ecosystem: cargo
     directory: "/"
     schedule:
       interval: monthly
     versioning-strategy: lockfile-only
-    # Version updates cover only direct deps by default, but deny.toml's skip
-    # list is entirely transitive duplicates — the drift this is meant to catch.
     allow:
       - dependency-type: all
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+
+# pixi.lock has no Dependabot ecosystem, so the conda-side toolchain and test
+# deps (rust, maturin, pytest, uv) stay manual.
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+    ignore:
+      # @1.85.0 asserts the declared rust-version; bumping it would leave a
+      # green MSRV check that no longer tests the MSRV.
+      - dependency-name: dtolnay/rust-toolchain
+
+  # Requirements are ranges, so most releases need no manifest change:
+  # lockfile-only makes this a scheduled `cargo update` that CI validates (every
+  # step runs --locked). Grouped so a bump that strands an exact crate@version
+  # in deny.toml's skip list costs one edit, not one per PR.
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: monthly
+    versioning-strategy: lockfile-only
+    open-pull-requests-limit: 3
+    groups:
+      cargo:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,10 @@ updates:
     schedule:
       interval: monthly
     versioning-strategy: lockfile-only
-    open-pull-requests-limit: 3
+    # Version updates cover only direct deps by default, but deny.toml's skip
+    # list is entirely transitive duplicates — the drift this is meant to catch.
+    allow:
+      - dependency-type: all
     groups:
       cargo:
         patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,10 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.85.0
       - uses: Swatinem/rust-cache@v2
-      - name: cargo check (workspace, all features, at the declared MSRV)
-        run: cargo check --workspace --all-features --locked
+      # --all-targets pulls in dev-dependencies: without it a dev-dep that
+      # raises the MSRV passes here and only breaks locally.
+      - name: cargo check (workspace, all features and targets, at the declared MSRV)
+        run: cargo check --workspace --all-features --all-targets --locked
 
   semver:
     name: SemVer (public API)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,6 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.85.0
       - uses: Swatinem/rust-cache@v2
-      # --all-targets pulls in dev-dependencies: without it a dev-dep that
-      # raises the MSRV passes here and only breaks locally.
       - name: cargo check (workspace, all features and targets, at the declared MSRV)
         run: cargo check --workspace --all-features --all-targets --locked
 

--- a/.github/workflows/perf-alert.yml
+++ b/.github/workflows/perf-alert.yml
@@ -4,8 +4,7 @@ name: Perf Alert
 # solve on every merge to main and compares the best of N runs against a
 # committed, FIXED reference. NON-blocking by design — it raises a job-summary
 # alert but never fails the build (it runs post-merge, so it cannot block a
-# merge). Refreshing the reference is the Perf Reference workflow's job, which
-# is why this one needs no write access.
+# merge). Supersedes the rolling-baseline bench workflow from #139.
 
 on:
   push:
@@ -16,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -23,9 +26,6 @@ jobs:
   wallclock:
     name: Wall-clock 1M 3FE (alert only)
     runs-on: ubuntu-latest
-    # rust-cache's target/ reuse is unreliable run-to-run, so sccache is the
-    # floor that keeps a miss from becoming a cold release build. Cache hits are
-    # bit-identical rustc output, so this cannot perturb the measurement.
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
@@ -39,10 +39,6 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
 
-      # Multi-threaded on purpose (default Rayon width = all runner cores): this
-      # tier is the multi-threaded safety net, not the deterministic path. The
-      # harness prints WALLCLOCK_BEST_NS=<ns> (best of N runs). `|| true` keeps a
-      # missing marker an empty value rather than a step failure under pipefail.
       - name: Time 1M-row 3FE solve (release, best-of-N)
         id: bench
         run: |

--- a/.github/workflows/perf-alert.yml
+++ b/.github/workflows/perf-alert.yml
@@ -29,6 +29,12 @@ jobs:
   wallclock:
     name: Wall-clock 1M 3FE (alert only)
     runs-on: ubuntu-latest
+    # rust-cache's target/ reuse is unreliable run-to-run, so sccache is the
+    # floor that keeps a miss from becoming a cold release build. Cache hits are
+    # bit-identical rustc output, so this cannot perturb the measurement.
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v7
       - uses: prefix-dev/setup-pixi@v0.10.0
@@ -36,6 +42,7 @@ jobs:
           environments: ci
           cache: true
           cache-write: ${{ github.ref == 'refs/heads/main' }}
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
 
       # Multi-threaded on purpose (default Rayon width = all runner cores): this

--- a/.github/workflows/perf-alert.yml
+++ b/.github/workflows/perf-alert.yml
@@ -4,21 +4,23 @@ name: Perf Alert
 # solve on every merge to main and compares the best of N runs against a
 # committed, FIXED reference. NON-blocking by design — it raises a job-summary
 # alert but never fails the build (it runs post-merge, so it cannot block a
-# merge). Supersedes the rolling-baseline bench workflow from #139.
+# merge). Refreshing the reference is the Perf Reference workflow's job, which
+# is why this one needs no write access.
 
 on:
   push:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      update-reference:
-        description: "Bootstrap/refresh the committed wall-clock reference from this run (on CI hardware)"
-        type: boolean
-        default: false
 
 permissions:
-  contents: write
+  contents: read
+
+# The bench takes minutes; queue back-to-back merges rather than cancelling, so
+# every merge to main gets its own attributed measurement.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -47,31 +49,6 @@ jobs:
           best="$(printf '%s\n' "$out" | grep -oE 'WALLCLOCK_BEST_NS=[0-9]+' | tail -n1 | cut -d= -f2)"
           echo "best_ns=${best:-}" >> "$GITHUB_OUTPUT"
 
-      - name: Bootstrap reference
-        if: github.event_name == 'workflow_dispatch' && inputs.update-reference && steps.bench.outputs.best_ns != ''
-        run: python3 scripts/check-wallclock-reference.py --measured-ns "${{ steps.bench.outputs.best_ns }}" --update
-
       - name: Compare against committed reference (alert only)
-        if: steps.bench.outputs.best_ns != '' && !(github.event_name == 'workflow_dispatch' && inputs.update-reference)
+        if: steps.bench.outputs.best_ns != ''
         run: python3 scripts/check-wallclock-reference.py --measured-ns "${{ steps.bench.outputs.best_ns }}" --commit "${{ github.sha }}"
-
-      - name: Commit refreshed reference
-        if: github.event_name == 'workflow_dispatch' && inputs.update-reference
-        run: |
-          if git diff --quiet -- benches/wallclock_reference.json; then
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add benches/wallclock_reference.json
-          git commit -m "chore(perf): bootstrap wall-clock reference (#147) [skip ci]"
-          # The bench takes minutes; a merge to main can land in that window and
-          # make the push a non-fast-forward. Rebase our single-file commit onto
-          # the new tip (no concurrent merge touches this file) and retry.
-          for attempt in 1 2 3 4 5; do
-            git push && exit 0
-            echo "push rejected (raced a merge to main); rebasing and retrying ($attempt)…"
-            git pull --rebase origin main
-          done
-          echo "::error::could not push refreshed wall-clock reference after retries"
-          exit 1

--- a/.github/workflows/perf-alert.yml
+++ b/.github/workflows/perf-alert.yml
@@ -16,12 +16,6 @@ on:
 permissions:
   contents: read
 
-# The bench takes minutes; queue back-to-back merges rather than cancelling, so
-# every merge to main gets its own attributed measurement.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
-
 env:
   CARGO_TERM_COLOR: always
 
@@ -47,13 +41,14 @@ jobs:
 
       # Multi-threaded on purpose (default Rayon width = all runner cores): this
       # tier is the multi-threaded safety net, not the deterministic path. The
-      # harness prints WALLCLOCK_BEST_NS=<ns> (best of N runs).
+      # harness prints WALLCLOCK_BEST_NS=<ns> (best of N runs). `|| true` keeps a
+      # missing marker an empty value rather than a step failure under pipefail.
       - name: Time 1M-row 3FE solve (release, best-of-N)
         id: bench
         run: |
           out="$(pixi run -e ci cargo bench -p within --bench wallclock_1m3fe)"
           echo "$out"
-          best="$(printf '%s\n' "$out" | grep -oE 'WALLCLOCK_BEST_NS=[0-9]+' | tail -n1 | cut -d= -f2)"
+          best="$(printf '%s\n' "$out" | grep -oE 'WALLCLOCK_BEST_NS=[0-9]+' | tail -n1 | cut -d= -f2 || true)"
           echo "best_ns=${best:-}" >> "$GITHUB_OUTPUT"
 
       - name: Compare against committed reference (alert only)

--- a/.github/workflows/perf-reference.yml
+++ b/.github/workflows/perf-reference.yml
@@ -1,10 +1,5 @@
 name: Perf Reference
 
-# Manual counterpart to Perf Alert (#147): re-measures the 1M-row 3FE solve on
-# CI hardware and commits the result as the new fixed reference. Split out of
-# Perf Alert so the always-on alert never holds write access. This job pushes a
-# commit, so its actions are SHA-pinned rather than tag-pinned.
-
 on:
   workflow_dispatch:
 
@@ -22,12 +17,16 @@ jobs:
   refresh:
     name: Refresh wall-clock reference
     runs-on: ubuntu-latest
-    # Same caching as the alert path, so the reference is built the same way it
-    # will be compared against. Cache hits are bit-identical rustc output.
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     steps:
+      - name: Require main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::dispatch this workflow on main"
+          exit 1
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
@@ -37,9 +36,6 @@ jobs:
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
-      # Same harness and threading as the alert path, so the reference is
-      # measured on the same footing it will be compared against. `|| true` keeps
-      # a missing marker an empty value, so the next step reports why.
       - name: Time 1M-row 3FE solve (release, best-of-N)
         id: bench
         run: |
@@ -66,9 +62,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add benches/wallclock_reference.json
           git commit -m "chore(perf): refresh wall-clock reference (#147) [skip ci]"
-          # The bench takes minutes; a merge to main can land in that window and
-          # make the push a non-fast-forward. Rebase our single-file commit onto
-          # the new tip (no concurrent merge touches this file) and retry.
           for attempt in 1 2 3 4 5; do
             git push && exit 0
             echo "push rejected (raced a merge to main); rebasing and retrying ($attempt)…"

--- a/.github/workflows/perf-reference.yml
+++ b/.github/workflows/perf-reference.yml
@@ -1,0 +1,71 @@
+name: Perf Reference
+
+# Manual counterpart to Perf Alert (#147): re-measures the 1M-row 3FE solve on
+# CI hardware and commits the result as the new fixed reference. Split out of
+# Perf Alert so the always-on alert never holds write access to main — this is
+# the only workflow that can push to the default branch, so its actions are
+# SHA-pinned rather than tag-pinned.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  refresh:
+    name: Refresh wall-clock reference
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
+        with:
+          environments: ci
+          cache: true
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      # Same harness and threading as the alert path, so the reference is
+      # measured on the same footing it will be compared against.
+      - name: Time 1M-row 3FE solve (release, best-of-N)
+        id: bench
+        run: |
+          out="$(pixi run -e ci cargo bench -p within --bench wallclock_1m3fe)"
+          echo "$out"
+          best="$(printf '%s\n' "$out" | grep -oE 'WALLCLOCK_BEST_NS=[0-9]+' | tail -n1 | cut -d= -f2)"
+          echo "best_ns=${best:-}" >> "$GITHUB_OUTPUT"
+
+      - name: Write reference
+        run: |
+          if [ -z "${{ steps.bench.outputs.best_ns }}" ]; then
+            echo "::error::bench emitted no WALLCLOCK_BEST_NS; reference unchanged"
+            exit 1
+          fi
+          python3 scripts/check-wallclock-reference.py --measured-ns "${{ steps.bench.outputs.best_ns }}" --update
+
+      - name: Commit refreshed reference
+        run: |
+          if git diff --quiet -- benches/wallclock_reference.json; then
+            echo "reference already matches this run; nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add benches/wallclock_reference.json
+          git commit -m "chore(perf): refresh wall-clock reference (#147) [skip ci]"
+          # The bench takes minutes; a merge to main can land in that window and
+          # make the push a non-fast-forward. Rebase our single-file commit onto
+          # the new tip (no concurrent merge touches this file) and retry.
+          for attempt in 1 2 3 4 5; do
+            git push && exit 0
+            echo "push rejected (raced a merge to main); rebasing and retrying ($attempt)…"
+            git pull --rebase origin main
+          done
+          echo "::error::could not push refreshed wall-clock reference after retries"
+          exit 1

--- a/.github/workflows/perf-reference.yml
+++ b/.github/workflows/perf-reference.yml
@@ -23,12 +23,19 @@ jobs:
   refresh:
     name: Refresh wall-clock reference
     runs-on: ubuntu-latest
+    # Same caching as the alert path, so the reference is built the same way it
+    # will be compared against. Cache hits are bit-identical rustc output.
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           environments: ci
           cache: true
+          cache-write: ${{ github.ref == 'refs/heads/main' }}
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       # Same harness and threading as the alert path, so the reference is

--- a/.github/workflows/perf-reference.yml
+++ b/.github/workflows/perf-reference.yml
@@ -2,9 +2,8 @@ name: Perf Reference
 
 # Manual counterpart to Perf Alert (#147): re-measures the 1M-row 3FE solve on
 # CI hardware and commits the result as the new fixed reference. Split out of
-# Perf Alert so the always-on alert never holds write access to main — this is
-# the only workflow that can push to the default branch, so its actions are
-# SHA-pinned rather than tag-pinned.
+# Perf Alert so the always-on alert never holds write access. This job pushes a
+# commit, so its actions are SHA-pinned rather than tag-pinned.
 
 on:
   workflow_dispatch:
@@ -39,13 +38,14 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       # Same harness and threading as the alert path, so the reference is
-      # measured on the same footing it will be compared against.
+      # measured on the same footing it will be compared against. `|| true` keeps
+      # a missing marker an empty value, so the next step reports why.
       - name: Time 1M-row 3FE solve (release, best-of-N)
         id: bench
         run: |
           out="$(pixi run -e ci cargo bench -p within --bench wallclock_1m3fe)"
           echo "$out"
-          best="$(printf '%s\n' "$out" | grep -oE 'WALLCLOCK_BEST_NS=[0-9]+' | tail -n1 | cut -d= -f2)"
+          best="$(printf '%s\n' "$out" | grep -oE 'WALLCLOCK_BEST_NS=[0-9]+' | tail -n1 | cut -d= -f2 || true)"
           echo "best_ns=${best:-}" >> "$GITHUB_OUTPUT"
 
       - name: Write reference

--- a/benches/wallclock_reference.json
+++ b/benches/wallclock_reference.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Fixed (NOT rolling) wall-clock reference for the Tier-2 non-blocking perf alert (#147). best_ns is a PLACEHOLDER (null) until CI bootstraps it: the reference MUST be measured on CI hardware (ubuntu-latest), not a maintainer's machine, so run the perf-alert workflow via workflow_dispatch with update-reference=true on first setup. An intentional, accepted slowdown is recorded by re-running that dispatch, so drift shows up as a reviewable diff to this file. threshold_pct is set well above the repo's documented +-2-9% runner noise so only genuine sustained regressions alert (and the alert is non-blocking regardless).",
+  "_comment": "Fixed (NOT rolling) wall-clock reference for the Tier-2 non-blocking perf alert (#147). The reference MUST be measured on CI hardware (ubuntu-latest), not a maintainer's machine, so it is refreshed by dispatching the Perf Reference workflow on main. An intentional, accepted slowdown is recorded by re-running that dispatch, so drift shows up as a reviewable diff to this file. threshold_pct is set well above the repo's documented +-2-9% runner noise so only genuine sustained regressions alert (and the alert is non-blocking regardless).",
   "threshold_pct": 25.0,
   "best_ns": 239836106.0
 }

--- a/scripts/check-wallclock-reference.py
+++ b/scripts/check-wallclock-reference.py
@@ -58,8 +58,8 @@ def main() -> int:
     if not baseline:
         emit(
             f"⚠️ **Perf reference not bootstrapped.** Measured {measured_ms:.1f} ms. "
-            f"Run the perf-alert workflow via `workflow_dispatch` with "
-            f"`update-reference=true` to seed it on CI hardware."
+            f"Run the **Perf Reference** workflow via `workflow_dispatch` to "
+            f"seed it on CI hardware."
         )
         return 0
 
@@ -76,8 +76,8 @@ def main() -> int:
             f"| reference | {baseline_ms:.1f} ms |\n"
             f"| change | +{delta_pct:.1f}% |\n"
             f"| threshold | +{threshold_pct:.1f}% |\n\n"
-            f"If this cost is expected, refresh the reference via the perf-alert "
-            f"`workflow_dispatch` (`update-reference=true`)."
+            f"If this cost is expected, refresh the reference via the "
+            f"**Perf Reference** workflow."
         )
     else:
         emit(


### PR DESCRIPTION
Four CI improvements, one commit each.

- **MSRV check covers dev-deps** — `--all-targets` on the `msrv` job. Without it a dev-dep that raised the MSRV left the job green. Verified against the real 1.85.0 toolchain: passes, with `criterion 0.7.0` now entering the check.

- **The perf alert no longer holds write access to `main`** — it ran on every push with `contents: write`, though only the manual reference refresh writes. The refresh moved to a dispatch-only `perf-reference.yml` (`contents: write`, SHA-pinned actions as the sole workflow that can push to the default branch); `perf-alert.yml` drops to `contents: read`, loses the boolean input and all four step-level event guards, and gains a queueing concurrency group. The refresh now fails loudly instead of silently no-op'ing when the bench emits no measurement.

- **Dependabot** — weekly grouped `github-actions` with `dtolnay/rust-toolchain` ignored (that pin *is* the MSRV assertion), monthly grouped `cargo` at `versioning-strategy: lockfile-only`. Requirements are ranges, so this is a scheduled `cargo update` validated by CI rather than manifest churn — and a bump that strands an exact `crate@version` in `deny.toml`'s skip list now surfaces as a red check on a bot PR instead of mid-task.

Not covered: `pixi.lock` has no Dependabot ecosystem, so the conda-side toolchain and test deps stay manual.


- **sccache on both perf workflows** — they ran with `rust-cache` only, whose `target/` reuse is unreliable run-to-run, so a miss meant a cold `lto = "fat"` release build. Cache hits are bit-identical rustc output and nothing in the build sets `target-cpu=native`, so this cannot perturb the measurement.
