### PR TITLE
feat!: make ndarray an opt-in feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         run: pixi run -e ci cargo fmt --all -- --check
       - name: cargo clippy
         run: pixi run -e ci cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+      - name: cargo clippy (within, default features — no ndarray)
+        run: pixi run -e ci cargo clippy -p within --no-default-features --locked -- -D warnings
       - name: cargo deny
         run: pixi run -e ci cargo deny --locked check
       # Coverage instruments and runs the full workspace test suite + pytest,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,10 @@ jobs:
         run: pixi run -e ci cargo fmt --all -- --check
       - name: cargo clippy
         run: pixi run -e ci cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
-      - name: cargo clippy (within, default features — no ndarray)
+      - name: cargo clippy (within, no ndarray — lib only by design)
         run: pixi run -e ci cargo clippy -p within --no-default-features --locked -- -D warnings
+      - name: cargo test -p within (exercises the self-referential dev-dependency)
+        run: pixi run -e ci cargo test -p within --locked --no-run
       - name: cargo deny
         run: pixi run -e ci cargo deny --locked check
       # Coverage instruments and runs the full workspace test suite + pytest,
@@ -69,6 +71,7 @@ jobs:
         uses: obi1kenobi/cargo-semver-checks-action@v2.9
         with:
           package: within, schwarz-precond
+          feature-group: all-features
 
   platform:
     name: Tests (${{ matrix.os }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - `SchurMode` (Rust) / `Schur` (Python, `Schur.approximate(...)` / `Schur.exact()`) names the local solver's Schur-reduction mode explicitly (#104).
 - New `BuildError` variants `EmptyEffect` and `SlopeLengthMismatch` for malformed effect terms (#58).
 - **`ObservationFrame`:** columnar observation storage — one `u32` level-code column per factor plus `f64` loading columns, each independently borrowed or owned (#68).
+- Optional, off-by-default `ndarray` feature for `ArrayView2<u32>` design input; a default build has no `ndarray` dependency.
 - **Locality sort:** `Design` reorders observations by the highest-cardinality factor when unsorted, copying columns once; results still return in caller row order (#68).
 
 ### Changed
@@ -31,6 +32,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - **BREAKING:** `Design::from_store` → `Design::from_frame`, taking an `ObservationFrame` (#68).
 - **BREAKING:** `BuildError::ObservationCountMismatch` reports the offending `column` index (#68).
 - **BREAKING:** `BuildError::SingularDiagonal` no longer carries a `block` field (was `&'static str`); which diagonal block held the degenerate entry was not user-diagnosable.
+- **BREAKING:** `ArrayView2<u32>` design input moved behind the opt-in `ndarray` feature, and `ndarray` bumped 0.16 → 0.17; `Effect` slice terms need neither.
 - `approx-chol` bumped 0.2.0 → 0.3.1, speeding up local-solver setup.
 - The locality reorder changes summation order, so unsorted-input results match 0.2.0 within solver tolerance, not bitwise.
 - Documented the reproducibility contract (#110): a single-threaded run is bitwise-reproducible; across thread counts, parallel summation reorders floating-point adds, so coefficients agree within solver tolerance (~1e-16), not bitwise. Pin the Rayon width — and an explicit `ReductionStrategy` if the width may vary — to hold estimates stable within solver tolerance across runs (single-threaded is the only bitwise guarantee).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - `SchurMode` (Rust) / `Schur` (Python, `Schur.approximate(...)` / `Schur.exact()`) names the local solver's Schur-reduction mode explicitly (#104).
 - New `BuildError` variants `EmptyEffect` and `SlopeLengthMismatch` for malformed effect terms (#58).
 - **`ObservationFrame`:** columnar observation storage — one `u32` level-code column per factor plus `f64` loading columns, each independently borrowed or owned (#68).
-- Optional, off-by-default `ndarray` feature for `ArrayView2<u32>` design input; a default build has no `ndarray` dependency.
 - **Locality sort:** `Design` reorders observations by the highest-cardinality factor when unsorted, copying columns once; results still return in caller row order (#68).
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,6 +2059,7 @@ dependencies = [
  "schwarz-precond",
  "serde",
  "thiserror 2.0.19",
+ "within",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "2"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs)'] }
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -160,15 +160,15 @@ Coefficients for unidentified directions are pinned to the **minimal-norm** valu
 ## Rust API
 
 ```rust
-use ndarray::Array2;
-use within::{solve, LsmrOptions, PreconditionerConfig};
+use within::{solve, Effect, LsmrOptions, PreconditionerConfig};
 use within::config::{LocalSolverConfig, ReductionStrategy};
 
-let categories = /* Array2<u32> of shape (n_obs, n_factors) */;
+let levels: &[u32] = /* level codes, one per observation, per factor */;
 let y: &[f64] = /* response vector */;
+let design = vec![Effect::new(levels, true, [])?];
 
 // Default: LSMR + additive Schwarz (None → library default)
-let r = solve(categories.view(), &y, None, &LsmrOptions::default(), None)?;
+let r = solve(design.clone(), &y, None, &LsmrOptions::default(), None)?;
 assert!(r.converged);
 
 // Tighter tolerance with an explicit additive preconditioner
@@ -177,11 +177,11 @@ let precond = PreconditionerConfig::Additive {
     local_solver: LocalSolverConfig::default(),
     reduction: ReductionStrategy::default(),
 };
-let r = solve(categories.view(), &y, None, &lsmr, &precond)?;
+let r = solve(design.clone(), &y, None, &lsmr, &precond)?;
 
 // Opt into diagonal/Jacobi preconditioning
 let diagonal = PreconditionerConfig::Diagonal;
-let r = solve(categories.view(), &y, None, &lsmr, &diagonal)?;
+let r = solve(design.clone(), &y, None, &lsmr, &diagonal)?;
 ```
 
 Persistent solver — build once, solve many:
@@ -189,7 +189,7 @@ Persistent solver — build once, solve many:
 ```rust
 use within::Solver;
 
-let solver = Solver::new(categories.view(), None, None)?;
+let solver = Solver::new(design, None, None)?;
 let r1 = solver.solve(&y, &LsmrOptions::default())?;
 let r2 = solver.solve(&another_y, &LsmrOptions::default())?;  // reuses preconditioner
 ```
@@ -221,7 +221,7 @@ let r2 = solver.solve(&another_y, &LsmrOptions::default())?;  // reuses precondi
 
 | Feature | Default | Effect |
 |---|---|---|
-| `ndarray` | yes | Enables `from_array` constructors for `ndarray::ArrayView2` interop. |
+| `ndarray` | no | Accepts `ndarray::ArrayView2<u32>` as a design, in addition to the always-available `Effect` slice terms. Off by default so the crate imposes no `ndarray` major version on callers. |
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -163,9 +163,13 @@ Coefficients for unidentified directions are pinned to the **minimal-norm** valu
 use within::{solve, Effect, LsmrOptions, PreconditionerConfig};
 use within::config::{LocalSolverConfig, ReductionStrategy};
 
-let levels: &[u32] = /* level codes, one per observation, per factor */;
+let firm: &[u32] = /* level codes, one per observation */;
+let year: &[u32] = /* level codes, one per observation */;
 let y: &[f64] = /* response vector */;
-let design = vec![Effect::new(levels, true, [])?];
+let design = vec![
+    Effect::new(firm, true, [])?,
+    Effect::new(year, true, [])?,
+];
 
 // Default: LSMR + additive Schwarz (None → library default)
 let r = solve(design.clone(), &y, None, &LsmrOptions::default(), None)?;

--- a/crates/within-py/Cargo.toml
+++ b/crates/within-py/Cargo.toml
@@ -11,7 +11,7 @@ name = "_within"
 crate-type = ["cdylib"]
 
 [dependencies]
-within = { path = "../within" }
+within = { path = "../within", features = ["ndarray"] }
 postcard.workspace = true
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }
 numpy = "0.29"

--- a/crates/within/Cargo.toml
+++ b/crates/within/Cargo.toml
@@ -10,18 +10,24 @@ repository.workspace = true
 keywords = ["fixed-effects", "least-squares", "preconditioner", "schwarz", "econometrics"]
 categories.workspace = true
 
+[features]
+default = []
+ndarray = ["dep:ndarray"]
+
 [dependencies]
 schwarz-precond = { workspace = true, features = ["serde"] }
 approx-chol = { version = "0.3.1", features = ["serde"] }
 serde = { workspace = true, features = ["rc"] }
 postcard.workspace = true
-ndarray = "0.17"
+ndarray = { version = "0.17", optional = true }
 portable-atomic = { version = "1", features = ["float"] }
 rayon.workspace = true
 faer.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+within = { path = ".", features = ["ndarray"] }
+ndarray = "0.17"
 criterion = { version = "0.7", features = ["html_reports"] }
 rand = "0.10"
 proptest = "1"

--- a/crates/within/Cargo.toml
+++ b/crates/within/Cargo.toml
@@ -9,6 +9,14 @@ readme = "README.md"
 repository.workspace = true
 keywords = ["fixed-effects", "least-squares", "preconditioner", "schwarz", "econometrics"]
 categories.workspace = true
+# Test and bench targets reach the array path through a self-referential
+# dev-dependency, which cargo strips on publish; shipping them would ship
+# sources that cannot build from the tarball.
+exclude = ["tests/", "benches/"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []

--- a/crates/within/README.md
+++ b/crates/within/README.md
@@ -15,20 +15,20 @@ cargo add within
 ## Quick example
 
 ```rust
-use ndarray::Array2;
-use within::{solve, LsmrOptions, PreconditionerConfig};
+use within::{solve, Effect, LsmrOptions, PreconditionerConfig};
 
 // Two factors: 100 levels each, 10 000 observations
 let n_obs = 10_000usize;
-let mut categories = Array2::<u32>::zeros((n_obs, 2));
-for i in 0..n_obs {
-    categories[[i, 0]] = (i % 100) as u32;
-    categories[[i, 1]] = (i / 100) as u32;
-}
+let f0: Vec<u32> = (0..n_obs).map(|i| (i % 100) as u32).collect();
+let f1: Vec<u32> = (0..n_obs).map(|i| (i / 100) as u32).collect();
 let y: Vec<f64> = (0..n_obs).map(|i| i as f64 * 0.01).collect();
+let design = vec![
+    Effect::new(&f0, true, []).expect("valid effect"),
+    Effect::new(&f1, true, []).expect("valid effect"),
+];
 
 // Solve with library defaults: LSMR + additive Schwarz
-let result = solve(categories.view(), &y, None, &LsmrOptions::default(), None)
+let result = solve(design.clone(), &y, None, &LsmrOptions::default(), None)
     .expect("solve should succeed");
 assert!(result.converged);
 println!("LSMR converged in {} iterations", result.iterations);
@@ -36,13 +36,13 @@ println!("LSMR converged in {} iterations", result.iterations);
 // Tighter tolerance with an explicit preconditioner config
 let lsmr = LsmrOptions { tol: 1e-10, ..LsmrOptions::default() };
 let precond = PreconditionerConfig::default();
-let result = solve(categories.view(), &y, None, &lsmr, &precond)
+let result = solve(design.clone(), &y, None, &lsmr, &precond)
     .expect("solve should succeed");
 assert!(result.converged);
 
 // Or opt into a diagonal/Jacobi preconditioner.
 let diagonal = PreconditionerConfig::Diagonal;
-let result = solve(categories.view(), &y, None, &lsmr, &diagonal)
+let result = solve(design, &y, None, &lsmr, &diagonal)
     .expect("solve should succeed");
 assert!(result.converged);
 ```
@@ -51,7 +51,7 @@ assert!(result.converged);
 
 | Feature   | Default | Effect                                                                 |
 |-----------|---------|------------------------------------------------------------------------|
-| `ndarray` | yes     | Enables `from_array` constructors on observation stores for interop with `ndarray::ArrayView2`. |
+| `ndarray` | no      | Accepts `ndarray::ArrayView2<u32>` as a design, in addition to the always-available `Effect` slice terms. Off by default so the crate imposes no `ndarray` major version on callers. |
 
 ## Architecture
 

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -4,6 +4,24 @@
 //! Schwarz preconditioner over factor-pair subdomains.
 //!
 //! ```
+//! use within::{solve, Effect, LsmrOptions};
+//!
+//! let f0 = vec![0u32; 10_000];
+//! let f1 = vec![0u32; 10_000];
+//! let design = vec![
+//!     Effect::new(&f0, true, []).unwrap(),
+//!     Effect::new(&f1, true, []).unwrap(),
+//! ];
+//! let y = vec![0.0; 10_000];
+//! let r = solve(design, &y, None, &LsmrOptions::default(), None).unwrap();
+//! assert!(r.converged);
+//! ```
+//!
+//! The optional `ndarray` feature additionally accepts a categories matrix,
+//! at the cost of pinning callers to this crate's `ndarray` major version:
+//!
+//! ```
+//! # #[cfg(feature = "ndarray")] fn main() {
 //! use ndarray::Array2;
 //! use within::{solve, LsmrOptions};
 //!
@@ -11,6 +29,8 @@
 //! let y = vec![0.0; 10_000];
 //! let r = solve(categories.view(), &y, None, &LsmrOptions::default(), None).unwrap();
 //! assert!(r.converged);
+//! # }
+//! # #[cfg(not(feature = "ndarray"))] fn main() {}
 //! ```
 //!
 //! # Reproducibility

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]
 //! Fixed-effects normal-equation solver. Solves `G x = D^T W y` (with
 //! `G = D^T W D`) for a sparse categorical design `D` via modified LSMR with a

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -28,6 +28,11 @@ use reparam::SlopeReparam;
 /// Fallible conversion into a [`Design`] for [`Solver::new`]: a list of
 /// [`Effect`] terms, a pass-through [`Design`], or — with the optional
 /// `ndarray` feature — a categories matrix (`ArrayView2<u32>`).
+#[diagnostic::on_unimplemented(
+    note = "to pass an `ndarray::ArrayView2<u32>`, enable this crate's `ndarray` feature",
+    note = "if it is already enabled, your `ndarray` major version differs from this crate's, which makes the two `ArrayView2` types distinct",
+    note = "`Effect` terms are built from plain slices and need neither"
+)]
 pub trait IntoDesign<'a> {
     /// Build the [`Design`], validating inputs along the way.
     fn into_design(self) -> Result<Design<'a>, BuildError>;

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -29,9 +29,9 @@ use reparam::SlopeReparam;
 /// [`Effect`] terms, a pass-through [`Design`], or — with the optional
 /// `ndarray` feature — a categories matrix (`ArrayView2<u32>`).
 #[diagnostic::on_unimplemented(
-    note = "to pass an `ndarray::ArrayView2<u32>`, enable this crate's `ndarray` feature",
-    note = "if it is already enabled, your `ndarray` major version differs from this crate's, which makes the two `ArrayView2` types distinct",
-    note = "`Effect` terms are built from plain slices and need neither"
+    note = "`Effect` terms are built from plain slices and always apply",
+    note = "an `ndarray::ArrayView2<u32>` additionally requires this crate's `ndarray` feature and the same `ndarray` release line, which makes the two `ArrayView2` types distinct otherwise",
+    note = "an owned `Array2<u32>` must be borrowed first, as `array.view()`"
 )]
 pub trait IntoDesign<'a> {
     /// Build the [`Design`], validating inputs along the way.
@@ -354,8 +354,9 @@ struct RhsSolution {
 impl<'a> Solver<'a> {
     /// Construct a solver.
     ///
-    /// `design` accepts raw categories (`ArrayView2<u32>`) or a pre-built
-    /// [`Design`]. `preconditioner` accepts:
+    /// `design` accepts a list of [`Effect`] terms, a pre-built [`Design`], or
+    /// — with the `ndarray` feature — raw categories (`ArrayView2<u32>`).
+    /// `preconditioner` accepts:
     /// - `None` — build the library default Schwarz preconditioner
     /// - `&PreconditionerConfig` / `Some(&PreconditionerConfig)` — build from a tuned config
     /// - `PreconditionerConfig::Off` — solve unpreconditioned
@@ -615,9 +616,9 @@ impl<'a> Solver<'a> {
 
 /// Solve fixed-effects least squares for a design input.
 ///
-/// `design` is anything implementing [`IntoDesign`]: an observation-major
-/// `(n_obs, n_factors)` categories array (levels `0..max_level` per factor,
-/// count inferred) or a list of [`Effect`] terms.
+/// `design` is anything implementing [`IntoDesign`]: a list of [`Effect`] terms,
+/// or — with the `ndarray` feature — an observation-major `(n_obs, n_factors)`
+/// categories array (levels `0..max_level` per factor, count inferred).
 /// `y` is the response vector (length = n_obs).
 ///
 /// Zero-copy for F-order category arrays whose dominant factor is already

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -2,15 +2,18 @@
 //! multiple solves on the same design) and the one-shot [`solve`] / [`solve_batch`]
 //! convenience wrappers built on top of it.
 
+#[cfg(feature = "ndarray")]
 use std::borrow::Cow;
 use std::time::Instant;
 
+#[cfg(feature = "ndarray")]
 use ndarray::{ArrayView2, Axis};
 use rayon::prelude::*;
 use schwarz_precond::{lsmr as lsmr_solve, mlsmr};
 
 use crate::config::{LsmrOptions, PreconditionerConfig};
 use crate::domain::{Design, Effect};
+#[cfg(feature = "ndarray")]
 use crate::observation::ObservationFrame;
 use crate::operator::design::gather_apply;
 use crate::operator::schwarz::{build_preconditioner, Preconditioner};
@@ -22,14 +25,15 @@ mod reparam;
 mod tests;
 use reparam::SlopeReparam;
 
-/// Fallible conversion into a [`Design`] for [`Solver::new`]: a categories
-/// matrix (`ArrayView2<u32>`), a list of [`Effect`] terms, or a pass-through
-/// [`Design`].
+/// Fallible conversion into a [`Design`] for [`Solver::new`]: a list of
+/// [`Effect`] terms, a pass-through [`Design`], or — with the optional
+/// `ndarray` feature — a categories matrix (`ArrayView2<u32>`).
 pub trait IntoDesign<'a> {
     /// Build the [`Design`], validating inputs along the way.
     fn into_design(self) -> Result<Design<'a>, BuildError>;
 }
 
+#[cfg(feature = "ndarray")]
 impl<'a> IntoDesign<'a> for ArrayView2<'a, u32> {
     fn into_design(self) -> Result<Design<'a>, BuildError> {
         // Borrow F-contiguous columns zero-copy; gather strided (C-order)


### PR DESCRIPTION
Gates `IntoDesign for ArrayView2<u32>` behind an off-by-default `ndarray` feature. A default build pulls in no `ndarray` at all; designs are built from slices via `Effect`.

`ndarray` is a public dependency, so the 0.16 → 0.17 bump (`d9dac6d`) is breaking for every Rust consumer, and `rust-numpy` pins `ndarray` per release — a PyO3 consumer cannot resolve a mismatch on its own. Default-off rather than default-on because dropping a default feature later would itself be breaking, and 0.3.0 is already breaking.

Verified against `../pyfixest` (the one known Rust consumer, on `ndarray` 0.16 via `numpy` 0.26): with this change plus a slice-based call site on their end, its full quick suite is green at 732 passed / 13 skipped, with a single `ndarray` in the graph.

Notes:

- Tests keep the array path via a self-referential dev-dependency, so `cargo test -p within` is unaffected. `cargo check --workspace` does not cover the feature-off build (within-py unifies the feature on), hence the added CI step.
- Both READMEs already documented an `ndarray` feature that did not exist, described via the `from_array` constructors removed in #68; tables and examples now match what ships.
- The feature is hygiene, not necessity: two `ndarray` majors coexist in one graph fine. It avoids compiling a redundant copy and makes the slice path an explicit contract.