### PR TITLE
ci: refresh the wall-clock reference by pull request (#147)

### DIFF
--- a/.github/workflows/perf-reference.yml
+++ b/.github/workflows/perf-reference.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}
@@ -12,6 +13,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  REFERENCE_FILE: benches/wallclock_reference.json
 
 jobs:
   refresh:
@@ -44,28 +46,34 @@ jobs:
           best="$(printf '%s\n' "$out" | grep -oE 'WALLCLOCK_BEST_NS=[0-9]+' | tail -n1 | cut -d= -f2 || true)"
           echo "best_ns=${best:-}" >> "$GITHUB_OUTPUT"
 
-      - name: Write reference
+      - name: Update reference
+        env:
+          BEST_NS: ${{ steps.bench.outputs.best_ns }}
         run: |
-          if [ -z "${{ steps.bench.outputs.best_ns }}" ]; then
+          if [ -z "$BEST_NS" ]; then
             echo "::error::bench emitted no WALLCLOCK_BEST_NS; reference unchanged"
             exit 1
           fi
-          python3 scripts/check-wallclock-reference.py --measured-ns "${{ steps.bench.outputs.best_ns }}" --update
+          python3 scripts/check-wallclock-reference.py --measured-ns "$BEST_NS" --update
 
-      - name: Commit refreshed reference
+      - name: Open refresh pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BEST_NS: ${{ steps.bench.outputs.best_ns }}
+          SOURCE_SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if git diff --quiet -- benches/wallclock_reference.json; then
-            echo "reference already matches this run; nothing to commit"
+          if git diff --quiet -- "$REFERENCE_FILE"; then
+            echo "reference already matches this run; no pull request opened"
             exit 0
           fi
+          stamp="$(date -u +%Y%m%dT%H%M%SZ)"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add benches/wallclock_reference.json
-          git commit -m "chore(perf): refresh wall-clock reference (#147) [skip ci]"
-          for attempt in 1 2 3 4 5; do
-            git push && exit 0
-            echo "push rejected (raced a merge to main); rebasing and retrying ($attempt)…"
-            git pull --rebase origin main
-          done
-          echo "::error::could not push refreshed wall-clock reference after retries"
-          exit 1
+          git switch -c "perf/reference-$stamp"
+          git add "$REFERENCE_FILE"
+          git commit -m "chore(perf): refresh wall-clock reference to ${BEST_NS}ns (#147)" -m "Measured on ${SOURCE_SHA}."
+          git push origin "perf/reference-$stamp"
+          gh pr create --base main --head "perf/reference-$stamp" \
+            --title "chore(perf): refresh wall-clock reference ($stamp)" \
+            --body "$(printf 'Measured on `%s` by [this run](%s).\n\nRequired checks do not start on a `GITHUB_TOKEN` pull request: merge with the admin bypass, or push to the branch to trigger them.\n' "$SOURCE_SHA" "$RUN_URL")"

--- a/benches/wallclock_reference.json
+++ b/benches/wallclock_reference.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Fixed (NOT rolling) wall-clock reference for the Tier-2 non-blocking perf alert (#147). The reference MUST be measured on CI hardware (ubuntu-latest), not a maintainer's machine, so it is refreshed by dispatching the Perf Reference workflow on main. An intentional, accepted slowdown is recorded by re-running that dispatch, so drift shows up as a reviewable diff to this file. threshold_pct is set well above the repo's documented +-2-9% runner noise so only genuine sustained regressions alert (and the alert is non-blocking regardless).",
   "threshold_pct": 25.0,
+  "refresh_min_delta_pct": 10.0,
   "best_ns": 239836106.0
 }

--- a/scripts/check-wallclock-reference.py
+++ b/scripts/check-wallclock-reference.py
@@ -39,7 +39,7 @@ def main() -> int:
     p.add_argument(
         "--update",
         action="store_true",
-        help="write the measured time into the reference file and exit",
+        help="refresh the reference file if the measured time clears the noise floor, then exit",
     )
     args = p.parse_args()
 
@@ -47,14 +47,23 @@ def main() -> int:
     reference = json.loads(ref_path.read_text())
     measured = args.measured_ns
     measured_ms = measured / 1e6
+    baseline = reference.get("best_ns")
 
     if args.update:
+        min_delta_pct = float(reference.get("refresh_min_delta_pct", 10.0))
+        if baseline:
+            delta_pct = (measured - baseline) / baseline * 100.0
+            if abs(delta_pct) <= min_delta_pct:
+                emit(
+                    f"Reference unchanged: {measured_ms:.1f} ms vs {baseline / 1e6:.1f} ms "
+                    f"({delta_pct:+.1f}%) is inside the ±{min_delta_pct:.0f}% refresh floor."
+                )
+                return 0
         reference["best_ns"] = round(measured, 3)
         ref_path.write_text(json.dumps(reference, indent=2) + "\n")
         emit(f"Updated wall-clock reference to {measured_ms:.1f} ms (best of runs).")
         return 0
 
-    baseline = reference.get("best_ns")
     if not baseline:
         emit(
             f"⚠️ **Perf reference not bootstrapped.** Measured {measured_ms:.1f} ms. "


### PR DESCRIPTION
The Perf Reference workflow had never succeeded: it pushed to main, whose
ruleset requires five status checks that a direct push can never carry. Its
retry loop misread the rejection as a lost race.

The measured value now lands on a timestamped `perf/reference-<stamp>` branch
and is proposed as a pull request, so the push targets an unguarded ref while
the merge into main stays reviewed. No bypass grant and no new secret.

`--update` also leaves the reference alone when the delta is inside
`refresh_min_delta_pct` (10%) — above the runner's ±2–9% noise, below the 25%
alert threshold — so refreshes cannot ratchet the fixed reference on noise.
The run that prompted this measured −3.5%.

`perf-alert.yml` is unchanged. Required checks do not start on a
`GITHUB_TOKEN` pull request, so refresh PRs merge via the admin bypass.
