### PR TITLE
Introduce `Design` configuration API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "schwarz-precond"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "faer",
  "rayon",
@@ -2045,7 +2045,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "within"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "approx-chol",
  "criterion",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "within-py"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "numpy",
  "postcard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"
@@ -15,7 +15,7 @@ repository = "https://github.com/py-econometrics/within"
 categories = ["mathematics", "science", "algorithms"]
 
 [workspace.dependencies]
-schwarz-precond = { version = "0.3.0", path = "crates/schwarz-precond" }
+schwarz-precond = { version = "0.4.0", path = "crates/schwarz-precond" }
 faer = "0.24.4"
 rayon = "1.12"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -161,14 +161,14 @@ Coefficients for unidentified directions are pinned to the **minimal-norm** valu
 
 ```rust
 use ndarray::Array2;
-use within::{solve, DesignOptions, IntoDesign, LsmrOptions, PreconditionerConfig};
+use within::{solve, Design, DesignOptions, LsmrOptions, PreconditionerConfig};
 use within::config::{LocalSolverConfig, ReductionStrategy};
 
 let categories = /* Array2<u32> of shape (n_obs, n_factors) */;
 let y: &[f64] = /* response vector */;
 
 // Default: LSMR + additive Schwarz (None → library default)
-let design = categories.view().into_design(DesignOptions::default())?;
+let design = Design::from_categories(categories.view(), DesignOptions::default())?;
 let r = solve(design, &y, &LsmrOptions::default(), None)?;
 assert!(r.converged);
 
@@ -178,21 +178,21 @@ let precond = PreconditionerConfig::Additive {
     local_solver: LocalSolverConfig::default(),
     reduction: ReductionStrategy::default(),
 };
-let design = categories.view().into_design(DesignOptions::default())?;
+let design = Design::from_categories(categories.view(), DesignOptions::default())?;
 let r = solve(design, &y, &lsmr, &precond)?;
 
 // Opt into diagonal/Jacobi preconditioning
 let diagonal = PreconditionerConfig::Diagonal;
-let design = categories.view().into_design(DesignOptions::default())?;
+let design = Design::from_categories(categories.view(), DesignOptions::default())?;
 let r = solve(design, &y, &lsmr, &diagonal)?;
 ```
 
 Persistent solver — build once, solve many:
 
 ```rust
-use within::{DesignOptions, IntoDesign, Solver};
+use within::{Design, DesignOptions, Solver};
 
-let design = categories.view().into_design(DesignOptions::default())?;
+let design = Design::from_categories(categories.view(), DesignOptions::default())?;
 let solver = Solver::new(design, None)?;
 let r1 = solver.solve(&y, &LsmrOptions::default())?;
 let r2 = solver.solve(&another_y, &LsmrOptions::default())?;  // reuses preconditioner

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ result = solve(fe, y)
 result = solve(fe, y, options=LsmrOptions(tol=1e-10, maxiter=2000))
 
 # Weighted solve
-result = solve(fe, y, weights=np.ones(n))
+result = solve(fe, y, design_options=DesignOptions(weights=np.ones(n)))
 
 # Opt into diagonal/Jacobi preconditioning
 result = solve(fe, y, preconditioner=PreconditionerConfig.Diagonal)
@@ -92,8 +92,8 @@ print(result.x[i])
 
 | Function | Description |
 |---|---|
-| `solve(design, y, weights?, options?, preconditioner?)` | Solve a single right-hand side. Returns `SolveResult`. |
-| `solve_batch(design, Y, weights?, options?, preconditioner?)` | Solve multiple RHS vectors in parallel. `Y` has shape `(n_obs, k)`. Returns `BatchSolveResult`. |
+| `solve(design, y, options?, preconditioner?, *, design_options?)` | Solve a single right-hand side. Returns `SolveResult`. |
+| `solve_batch(design, Y, options?, preconditioner?, *, design_options?)` | Solve multiple RHS vectors in parallel. `Y` has shape `(n_obs, k)`. Returns `BatchSolveResult`. |
 
 `design` is either a 2-D `uint32` array of shape `(n_obs, n_factors)` or a list of `Effect` terms (see [Varying slopes](#varying-slopes)). A `UserWarning` is emitted when a C-contiguous categories array is passed — use `np.asfortranarray(design)` for best performance.
 
@@ -114,7 +114,7 @@ solver2 = Solver(fe, preconditioner=precond)   # skip re-factorization
 
 | Property / Method | Description |
 |---|---|
-| `Solver(design, weights?, preconditioner?)` | Build solver. Factorizes the preconditioner at construction. |
+| `Solver(design, preconditioner?, *, design_options?)` | Build solver. Factorizes the preconditioner at construction. |
 | `.solve(y, options?)` | Solve a single RHS with the given LSMR tuning. Returns `SolveResult`. |
 | `.solve_batch(Y, options?)` | Solve multiple RHS columns in parallel. Returns `BatchSolveResult`. |
 | `.preconditioner` | Return the built `Preconditioner` (picklable), or `None`. Reuse via `Solver(fe, preconditioner=p)`. |
@@ -161,14 +161,15 @@ Coefficients for unidentified directions are pinned to the **minimal-norm** valu
 
 ```rust
 use ndarray::Array2;
-use within::{solve, LsmrOptions, PreconditionerConfig};
+use within::{solve, DesignOptions, IntoDesign, LsmrOptions, PreconditionerConfig};
 use within::config::{LocalSolverConfig, ReductionStrategy};
 
 let categories = /* Array2<u32> of shape (n_obs, n_factors) */;
 let y: &[f64] = /* response vector */;
 
 // Default: LSMR + additive Schwarz (None → library default)
-let r = solve(categories.view(), &y, None, &LsmrOptions::default(), None)?;
+let design = categories.view().into_design(DesignOptions::default())?;
+let r = solve(design, &y, &LsmrOptions::default(), None)?;
 assert!(r.converged);
 
 // Tighter tolerance with an explicit additive preconditioner
@@ -177,19 +178,22 @@ let precond = PreconditionerConfig::Additive {
     local_solver: LocalSolverConfig::default(),
     reduction: ReductionStrategy::default(),
 };
-let r = solve(categories.view(), &y, None, &lsmr, &precond)?;
+let design = categories.view().into_design(DesignOptions::default())?;
+let r = solve(design, &y, &lsmr, &precond)?;
 
 // Opt into diagonal/Jacobi preconditioning
 let diagonal = PreconditionerConfig::Diagonal;
-let r = solve(categories.view(), &y, None, &lsmr, &diagonal)?;
+let design = categories.view().into_design(DesignOptions::default())?;
+let r = solve(design, &y, &lsmr, &diagonal)?;
 ```
 
 Persistent solver — build once, solve many:
 
 ```rust
-use within::Solver;
+use within::{DesignOptions, IntoDesign, Solver};
 
-let solver = Solver::new(categories.view(), None, None)?;
+let design = categories.view().into_design(DesignOptions::default())?;
+let solver = Solver::new(design, None)?;
 let r1 = solver.solve(&y, &LsmrOptions::default())?;
 let r2 = solver.solve(&another_y, &LsmrOptions::default())?;  // reuses preconditioner
 ```

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -7,11 +7,13 @@ use numpy::{PyReadonlyArray1, PyReadonlyArray2, PyUntypedArray};
 use pyo3::prelude::*;
 
 use within::{
-    BatchSolveResult, BuildError, BuildWarning, Design, Effect, IntoDesign, LsmrOptions,
+    BatchSolveResult, BuildError, BuildWarning, DesignOptions, Effect, IntoDesign, LsmrOptions,
     PreconditionerInput, SolveResult, Solver, WithinError,
 };
 
-use crate::config::{resolve_lsmr_config, resolve_precond_input, PyPreconditioner};
+use crate::config::{
+    resolve_lsmr_config, resolve_precond_input, PyDesignOptions, PyPreconditioner,
+};
 use crate::convert::{
     coerce_to_slice, column_refs, extract_columns, readonly_f64_1d, readonly_f64_2d,
     readonly_u32_2d, value_err, warn_c_contiguous,
@@ -24,12 +26,14 @@ use crate::results::{
 /// Build a one-shot solver and hand back build warnings for the caller to re-emit.
 fn build_and_solve<'a>(
     design: impl IntoDesign<'a>,
+    options: DesignOptions,
     y: &[f64],
     weights: Option<&[f64]>,
     lsmr: &LsmrOptions,
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(SolveResult, Vec<BuildWarning>), WithinError> {
     let t_start = Instant::now();
+    let design = design.into_design(options)?;
     let solver = Solver::new(design, weights.map(|w| w.to_vec()), precond)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve(y, lsmr)?;
@@ -41,12 +45,14 @@ fn build_and_solve<'a>(
 /// Batch counterpart to [`build_and_solve`], mirroring [`within::solve_batch`].
 fn build_and_solve_batch<'a>(
     design: impl IntoDesign<'a>,
+    options: DesignOptions,
     ys: &[&[f64]],
     weights: Option<&[f64]>,
     lsmr: &LsmrOptions,
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(BatchSolveResult, Vec<BuildWarning>), WithinError> {
     let t_start = Instant::now();
+    let design = design.into_design(options)?;
     let solver = Solver::new(design, weights.map(|w| w.to_vec()), precond)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve_batch(ys, lsmr)?;
@@ -56,7 +62,15 @@ fn build_and_solve_batch<'a>(
 }
 
 #[pyfunction]
-#[pyo3(signature = (design, y, weights=None, options=None, preconditioner=None))]
+#[pyo3(signature = (
+    design,
+    y,
+    weights=None,
+    options=None,
+    preconditioner=None,
+    *,
+    design_options=None
+))]
 pub fn solve<'py>(
     py: Python<'py>,
     design: &Bound<'py, PyAny>,
@@ -64,9 +78,14 @@ pub fn solve<'py>(
     weights: Option<&Bound<'py, PyAny>>,
     options: Option<&Bound<'py, PyAny>>,
     preconditioner: Option<&Bound<'py, PyAny>>,
+    design_options: Option<Py<PyDesignOptions>>,
 ) -> PyResult<PySolveResult> {
     let params = resolve_lsmr_config(options)?;
     let precond = resolve_precond_input(py, preconditioner)?;
+    let design_options = design_options
+        .as_ref()
+        .map(|options| options.bind(py).get().to_native())
+        .unwrap_or_default();
     let y = readonly_f64_1d("y", y)?;
     let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
 
@@ -80,20 +99,42 @@ pub fn solve<'py>(
             run_solve_with_warnings(py, move || {
                 let y_cow = coerce_to_slice(&y_arr);
                 let w_cow = w_view.as_ref().map(coerce_to_slice);
-                build_and_solve(cats, &y_cow, w_cow.as_deref(), &params, precond)
+                build_and_solve(
+                    cats,
+                    design_options,
+                    &y_cow,
+                    w_cow.as_deref(),
+                    &params,
+                    precond,
+                )
             })
         }
         DesignSource::Effects(terms) => run_solve_with_warnings(py, move || {
             let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
             let y_cow = coerce_to_slice(&y_arr);
             let w_cow = w_view.as_ref().map(coerce_to_slice);
-            build_and_solve(effects, &y_cow, w_cow.as_deref(), &params, precond)
+            build_and_solve(
+                effects,
+                design_options,
+                &y_cow,
+                w_cow.as_deref(),
+                &params,
+                precond,
+            )
         }),
     }
 }
 
 #[pyfunction]
-#[pyo3(signature = (design, Y, weights=None, options=None, preconditioner=None))]
+#[pyo3(signature = (
+    design,
+    Y,
+    weights=None,
+    options=None,
+    preconditioner=None,
+    *,
+    design_options=None
+))]
 pub fn solve_batch<'py>(
     py: Python<'py>,
     design: &Bound<'py, PyAny>,
@@ -101,9 +142,14 @@ pub fn solve_batch<'py>(
     weights: Option<&Bound<'py, PyAny>>,
     options: Option<&Bound<'py, PyAny>>,
     preconditioner: Option<&Bound<'py, PyAny>>,
+    design_options: Option<Py<PyDesignOptions>>,
 ) -> PyResult<PyBatchSolveResult> {
     let params = resolve_lsmr_config(options)?;
     let precond = resolve_precond_input(py, preconditioner)?;
+    let design_options = design_options
+        .as_ref()
+        .map(|options| options.bind(py).get().to_native())
+        .unwrap_or_default();
     let y = readonly_f64_2d("Y", Y)?;
     let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
 
@@ -118,7 +164,14 @@ pub fn solve_batch<'py>(
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
                 let w_cow = w_view.as_ref().map(coerce_to_slice);
-                build_and_solve_batch(cats, &col_refs, w_cow.as_deref(), &params, precond)
+                build_and_solve_batch(
+                    cats,
+                    design_options,
+                    &col_refs,
+                    w_cow.as_deref(),
+                    &params,
+                    precond,
+                )
             })
         }
         DesignSource::Effects(terms) => {
@@ -130,7 +183,14 @@ pub fn solve_batch<'py>(
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
                 let w_cow = w_view.as_ref().map(coerce_to_slice);
-                build_and_solve_batch(effects, &col_refs, w_cow.as_deref(), &params, precond)
+                build_and_solve_batch(
+                    effects,
+                    design_options,
+                    &col_refs,
+                    w_cow.as_deref(),
+                    &params,
+                    precond,
+                )
             })
         }
     }
@@ -229,30 +289,43 @@ pub struct PySolver {
 #[pymethods]
 impl PySolver {
     #[new]
-    #[pyo3(signature = (design, weights=None, preconditioner=None))]
+    #[pyo3(signature = (
+        design,
+        weights=None,
+        preconditioner=None,
+        *,
+        design_options=None
+    ))]
     fn new<'py>(
         py: Python<'py>,
         design: &Bound<'py, PyAny>,
         weights: Option<&Bound<'py, PyAny>>,
         preconditioner: Option<&Bound<'py, PyAny>>,
+        design_options: Option<Py<PyDesignOptions>>,
     ) -> PyResult<Self> {
         let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
         let weights_vec: Option<Vec<f64>> = weights.as_ref().map(|w| w.as_array().to_vec());
         let precond = resolve_precond_input(py, preconditioner)?;
+        let design_options = design_options
+            .as_ref()
+            .map(|options| options.bind(py).get().to_native())
+            .unwrap_or_default();
 
         // `BuildError` carries no Python types, so it maps to an exception once the GIL is back.
         let solver = match extract_design(py, design)? {
             DesignSource::Categories(categories) => {
                 let cats = categories.as_array();
                 py.detach(move || -> Result<Solver<'static>, BuildError> {
-                    Solver::new(cats.into_design()?.into_owned(), weights_vec, precond)
+                    let design = cats.into_design(design_options)?.into_owned();
+                    Solver::new(design, weights_vec, precond)
                 })
             }
             DesignSource::Effects(terms) => {
                 py.detach(move || -> Result<Solver<'static>, BuildError> {
                     let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
-                    // The solver outlives the terms' buffers, so lower to owned columns first.
-                    let design = Design::new(effects)?.into_owned();
+                    // The design borrows the terms' buffers; the solver outlives
+                    // them, so lower to owned columns first.
+                    let design = design_options.from_effects(effects)?.into_owned();
                     Solver::new(design, weights_vec, precond)
                 })
             }

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -26,15 +26,14 @@ use crate::results::{
 /// Build a one-shot solver and hand back build warnings for the caller to re-emit.
 fn build_and_solve<'a>(
     design: impl IntoDesign<'a>,
-    options: DesignOptions,
+    options: DesignOptions<'a>,
     y: &[f64],
-    weights: Option<&[f64]>,
     lsmr: &LsmrOptions,
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(SolveResult, Vec<BuildWarning>), WithinError> {
     let t_start = Instant::now();
     let design = design.into_design(options)?;
-    let solver = Solver::new(design, weights.map(|w| w.to_vec()), precond)?;
+    let solver = Solver::new(design, precond)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve(y, lsmr)?;
     result.time_setup += time_setup;
@@ -45,15 +44,14 @@ fn build_and_solve<'a>(
 /// Batch counterpart to [`build_and_solve`], mirroring [`within::solve_batch`].
 fn build_and_solve_batch<'a>(
     design: impl IntoDesign<'a>,
-    options: DesignOptions,
+    options: DesignOptions<'a>,
     ys: &[&[f64]],
-    weights: Option<&[f64]>,
     lsmr: &LsmrOptions,
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(BatchSolveResult, Vec<BuildWarning>), WithinError> {
     let t_start = Instant::now();
     let design = design.into_design(options)?;
-    let solver = Solver::new(design, weights.map(|w| w.to_vec()), precond)?;
+    let solver = Solver::new(design, precond)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve_batch(ys, lsmr)?;
     result.time_setup += time_setup;
@@ -65,7 +63,6 @@ fn build_and_solve_batch<'a>(
 #[pyo3(signature = (
     design,
     y,
-    weights=None,
     options=None,
     preconditioner=None,
     *,
@@ -75,7 +72,6 @@ pub fn solve<'py>(
     py: Python<'py>,
     design: &Bound<'py, PyAny>,
     y: &Bound<'py, PyAny>,
-    weights: Option<&Bound<'py, PyAny>>,
     options: Option<&Bound<'py, PyAny>>,
     preconditioner: Option<&Bound<'py, PyAny>>,
     design_options: Option<Py<PyDesignOptions>>,
@@ -84,40 +80,28 @@ pub fn solve<'py>(
     let precond = resolve_precond_input(py, preconditioner)?;
     let design_options = design_options
         .as_ref()
-        .map(|options| options.bind(py).get().to_native())
+        .map(|options| options.bind(py).get().clone())
         .unwrap_or_default();
     let y = readonly_f64_1d("y", y)?;
-    let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
 
     // Defer slice coercion into the released closures, so the F-contiguous path copies nothing.
     let y_arr = y.as_array();
-    let w_view = weights.as_ref().map(|w| w.as_array());
 
     match extract_design(py, design)? {
         DesignSource::Categories(categories) => {
             let cats = categories.as_array();
             run_solve_with_warnings(py, move || {
                 let y_cow = coerce_to_slice(&y_arr);
-                let w_cow = w_view.as_ref().map(coerce_to_slice);
-                build_and_solve(
-                    cats,
-                    design_options,
-                    &y_cow,
-                    w_cow.as_deref(),
-                    &params,
-                    precond,
-                )
+                build_and_solve(cats, design_options.to_native(), &y_cow, &params, precond)
             })
         }
         DesignSource::Effects(terms) => run_solve_with_warnings(py, move || {
             let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
             let y_cow = coerce_to_slice(&y_arr);
-            let w_cow = w_view.as_ref().map(coerce_to_slice);
             build_and_solve(
                 effects,
-                design_options,
+                design_options.to_native(),
                 &y_cow,
-                w_cow.as_deref(),
                 &params,
                 precond,
             )
@@ -129,7 +113,6 @@ pub fn solve<'py>(
 #[pyo3(signature = (
     design,
     Y,
-    weights=None,
     options=None,
     preconditioner=None,
     *,
@@ -139,7 +122,6 @@ pub fn solve_batch<'py>(
     py: Python<'py>,
     design: &Bound<'py, PyAny>,
     #[allow(non_snake_case)] Y: &Bound<'py, PyAny>,
-    weights: Option<&Bound<'py, PyAny>>,
     options: Option<&Bound<'py, PyAny>>,
     preconditioner: Option<&Bound<'py, PyAny>>,
     design_options: Option<Py<PyDesignOptions>>,
@@ -148,13 +130,11 @@ pub fn solve_batch<'py>(
     let precond = resolve_precond_input(py, preconditioner)?;
     let design_options = design_options
         .as_ref()
-        .map(|options| options.bind(py).get().to_native())
+        .map(|options| options.bind(py).get().clone())
         .unwrap_or_default();
     let y = readonly_f64_2d("Y", Y)?;
-    let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
 
     let y_arr = y.as_array();
-    let w_view = weights.as_ref().map(|w| w.as_array());
 
     match extract_design(py, design)? {
         DesignSource::Categories(categories) => {
@@ -163,12 +143,10 @@ pub fn solve_batch<'py>(
             run_batch_with_warnings(py, move || {
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
-                let w_cow = w_view.as_ref().map(coerce_to_slice);
                 build_and_solve_batch(
                     cats,
-                    design_options,
+                    design_options.to_native(),
                     &col_refs,
-                    w_cow.as_deref(),
                     &params,
                     precond,
                 )
@@ -182,12 +160,10 @@ pub fn solve_batch<'py>(
                 let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
-                let w_cow = w_view.as_ref().map(coerce_to_slice);
                 build_and_solve_batch(
                     effects,
-                    design_options,
+                    design_options.to_native(),
                     &col_refs,
-                    w_cow.as_deref(),
                     &params,
                     precond,
                 )
@@ -291,7 +267,6 @@ impl PySolver {
     #[new]
     #[pyo3(signature = (
         design,
-        weights=None,
         preconditioner=None,
         *,
         design_options=None
@@ -299,16 +274,13 @@ impl PySolver {
     fn new<'py>(
         py: Python<'py>,
         design: &Bound<'py, PyAny>,
-        weights: Option<&Bound<'py, PyAny>>,
         preconditioner: Option<&Bound<'py, PyAny>>,
         design_options: Option<Py<PyDesignOptions>>,
     ) -> PyResult<Self> {
-        let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
-        let weights_vec: Option<Vec<f64>> = weights.as_ref().map(|w| w.as_array().to_vec());
         let precond = resolve_precond_input(py, preconditioner)?;
         let design_options = design_options
             .as_ref()
-            .map(|options| options.bind(py).get().to_native())
+            .map(|options| options.bind(py).get().clone())
             .unwrap_or_default();
 
         // `BuildError` carries no Python types, so it maps to an exception once the GIL is back.
@@ -316,8 +288,8 @@ impl PySolver {
             DesignSource::Categories(categories) => {
                 let cats = categories.as_array();
                 py.detach(move || -> Result<Solver<'static>, BuildError> {
-                    let design = cats.into_design(design_options)?.into_owned();
-                    Solver::new(design, weights_vec, precond)
+                    let design = cats.into_design(design_options.to_native())?.into_owned();
+                    Solver::new(design, precond)
                 })
             }
             DesignSource::Effects(terms) => {
@@ -325,8 +297,11 @@ impl PySolver {
                     let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                     // The design borrows the terms' buffers; the solver outlives
                     // them, so lower to owned columns first.
-                    let design = design_options.from_effects(effects)?.into_owned();
-                    Solver::new(design, weights_vec, precond)
+                    let design = design_options
+                        .to_native()
+                        .from_effects(effects)?
+                        .into_owned();
+                    Solver::new(design, precond)
                 })
             }
         }

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -7,8 +7,8 @@ use numpy::{PyReadonlyArray1, PyReadonlyArray2, PyUntypedArray};
 use pyo3::prelude::*;
 
 use within::{
-    BatchSolveResult, BuildError, BuildWarning, DesignOptions, Effect, IntoDesign, LsmrOptions,
-    PreconditionerInput, SolveResult, Solver, WithinError,
+    BatchSolveResult, BuildError, BuildWarning, Design, Effect, LsmrOptions, PreconditionerInput,
+    SolveResult, Solver, WithinError,
 };
 
 use crate::config::{
@@ -25,14 +25,12 @@ use crate::results::{
 
 /// Build a one-shot solver and hand back build warnings for the caller to re-emit.
 fn build_and_solve<'a>(
-    design: impl IntoDesign<'a>,
-    options: DesignOptions<'a>,
+    design: Design<'a>,
     y: &[f64],
     lsmr: &LsmrOptions,
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(SolveResult, Vec<BuildWarning>), WithinError> {
     let t_start = Instant::now();
-    let design = design.into_design(options)?;
     let solver = Solver::new(design, precond)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve(y, lsmr)?;
@@ -43,14 +41,12 @@ fn build_and_solve<'a>(
 
 /// Batch counterpart to [`build_and_solve`], mirroring [`within::solve_batch`].
 fn build_and_solve_batch<'a>(
-    design: impl IntoDesign<'a>,
-    options: DesignOptions<'a>,
+    design: Design<'a>,
     ys: &[&[f64]],
     lsmr: &LsmrOptions,
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(BatchSolveResult, Vec<BuildWarning>), WithinError> {
     let t_start = Instant::now();
-    let design = design.into_design(options)?;
     let solver = Solver::new(design, precond)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve_batch(ys, lsmr)?;
@@ -92,19 +88,15 @@ pub fn solve<'py>(
             let cats = categories.as_array();
             run_solve_with_warnings(py, move || {
                 let y_cow = coerce_to_slice(&y_arr);
-                build_and_solve(cats, design_options.to_native(), &y_cow, &params, precond)
+                let design = Design::from_categories(cats, design_options.to_native())?;
+                build_and_solve(design, &y_cow, &params, precond)
             })
         }
         DesignSource::Effects(terms) => run_solve_with_warnings(py, move || {
             let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
             let y_cow = coerce_to_slice(&y_arr);
-            build_and_solve(
-                effects,
-                design_options.to_native(),
-                &y_cow,
-                &params,
-                precond,
-            )
+            let design = Design::from_effects(effects, design_options.to_native())?;
+            build_and_solve(design, &y_cow, &params, precond)
         }),
     }
 }
@@ -143,13 +135,8 @@ pub fn solve_batch<'py>(
             run_batch_with_warnings(py, move || {
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
-                build_and_solve_batch(
-                    cats,
-                    design_options.to_native(),
-                    &col_refs,
-                    &params,
-                    precond,
-                )
+                let design = Design::from_categories(cats, design_options.to_native())?;
+                build_and_solve_batch(design, &col_refs, &params, precond)
             })
         }
         DesignSource::Effects(terms) => {
@@ -160,13 +147,8 @@ pub fn solve_batch<'py>(
                 let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
-                build_and_solve_batch(
-                    effects,
-                    design_options.to_native(),
-                    &col_refs,
-                    &params,
-                    precond,
-                )
+                let design = Design::from_effects(effects, design_options.to_native())?;
+                build_and_solve_batch(design, &col_refs, &params, precond)
             })
         }
     }
@@ -288,7 +270,8 @@ impl PySolver {
             DesignSource::Categories(categories) => {
                 let cats = categories.as_array();
                 py.detach(move || -> Result<Solver<'static>, BuildError> {
-                    let design = cats.into_design(design_options.to_native())?.into_owned();
+                    let design =
+                        Design::from_categories(cats, design_options.to_native())?.into_owned();
                     Solver::new(design, precond)
                 })
             }
@@ -297,10 +280,8 @@ impl PySolver {
                     let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                     // The design borrows the terms' buffers; the solver outlives
                     // them, so lower to owned columns first.
-                    let design = design_options
-                        .to_native()
-                        .from_effects(effects)?
-                        .into_owned();
+                    let design =
+                        Design::from_effects(effects, design_options.to_native())?.into_owned();
                     Solver::new(design, precond)
                 })
             }

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -4,7 +4,7 @@
 //! Python→native config conversions (`to_native`, `resolve_precond_input`,
 //! `resolve_lsmr_config`). The low-level classes are exposed for benchmark tuning.
 
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use numpy::PyReadonlyArray1;
 use pyo3::prelude::*;
@@ -50,11 +50,10 @@ impl PyDesignOptions {
 
 impl PyDesignOptions {
     pub(crate) fn to_native(&self) -> DesignOptions<'_> {
-        let options = DesignOptions::default().drop_singletons(self.drop_singletons);
-        match &self.weights {
-            Some(weights) => options.weights(weights.as_ref()),
-            None => options,
-        }
+        DesignOptions::new(
+            self.drop_singletons,
+            self.weights.as_deref().map(Cow::Borrowed),
+        )
     }
 }
 

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -11,9 +11,32 @@ use within::config::{
     ApproxCholConfig, ApproxSchurConfig, LocalSolverConfig, LsmrOptions, PreconditionerConfig,
     ReductionStrategy, ScalingConfig, ScalingFailure, SchurMode,
 };
-use within::{Preconditioner, PreconditionerInput};
+use within::{DesignOptions, Preconditioner, PreconditionerInput};
 
 use crate::convert::IntoPyErr;
+
+/// Processing applied while constructing a fixed-effects design.
+#[pyclass(frozen, module = "within._within")]
+#[pyo3(name = "DesignOptions")]
+pub struct PyDesignOptions {
+    #[pyo3(get)]
+    pub drop_singletons: bool,
+}
+
+#[pymethods]
+impl PyDesignOptions {
+    #[new]
+    #[pyo3(signature = (drop_singletons=false))]
+    fn new(drop_singletons: bool) -> Self {
+        Self { drop_singletons }
+    }
+}
+
+impl PyDesignOptions {
+    pub(crate) fn to_native(&self) -> DesignOptions {
+        DesignOptions::default().drop_singletons(self.drop_singletons)
+    }
+}
 
 #[pyclass(frozen, module = "within._within")]
 #[pyo3(name = "ApproxCholConfig")]

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -50,10 +50,10 @@ impl PyDesignOptions {
 
 impl PyDesignOptions {
     pub(crate) fn to_native(&self) -> DesignOptions<'_> {
-        DesignOptions::new(
-            self.drop_singletons,
-            self.weights.as_deref().map(Cow::Borrowed),
-        )
+        DesignOptions {
+            drop_singletons: self.drop_singletons,
+            weights: self.weights.as_deref().map(Cow::Borrowed),
+        }
     }
 }
 

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -4,6 +4,8 @@
 //! Python→native config conversions (`to_native`, `resolve_precond_input`,
 //! `resolve_lsmr_config`). The low-level classes are exposed for benchmark tuning.
 
+use std::sync::Arc;
+
 use numpy::PyReadonlyArray1;
 use pyo3::prelude::*;
 
@@ -13,28 +15,46 @@ use within::config::{
 };
 use within::{DesignOptions, Preconditioner, PreconditionerInput};
 
-use crate::convert::IntoPyErr;
+use crate::convert::{readonly_f64_1d, IntoPyErr};
 
 /// Processing applied while constructing a fixed-effects design.
-#[pyclass(frozen, module = "within._within")]
+#[pyclass(frozen, module = "within._within", skip_from_py_object)]
 #[pyo3(name = "DesignOptions")]
+#[derive(Clone, Default)]
 pub struct PyDesignOptions {
     #[pyo3(get)]
     pub drop_singletons: bool,
+    weights: Option<Arc<[f64]>>,
 }
 
 #[pymethods]
 impl PyDesignOptions {
     #[new]
-    #[pyo3(signature = (drop_singletons=false))]
-    fn new(drop_singletons: bool) -> Self {
-        Self { drop_singletons }
+    #[pyo3(signature = (drop_singletons=false, weights=None))]
+    fn new(drop_singletons: bool, weights: Option<&Bound<'_, PyAny>>) -> PyResult<Self> {
+        let weights = weights
+            .map(|weights| readonly_f64_1d("weights", weights))
+            .transpose()?;
+        Ok(Self {
+            drop_singletons,
+            weights: weights.map(|weights| Arc::from(weights.as_array().to_vec())),
+        })
+    }
+
+    /// Caller-order weights as an immutable configuration snapshot.
+    #[getter]
+    fn weights(&self) -> Option<Vec<f64>> {
+        self.weights.as_deref().map(<[f64]>::to_vec)
     }
 }
 
 impl PyDesignOptions {
-    pub(crate) fn to_native(&self) -> DesignOptions {
-        DesignOptions::default().drop_singletons(self.drop_singletons)
+    pub(crate) fn to_native(&self) -> DesignOptions<'_> {
+        let options = DesignOptions::default().drop_singletons(self.drop_singletons);
+        match &self.weights {
+            Some(weights) => options.weights(weights.as_ref()),
+            None => options,
+        }
     }
 }
 

--- a/crates/within-py/src/lib.rs
+++ b/crates/within-py/src/lib.rs
@@ -15,8 +15,9 @@ mod results;
 
 use api::{solve, solve_batch, PyEffect, PySolver};
 use config::{
-    PyAdditiveSchwarz, PyApproxCholConfig, PyApproxSchurConfig, PyLocalSolverConfig, PyLsmrOptions,
-    PyPreconditioner, PyPreconditionerConfig, PyReductionStrategy, PyScalingConfig, PySchur,
+    PyAdditiveSchwarz, PyApproxCholConfig, PyApproxSchurConfig, PyDesignOptions,
+    PyLocalSolverConfig, PyLsmrOptions, PyPreconditioner, PyPreconditionerConfig,
+    PyReductionStrategy, PyScalingConfig, PySchur,
 };
 use results::{PyBatchSolveResult, PyCoefficientLayout, PySolveResult, PyUnidentifiedDirection};
 
@@ -27,6 +28,7 @@ fn _within(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyUnidentifiedDirection>()?;
     m.add_class::<PyCoefficientLayout>()?;
     m.add_class::<PyLsmrOptions>()?;
+    m.add_class::<PyDesignOptions>()?;
     m.add_class::<PyAdditiveSchwarz>()?;
     m.add_class::<PyReductionStrategy>()?;
     m.add_class::<PyPreconditionerConfig>()?;

--- a/crates/within/README.md
+++ b/crates/within/README.md
@@ -16,7 +16,7 @@ cargo add within
 
 ```rust
 use ndarray::Array2;
-use within::{solve, LsmrOptions, PreconditionerConfig};
+use within::{solve, DesignOptions, IntoDesign, LsmrOptions, PreconditionerConfig};
 
 // Two factors: 100 levels each, 10 000 observations
 let n_obs = 10_000usize;
@@ -28,7 +28,8 @@ for i in 0..n_obs {
 let y: Vec<f64> = (0..n_obs).map(|i| i as f64 * 0.01).collect();
 
 // Solve with library defaults: LSMR + additive Schwarz
-let result = solve(categories.view(), &y, None, &LsmrOptions::default(), None)
+let design = categories.view().into_design(DesignOptions::default()).unwrap();
+let result = solve(design, &y, &LsmrOptions::default(), None)
     .expect("solve should succeed");
 assert!(result.converged);
 println!("LSMR converged in {} iterations", result.iterations);
@@ -36,13 +37,15 @@ println!("LSMR converged in {} iterations", result.iterations);
 // Tighter tolerance with an explicit preconditioner config
 let lsmr = LsmrOptions { tol: 1e-10, ..LsmrOptions::default() };
 let precond = PreconditionerConfig::default();
-let result = solve(categories.view(), &y, None, &lsmr, &precond)
+let design = categories.view().into_design(DesignOptions::default()).unwrap();
+let result = solve(design, &y, &lsmr, &precond)
     .expect("solve should succeed");
 assert!(result.converged);
 
 // Or opt into a diagonal/Jacobi preconditioner.
 let diagonal = PreconditionerConfig::Diagonal;
-let result = solve(categories.view(), &y, None, &lsmr, &diagonal)
+let design = categories.view().into_design(DesignOptions::default()).unwrap();
+let result = solve(design, &y, &lsmr, &diagonal)
     .expect("solve should succeed");
 assert!(result.converged);
 ```

--- a/crates/within/README.md
+++ b/crates/within/README.md
@@ -16,7 +16,7 @@ cargo add within
 
 ```rust
 use ndarray::Array2;
-use within::{solve, DesignOptions, IntoDesign, LsmrOptions, PreconditionerConfig};
+use within::{solve, Design, DesignOptions, LsmrOptions, PreconditionerConfig};
 
 // Two factors: 100 levels each, 10 000 observations
 let n_obs = 10_000usize;
@@ -28,7 +28,8 @@ for i in 0..n_obs {
 let y: Vec<f64> = (0..n_obs).map(|i| i as f64 * 0.01).collect();
 
 // Solve with library defaults: LSMR + additive Schwarz
-let design = categories.view().into_design(DesignOptions::default()).unwrap();
+let design =
+    Design::from_categories(categories.view(), DesignOptions::default()).unwrap();
 let result = solve(design, &y, &LsmrOptions::default(), None)
     .expect("solve should succeed");
 assert!(result.converged);
@@ -37,14 +38,16 @@ println!("LSMR converged in {} iterations", result.iterations);
 // Tighter tolerance with an explicit preconditioner config
 let lsmr = LsmrOptions { tol: 1e-10, ..LsmrOptions::default() };
 let precond = PreconditionerConfig::default();
-let design = categories.view().into_design(DesignOptions::default()).unwrap();
+let design =
+    Design::from_categories(categories.view(), DesignOptions::default()).unwrap();
 let result = solve(design, &y, &lsmr, &precond)
     .expect("solve should succeed");
 assert!(result.converged);
 
 // Or opt into a diagonal/Jacobi preconditioner.
 let diagonal = PreconditionerConfig::Diagonal;
-let design = categories.view().into_design(DesignOptions::default()).unwrap();
+let design =
+    Design::from_categories(categories.view(), DesignOptions::default()).unwrap();
 let result = solve(design, &y, &lsmr, &diagonal)
     .expect("solve should succeed");
 assert!(result.converged);

--- a/crates/within/benches/fixest.rs
+++ b/crates/within/benches/fixest.rs
@@ -96,7 +96,7 @@ fn run_lsmr_one_level(design: &Design<'_>, y: &[f64], ac2: bool) {
         local_solver: cfg,
         reduction: ReductionStrategy::Auto,
     };
-    let solver = Solver::new(design.clone(), None, &precond).expect("solver build");
+    let solver = Solver::new(design.clone(), &precond).expect("solver build");
     let _ = solver.solve(y, &params).expect("solve");
 }
 

--- a/crates/within/benches/shared/fixest_dgp.rs
+++ b/crates/within/benches/shared/fixest_dgp.rs
@@ -5,7 +5,7 @@
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 use within::observation::ObservationFrame;
-use within::Design;
+use within::{Design, DesignOptions};
 
 /// Build a panel with 10 observations per worker and ~23 workers per firm.
 /// `difficult` assigns firms round-robin (`i % n_firm`, high connectivity);
@@ -49,7 +49,7 @@ pub fn generate_fixest_like_case(
         Vec::new(),
     )
     .expect("valid frame");
-    let design = Design::from_frame(frame).expect("valid design");
+    let design = Design::from_frame(frame, DesignOptions::default()).expect("valid design");
 
     // Random y — callers measure iteration time on an arbitrary RHS, not
     // ground-truth recovery.

--- a/crates/within/benches/store_backend.rs
+++ b/crates/within/benches/store_backend.rs
@@ -9,7 +9,7 @@ use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
 use within::config::{LsmrOptions, PreconditionerConfig};
-use within::Solver;
+use within::{DesignOptions, IntoDesign, Solver};
 
 const TOL: f64 = 1e-6;
 const MAXITER: usize = 20;
@@ -96,7 +96,12 @@ fn bench_store_backends(c: &mut Criterion) {
         // C-order view: ingest copies each strided column once.
         group.bench_function(BenchmarkId::new("Array(C)", &p.label), |b| {
             b.iter(|| {
-                let solver = Solver::new(p.categories_c.view(), None, precond_ref).unwrap();
+                let design = p
+                    .categories_c
+                    .view()
+                    .into_design(DesignOptions::default())
+                    .unwrap();
+                let solver = Solver::new(design, precond_ref).unwrap();
                 let r = solver.solve(&p.y, &p.params).unwrap();
                 assert!(r.converged);
             });
@@ -105,7 +110,12 @@ fn bench_store_backends(c: &mut Criterion) {
         // F-order view: contiguous columns borrowed zero-copy.
         group.bench_function(BenchmarkId::new("Array(F)", &p.label), |b| {
             b.iter(|| {
-                let solver = Solver::new(p.categories_f.view(), None, precond_ref).unwrap();
+                let design = p
+                    .categories_f
+                    .view()
+                    .into_design(DesignOptions::default())
+                    .unwrap();
+                let solver = Solver::new(design, precond_ref).unwrap();
                 let r = solver.solve(&p.y, &p.params).unwrap();
                 assert!(r.converged);
             });

--- a/crates/within/benches/store_backend.rs
+++ b/crates/within/benches/store_backend.rs
@@ -9,7 +9,7 @@ use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
 use within::config::{LsmrOptions, PreconditionerConfig};
-use within::{DesignOptions, IntoDesign, Solver};
+use within::{Design, DesignOptions, Solver};
 
 const TOL: f64 = 1e-6;
 const MAXITER: usize = 20;
@@ -96,11 +96,9 @@ fn bench_store_backends(c: &mut Criterion) {
         // C-order view: ingest copies each strided column once.
         group.bench_function(BenchmarkId::new("Array(C)", &p.label), |b| {
             b.iter(|| {
-                let design = p
-                    .categories_c
-                    .view()
-                    .into_design(DesignOptions::default())
-                    .unwrap();
+                let design =
+                    Design::from_categories(p.categories_c.view(), DesignOptions::default())
+                        .unwrap();
                 let solver = Solver::new(design, precond_ref).unwrap();
                 let r = solver.solve(&p.y, &p.params).unwrap();
                 assert!(r.converged);
@@ -110,11 +108,9 @@ fn bench_store_backends(c: &mut Criterion) {
         // F-order view: contiguous columns borrowed zero-copy.
         group.bench_function(BenchmarkId::new("Array(F)", &p.label), |b| {
             b.iter(|| {
-                let design = p
-                    .categories_f
-                    .view()
-                    .into_design(DesignOptions::default())
-                    .unwrap();
+                let design =
+                    Design::from_categories(p.categories_f.view(), DesignOptions::default())
+                        .unwrap();
                 let solver = Solver::new(design, precond_ref).unwrap();
                 let r = solver.solve(&p.y, &p.params).unwrap();
                 assert!(r.converged);

--- a/crates/within/benches/wallclock_1m3fe.rs
+++ b/crates/within/benches/wallclock_1m3fe.rs
@@ -40,7 +40,7 @@ fn main() {
     let mut best = u128::MAX;
     for _ in 0..RUNS {
         let start = Instant::now();
-        let solver = Solver::new(design.clone(), None, &precond).expect("solver build");
+        let solver = Solver::new(design.clone(), &precond).expect("solver build");
         let result = solver.solve(&y, &params).expect("solve");
         best = best.min(start.elapsed().as_nanos());
         black_box(&result);

--- a/crates/within/examples/profile_hot_loop.rs
+++ b/crates/within/examples/profile_hot_loop.rs
@@ -50,7 +50,7 @@ fn main() {
     };
 
     let t_build = Instant::now();
-    let solver = Solver::new(design, None, &precond).expect("solver build");
+    let solver = Solver::new(design, &precond).expect("solver build");
     eprintln!(
         "preconditioner build: {:.3}s",
         t_build.elapsed().as_secs_f64()

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -76,6 +76,73 @@ impl<T> Loading<T> {
     }
 }
 
+/// Configuration applied while constructing a [`Design`].
+///
+/// Options operate on the observation data before the design's internal row
+/// order is finalized. Use [`DesignOptions::from_effects`] or
+/// [`DesignOptions::from_frame`] to construct a configured design; the
+/// convenience constructors on [`Design`] use [`DesignOptions::default`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DesignOptions {
+    drop_singletons: bool,
+    locality_sort: bool,
+}
+
+impl DesignOptions {
+    /// Remove observations belonging to a singleton level in any fixed-effect
+    /// term.
+    ///
+    /// Removal is iterative: dropping one observation can make another level a
+    /// singleton, so processing continues until every retained level occurs at
+    /// least twice. The default is `false`.
+    #[must_use]
+    pub fn drop_singletons(mut self, enabled: bool) -> Self {
+        self.drop_singletons = enabled;
+        self
+    }
+
+    /// Lower effect terms into a configured design.
+    pub fn from_effects<'a>(
+        self,
+        effects: impl IntoIterator<Item = Effect<'a>>,
+    ) -> Result<Design<'a>, BuildError> {
+        let mut categorical: Vec<Cow<'a, [u32]>> = Vec::new();
+        let mut continuous: Vec<Cow<'a, [f64]>> = Vec::new();
+        let mut structure: Vec<NonEmpty<Loading<u32>>> = Vec::new();
+        for effect in effects {
+            structure.push(effect.columns().map(|column| {
+                column.map(|&z| {
+                    continuous.push(Cow::Borrowed(z));
+                    (continuous.len() - 1) as u32
+                })
+            }));
+            categorical.push(Cow::Borrowed(effect.levels()));
+        }
+        let frame = ObservationFrame::new(categorical, continuous)?;
+        Design::build(frame, structure, self)
+    }
+
+    /// Construct a configured design from a frame of plain factors.
+    pub fn from_frame<'a>(self, frame: ObservationFrame<'a>) -> Result<Design<'a>, BuildError> {
+        let structure = vec![NonEmpty::of(Loading::Constant); frame.n_factors()];
+        Design::build(frame, structure, self)
+    }
+
+    fn with_locality_sort(mut self, enabled: bool) -> Self {
+        self.locality_sort = enabled;
+        self
+    }
+}
+
+impl Default for DesignOptions {
+    fn default() -> Self {
+        Self {
+            drop_singletons: false,
+            locality_sort: true,
+        }
+    }
+}
+
 /// Per-term metadata; coefficient `c` of `level` lives at `offset + c · n_levels + level`.
 #[derive(Debug, Clone)]
 pub(crate) struct TermMeta {
@@ -139,15 +206,81 @@ fn stable_argsort(key: &[u32], n_levels: usize) -> Vec<u32> {
     perm
 }
 
+/// Return caller rows surviving iterative singleton removal.
+///
+/// Adapted from pyfixest's [`_detect_singletons_rs`](https://github.com/py-econometrics/pyfixest/blob/0f608eb6e13930b355b4dac9b3f34ad5974e95a1/src/detect_singletons.rs#L25-L93)
+fn retained_non_singletons(frame: &ObservationFrame<'_>) -> Result<Option<Vec<u32>>, BuildError> {
+    let n_obs = frame.n_obs();
+    if frame.n_factors() == 0 {
+        return Ok(None);
+    }
+    if u32::try_from(n_obs).is_err() {
+        return Err(BuildError::RowIndexSpaceExceedsU32 { n_obs });
+    }
+
+    let max_level = (0..frame.n_factors())
+        .filter_map(|term| frame.level_column(term).iter().max().copied())
+        .max()
+        .unwrap_or(0) as usize;
+    let mut counts = vec![0u32; max_level + 1];
+    let mut retained: Vec<u32> = (0..n_obs as u32).collect();
+    let mut n_retained = n_obs;
+
+    loop {
+        let previous_n_retained = n_retained;
+
+        for term in 0..frame.n_factors() {
+            let levels = frame.level_column(term);
+            counts.fill(0);
+
+            let mut n_singleton_levels = 0i32;
+            for &row in &retained[..n_retained] {
+                let level = levels[row as usize] as usize;
+                let count = counts[level];
+                n_singleton_levels += i32::from(count == 0) - i32::from(count == 1);
+                counts[level] += 1;
+            }
+
+            if n_singleton_levels == 0 {
+                continue;
+            }
+
+            let mut write = 0;
+            for read in 0..n_retained {
+                let row = retained[read];
+                if counts[levels[row as usize] as usize] != 1 {
+                    retained[write] = row;
+                    write += 1;
+                }
+            }
+            n_retained = write;
+        }
+
+        if previous_n_retained == n_retained {
+            break;
+        }
+    }
+
+    if n_retained == n_obs {
+        return Ok(None);
+    }
+    if n_retained == 0 {
+        return Err(BuildError::EmptyObservations);
+    }
+
+    retained.truncate(n_retained);
+    Ok(Some(retained))
+}
+
 /// Fixed-effects design: observation columns plus coefficient-space layout.
 #[derive(Clone, Debug)]
 pub struct Design<'a> {
     /// Columns in internal row order (caller's, or an owned locality-sorted copy).
     pub(crate) frame: ObservationFrame<'a>,
     pub(crate) terms: Vec<TermMeta>,
-    /// Number of rows expected in caller-provided observation vectors.
-    pub(crate) input_n_obs: usize,
-    /// Number of retained rows represented by the design and numerical operator.
+    /// Number of observations provided by caller.
+    pub(crate) n_obs_input: usize,
+    /// Number of retained observations.
     pub(crate) n_obs: usize,
     pub(crate) n_dofs: usize,
     /// `rows[k]` = caller's original row represented at internal position `k`.
@@ -160,47 +293,34 @@ pub struct Design<'a> {
 impl<'a> Design<'a> {
     /// Lower effect terms into a design, laid out term-major (`offset[t] + c · L_t + level`).
     pub fn new(effects: impl IntoIterator<Item = Effect<'a>>) -> Result<Self, BuildError> {
-        let mut categorical: Vec<Cow<'a, [u32]>> = Vec::new();
-        let mut continuous: Vec<Cow<'a, [f64]>> = Vec::new();
-        let mut structure: Vec<NonEmpty<Loading<u32>>> = Vec::new();
-        for effect in effects {
-            structure.push(effect.columns().map(|column| {
-                column.map(|&z| {
-                    continuous.push(Cow::Borrowed(z));
-                    (continuous.len() - 1) as u32
-                })
-            }));
-            categorical.push(Cow::Borrowed(effect.levels()));
-        }
-        let frame = ObservationFrame::new(categorical, continuous)?;
-        Self::build(frame, structure, true)
+        DesignOptions::default().from_effects(effects)
     }
 
     /// Intercept-only factors, level count `max + 1`; locality-sorts an unsorted dominant factor.
     pub fn from_frame(frame: ObservationFrame<'a>) -> Result<Self, BuildError> {
-        let structure = vec![NonEmpty::of(Loading::Constant); frame.n_factors()];
-        Self::build(frame, structure, true)
+        DesignOptions::default().from_frame(frame)
     }
 
     /// [`from_frame`](Self::from_frame) without the locality sort — profiling escape hatch.
     #[doc(hidden)]
     pub fn from_frame_unsorted(frame: ObservationFrame<'a>) -> Result<Self, BuildError> {
-        let structure = vec![NonEmpty::of(Loading::Constant); frame.n_factors()];
-        Self::build(frame, structure, false)
+        DesignOptions::default()
+            .with_locality_sort(false)
+            .from_frame(frame)
     }
 
     /// `column_structure[term]` = that term's coefficient columns, aligned with the frame.
     fn build(
         frame: ObservationFrame<'a>,
         column_structure: Vec<NonEmpty<Loading<u32>>>,
-        locality_sort: bool,
+        options: DesignOptions,
     ) -> Result<Self, BuildError> {
         if frame.n_obs() == 0 {
             return Err(BuildError::EmptyObservations);
         }
         debug_assert_eq!(column_structure.len(), frame.n_factors());
 
-        let n_obs = frame.n_obs();
+        let n_obs_input = frame.n_obs();
         let mut terms = Vec::with_capacity(frame.n_factors());
         let mut offset = 0;
         for (q, columns) in column_structure.into_iter().enumerate() {
@@ -233,61 +353,50 @@ impl<'a> Design<'a> {
         // `rows` indexes observations as u32; beyond u32::MAX rows skip
         // the optimization — the solve itself has no such limit.
         let dominant = (0..terms.len()).max_by_key(|&q| terms[q].n_dofs());
-        let row_order = match dominant {
-            Some(d) if locality_sort && !terms[d].sorted && u32::try_from(n_obs).is_ok() => {
-                let perm = stable_argsort(frame.level_column(d), terms[d].n_levels);
-                Some(perm)
-            }
-            _ => None,
+        let mut rows = if options.drop_singletons {
+            retained_non_singletons(&frame)?
+        } else {
+            None
         };
 
-        let mut design = Design {
+        if let Some(dominant_term) = dominant {
+            let should_sort = options.locality_sort
+                && !terms[dominant_term].sorted
+                && u32::try_from(n_obs_input).is_ok();
+
+            if should_sort {
+                let key = frame.level_column(dominant_term);
+                match &mut rows {
+                    Some(retained) => {
+                        retained.sort_by_cached_key(|&caller_row| key[caller_row as usize]);
+                    }
+                    None => {
+                        rows = Some(stable_argsort(key, terms[dominant_term].n_levels));
+                    }
+                }
+            }
+        }
+
+        let n_obs_retained = rows.as_ref().map_or(n_obs_input, Vec::len);
+        let frame = match rows.as_deref() {
+            Some(selected_rows) => frame.permuted(selected_rows),
+            None => frame,
+        };
+
+        // Filtering and locality sorting can change whether any factor is
+        // non-decreasing in internal row order.
+        for (term, meta) in terms.iter_mut().enumerate() {
+            meta.sorted = frame.level_column(term).is_sorted();
+        }
+
+        Ok(Design {
             frame,
             terms,
-            input_n_obs: n_obs,
-            n_obs,
+            n_obs_input: n_obs_input,
+            n_obs: n_obs_retained,
             n_dofs: offset,
-            rows: None,
-        };
-        if let Some(row_order) = row_order {
-            design.remap_internal_rows(&row_order)?;
-        }
-        Ok(design)
-    }
-
-    /// Replace the represented internal rows with a reordered subset.
-    ///
-    /// `internal_rows` indexes the current internal representation. Its mapping
-    /// to original caller rows is composed into [`Design::rows`] while every
-    /// observation column is gathered exactly once.
-    pub(crate) fn remap_internal_rows(&mut self, internal_rows: &[u32]) -> Result<(), BuildError> {
-        if internal_rows.is_empty() {
-            return Err(BuildError::EmptyObservations);
-        }
-        debug_assert!(internal_rows.iter().all(|&row| (row as usize) < self.n_obs));
-
-        self.frame = self.frame.permuted(internal_rows);
-        let composed: Vec<u32> = match &self.rows {
-            None => internal_rows.to_vec(),
-            Some(rows) => internal_rows
-                .iter()
-                .map(|&internal| rows[internal as usize])
-                .collect(),
-        };
-        self.n_obs = internal_rows.len();
-        self.rows = ((self.n_obs != self.input_n_obs)
-            || composed
-                .iter()
-                .enumerate()
-                .any(|(internal, &caller)| internal != caller as usize))
-        .then_some(composed);
-
-        // A subsequence can make a previously unsorted factor sorted. Rescan
-        // every term so gather/scatter can retain the coalesced fast path.
-        for (term, meta) in self.terms.iter_mut().enumerate() {
-            meta.sorted = self.frame.level_column(term).is_sorted();
-        }
-        Ok(())
+            rows,
+        })
     }
 
     /// Convert the frame's columns to owned, dropping ties to caller buffers.
@@ -295,7 +404,7 @@ impl<'a> Design<'a> {
         Design {
             frame: self.frame.into_owned(),
             terms: self.terms,
-            input_n_obs: self.input_n_obs,
+            n_obs_input: self.n_obs_input,
             n_obs: self.n_obs,
             n_dofs: self.n_dofs,
             rows: self.rows,
@@ -305,9 +414,9 @@ impl<'a> Design<'a> {
     /// Validate that an optional weight slice matches this design's observation count.
     pub(crate) fn validate_weights(&self, weights: Option<&[f64]>) -> Result<(), BuildError> {
         if let Some(w) = weights {
-            if w.len() != self.input_n_obs {
+            if w.len() != self.n_obs_input {
                 return Err(BuildError::WeightCountMismatch {
-                    expected: self.input_n_obs,
+                    expected: self.n_obs_input,
                     got: w.len(),
                 });
             }
@@ -340,7 +449,7 @@ impl<'a> Design<'a> {
     ///
     /// Borrows when every caller row is retained in its original order.
     pub(crate) fn permute_obs_in<'v>(&self, v: &'v [f64]) -> Cow<'v, [f64]> {
-        debug_assert_eq!(v.len(), self.input_n_obs);
+        debug_assert_eq!(v.len(), self.n_obs_input);
         match &self.rows {
             None => Cow::Borrowed(v),
             Some(rows) => Cow::Owned(rows.iter().map(|&i| v[i as usize]).collect()),
@@ -355,7 +464,7 @@ impl<'a> Design<'a> {
         match &self.rows {
             None => v,
             Some(rows) => {
-                let mut out = vec![f64::NAN; self.input_n_obs];
+                let mut out = vec![f64::NAN; self.n_obs_input];
                 for (k, &orig) in rows.iter().enumerate() {
                     out[orig as usize] = v[k];
                 }
@@ -389,7 +498,7 @@ impl<'a> Design<'a> {
     /// Number of rows expected in caller-provided observation vectors.
     #[inline]
     pub fn input_n_obs(&self) -> usize {
-        self.input_n_obs
+        self.n_obs_input
     }
 
     /// Original caller row represented by an internal observation position.
@@ -536,6 +645,90 @@ mod tests {
     }
 
     #[test]
+    fn design_options_default_preserves_singletons() {
+        let design = DesignOptions::default()
+            .from_frame(frame(vec![vec![0, 0, 1], vec![0, 1, 1]], vec![]))
+            .unwrap();
+
+        assert_eq!(design.input_n_obs(), 3);
+        assert_eq!(design.n_obs(), 3);
+    }
+
+    #[test]
+    fn singleton_detection_matches_pyfixest_fixtures() {
+        let cases = [
+            (
+                vec![
+                    vec![0, 0, 0, 0, 0],
+                    vec![2, 2, 1, 1, 1],
+                    vec![1, 1, 3, 2, 2],
+                ],
+                Some(vec![0, 1, 3, 4]),
+            ),
+            (
+                vec![
+                    vec![0, 0, 3, 0, 0],
+                    vec![2, 2, 1, 1, 1],
+                    vec![1, 1, 2, 1, 2],
+                ],
+                Some(vec![0, 1]),
+            ),
+            (
+                vec![
+                    vec![0, 0, 0, 0, 0],
+                    vec![2, 2, 1, 1, 1],
+                    vec![1, 1, 1, 2, 2],
+                ],
+                None,
+            ),
+        ];
+
+        for (categorical, expected) in cases {
+            let input = frame(categorical, vec![]);
+            assert_eq!(retained_non_singletons(&input).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn design_options_iteratively_drop_singletons_before_one_final_gather() {
+        // Rows 0..4 form a 2-core. Rows 4..7 form a path:
+        //
+        //     B2 -- A2 -- B3 -- A3
+        //
+        // Its endpoint singleton levels trigger a cascading removal of all
+        // three path observations, while the four-row core survives.
+        let design = DesignOptions::default()
+            .drop_singletons(true)
+            .from_frame(frame(
+                vec![vec![1, 0, 1, 0, 2, 2, 3], vec![1, 0, 0, 1, 2, 3, 3]],
+                vec![vec![10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]],
+            ))
+            .unwrap();
+
+        // The surviving caller rows [0,1,2,3] are locality-sorted by the
+        // dominant second factor in the same composed mapping.
+        assert_eq!(design.rows.as_deref(), Some(&[1, 2, 0, 3][..]));
+        assert_eq!(design.input_n_obs(), 7);
+        assert_eq!(design.n_obs(), 4);
+        assert_eq!(design.frame.level_column(0), &[0, 1, 1, 0]);
+        assert_eq!(design.frame.level_column(1), &[0, 0, 1, 1]);
+        assert_eq!(design.frame.loading_column(0), &[11.0, 12.0, 10.0, 13.0]);
+
+        let restored = design.permute_obs_out(vec![1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(&restored[..4], &[3.0, 1.0, 2.0, 4.0]);
+        assert!(restored[4..].iter().all(|value| value.is_nan()));
+    }
+
+    #[test]
+    fn design_options_reject_when_singletons_remove_every_observation() {
+        let result = DesignOptions::default()
+            .drop_singletons(true)
+            .from_frame(frame(vec![vec![0, 1], vec![0, 1]], vec![]));
+
+        assert!(matches!(result, Err(BuildError::EmptyObservations)));
+    }
+
+    #[test]
     fn continuous_column_stays_row_aligned_after_locality_sort() {
         let design = Design::from_frame(frame(
             vec![vec![2, 0, 1, 0]],
@@ -550,32 +743,11 @@ mod tests {
     }
 
     #[test]
-    fn composed_rows_select_and_restore_without_intermediate_order() {
-        let mut design =
-            Design::from_frame_unsorted(frame(vec![vec![0, 1, 0, 1, 2]], vec![])).unwrap();
-        design.remap_internal_rows(&[3, 0, 2]).unwrap();
-
-        assert_eq!(design.input_n_obs, 5);
-        assert_eq!(design.n_obs, 3);
-        assert_eq!(design.rows.as_deref(), Some(&[3, 0, 2][..]));
-        assert_eq!(design.frame.level_column(0), &[1, 0, 0]);
-
-        let caller = [10.0, 20.0, 30.0, 40.0, 50.0];
-        assert_eq!(&*design.permute_obs_in(&caller), &[40.0, 10.0, 30.0]);
-
-        let restored = design.permute_obs_out(vec![4.0, 1.0, 3.0]);
-        assert_eq!(restored[0], 1.0);
-        assert!(restored[1].is_nan());
-        assert_eq!(restored[2], 3.0);
-        assert_eq!(restored[3], 4.0);
-        assert!(restored[4].is_nan());
-    }
-
-    #[test]
     fn validation_ignores_weights_on_removed_rows() {
-        let mut design =
-            Design::from_frame_unsorted(frame(vec![vec![0, 1, 0, 1, 2]], vec![])).unwrap();
-        design.remap_internal_rows(&[3, 0, 2]).unwrap();
+        let design = DesignOptions::default()
+            .drop_singletons(true)
+            .from_frame(frame(vec![vec![0, 1, 0, 0, 2]], vec![]))
+            .unwrap();
 
         assert!(design
             .validate_weights(Some(&[1.0, f64::NAN, 1.0, 1.0, f64::NAN]))
@@ -587,23 +759,6 @@ mod tests {
                 value: -1.0
             })
         ));
-    }
-
-    #[test]
-    fn repeated_row_remapping_composes_to_original_caller_rows() {
-        let mut design = Design::from_frame(frame(vec![vec![2, 0, 1, 0]], vec![])).unwrap();
-        assert_eq!(design.rows.as_deref(), Some(&[1, 3, 2, 0][..]));
-
-        design.remap_internal_rows(&[3, 0]).unwrap();
-
-        assert_eq!(design.input_n_obs, 4);
-        assert_eq!(design.n_obs, 2);
-        assert_eq!(design.rows.as_deref(), Some(&[0, 1][..]));
-        assert_eq!(design.frame.level_column(0), &[2, 0]);
-        assert_eq!(
-            &*design.permute_obs_in(&[10.0, 20.0, 30.0, 40.0]),
-            &[10.0, 20.0]
-        );
     }
 
     #[test]

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -15,6 +15,8 @@ pub(crate) use factor_pairs::{
 
 use std::borrow::Cow;
 
+use ndarray::{ArrayView2, Axis};
+
 use crate::channel::Channel;
 use crate::observation::ObservationFrame;
 use crate::BuildError;
@@ -76,107 +78,37 @@ impl<T> Loading<T> {
     }
 }
 
-pub(crate) fn map_to_internal_order<'v, T: Clone>(
-    rows: Option<&[u32]>,
-    n_obs_input: usize,
-    values: &'v [T],
-) -> Cow<'v, [T]> {
-    assert_eq!(
-        values.len(),
-        n_obs_input,
-        "observation vector length must match the design input"
-    );
-    match rows {
-        None => Cow::Borrowed(values),
-        Some(rows) => Cow::Owned(
-            rows.iter()
-                .map(|&caller| values[caller as usize].clone())
-                .collect(),
-        ),
-    }
-}
-
 /// Configuration applied while constructing a [`Design`].
 ///
 /// Options operate on the observation data before the design's internal row
-/// order is finalized. Use [`DesignOptions::from_effects`] or
-/// [`DesignOptions::from_frame`] to construct a configured design; the
-/// convenience constructors on [`Design`] use [`DesignOptions::default`].
-#[derive(Clone, Debug, PartialEq)]
+/// order is finalized.
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct DesignOptions<'a> {
     drop_singletons: bool,
-    locality_sort: bool,
     weights: Option<Cow<'a, [f64]>>,
 }
 
 impl<'a> DesignOptions<'a> {
-    /// Remove observations belonging to a singleton level in any fixed-effect
-    /// term.
+    /// Create design-construction options.
     ///
-    /// Removal is iterative: dropping one observation can make another level a
-    /// singleton, so processing continues until every retained level occurs at
-    /// least twice. The default is `false`.
-    #[must_use]
-    pub fn drop_singletons(mut self, enabled: bool) -> Self {
-        self.drop_singletons = enabled;
-        self
-    }
-
-    /// Record observation weights in caller row order.
-    ///
-    /// Borrowed slices remain borrowed by the resulting [`Design`]; owned
-    /// vectors are retained without another copy.
-    #[must_use]
-    pub fn weights(mut self, weights: impl Into<Cow<'a, [f64]>>) -> Self {
-        self.weights = Some(weights.into());
-        self
-    }
-
-    /// Lower effect terms into a configured design.
-    pub fn from_effects(
-        self,
-        effects: impl IntoIterator<Item = Effect<'a>>,
-    ) -> Result<Design<'a>, BuildError> {
-        let mut categorical: Vec<Cow<'a, [u32]>> = Vec::new();
-        let mut continuous: Vec<Cow<'a, [f64]>> = Vec::new();
-        let mut structure: Vec<NonEmpty<Loading<u32>>> = Vec::new();
-        for effect in effects {
-            structure.push(effect.columns().map(|column| {
-                column.map(|&z| {
-                    continuous.push(Cow::Borrowed(z));
-                    (continuous.len() - 1) as u32
-                })
-            }));
-            categorical.push(Cow::Borrowed(effect.levels()));
-        }
-        let frame = ObservationFrame::new(categorical, continuous)?;
-        Design::build(frame, structure, self)
-    }
-
-    /// Construct a configured design from a frame of plain factors.
-    pub fn from_frame(self, frame: ObservationFrame<'a>) -> Result<Design<'a>, BuildError> {
-        let structure = vec![NonEmpty::of(Loading::Constant); frame.n_factors()];
-        Design::build(frame, structure, self)
-    }
-
-    #[doc(hidden)]
-    pub fn with_locality_sort(mut self, enabled: bool) -> Self {
-        self.locality_sort = enabled;
-        self
-    }
-
-    pub(crate) fn weight_values(&self) -> Option<&[f64]> {
-        self.weights.as_deref()
-    }
-}
-
-impl Default for DesignOptions<'_> {
-    fn default() -> Self {
+    /// `weights` are recorded in caller row order. Borrowed slices remain
+    /// borrowed by the resulting [`Design`]; owned vectors are retained
+    /// without another copy.
+    pub fn new(drop_singletons: bool, weights: Option<Cow<'a, [f64]>>) -> Self {
         Self {
-            drop_singletons: false,
-            locality_sort: true,
-            weights: None,
+            drop_singletons,
+            weights,
         }
+    }
+
+    /// Whether iterative singleton removal is enabled.
+    pub fn drop_singletons(&self) -> bool {
+        self.drop_singletons
+    }
+
+    /// Observation weights in caller row order.
+    pub fn weights(&self) -> Option<&[f64]> {
+        self.weights.as_deref()
     }
 }
 
@@ -330,22 +262,68 @@ pub struct Design<'a> {
 }
 
 impl<'a> Design<'a> {
-    /// Lower effect terms into a design, laid out term-major (`offset[t] + c · L_t + level`).
-    pub fn new(effects: impl IntoIterator<Item = Effect<'a>>) -> Result<Self, BuildError> {
-        DesignOptions::default().from_effects(effects)
+    /// Construct a design from a matrix of categorical fixed-effect codes.
+    ///
+    /// F-contiguous columns are borrowed zero-copy. Strided columns (such as
+    /// columns of a C-contiguous matrix) are gathered once during construction.
+    pub fn from_categories(
+        categories: ArrayView2<'a, u32>,
+        options: DesignOptions<'a>,
+    ) -> Result<Self, BuildError> {
+        let categorical = (0..categories.ncols())
+            .map(|q| {
+                let column = categories.index_axis_move(Axis(1), q);
+                match column.to_slice() {
+                    Some(values) => Cow::Borrowed(values),
+                    None => Cow::Owned(column.to_vec()),
+                }
+            })
+            .collect();
+        let frame = ObservationFrame::new(categorical, Vec::new())?;
+        Self::from_frame(frame, options)
     }
 
-    /// Intercept-only factors, level count `max + 1`; locality-sorts an unsorted dominant factor.
-    pub fn from_frame(frame: ObservationFrame<'a>) -> Result<Self, BuildError> {
-        DesignOptions::default().from_frame(frame)
+    /// Lower effect terms into a design: level columns plus each term's slope
+    /// loadings, laid out term-major (`offset[t] + c * L_t + level`).
+    pub fn from_effects(
+        effects: impl IntoIterator<Item = Effect<'a>>,
+        options: DesignOptions<'a>,
+    ) -> Result<Self, BuildError> {
+        let mut categorical: Vec<Cow<'a, [u32]>> = Vec::new();
+        let mut continuous: Vec<Cow<'a, [f64]>> = Vec::new();
+        let mut structure: Vec<NonEmpty<Loading<u32>>> = Vec::new();
+        for effect in effects {
+            structure.push(effect.columns().map(|column| {
+                column.map(|&z| {
+                    continuous.push(Cow::Borrowed(z));
+                    (continuous.len() - 1) as u32
+                })
+            }));
+            categorical.push(Cow::Borrowed(effect.levels()));
+        }
+        let frame = ObservationFrame::new(categorical, continuous)?;
+        Self::build(frame, structure, options, true)
+    }
+
+    /// Construct from a frame of plain factors (each an intercept-only term),
+    /// inferring each factor's level count (`max + 1`); locality-sorts all
+    /// columns when the dominant factor is unsorted.
+    pub fn from_frame(
+        frame: ObservationFrame<'a>,
+        options: DesignOptions<'a>,
+    ) -> Result<Self, BuildError> {
+        let structure = vec![NonEmpty::of(Loading::Constant); frame.n_factors()];
+        Self::build(frame, structure, options, true)
     }
 
     /// [`from_frame`](Self::from_frame) without the locality sort — profiling escape hatch.
     #[doc(hidden)]
-    pub fn from_frame_unsorted(frame: ObservationFrame<'a>) -> Result<Self, BuildError> {
-        DesignOptions::default()
-            .with_locality_sort(false)
-            .from_frame(frame)
+    pub fn from_frame_unsorted(
+        frame: ObservationFrame<'a>,
+        options: DesignOptions<'a>,
+    ) -> Result<Self, BuildError> {
+        let structure = vec![NonEmpty::of(Loading::Constant); frame.n_factors()];
+        Self::build(frame, structure, options, false)
     }
 
     /// `column_structure[term]` = that term's coefficient columns, aligned with the frame.
@@ -353,6 +331,7 @@ impl<'a> Design<'a> {
         frame: ObservationFrame<'a>,
         column_structure: Vec<NonEmpty<Loading<u32>>>,
         options: DesignOptions<'a>,
+        locality_sort: bool,
     ) -> Result<Self, BuildError> {
         if frame.n_obs() == 0 {
             return Err(BuildError::EmptyObservations);
@@ -392,16 +371,15 @@ impl<'a> Design<'a> {
         // `rows` indexes observations as u32; beyond u32::MAX rows skip
         // the optimization — the solve itself has no such limit.
         let dominant = (0..terms.len()).max_by_key(|&q| terms[q].n_dofs());
-        let mut rows = if options.drop_singletons {
+        let mut rows = if options.drop_singletons() {
             retained_non_singletons(&frame)?
         } else {
             None
         };
 
         if let Some(dominant_term) = dominant {
-            let should_sort = options.locality_sort
-                && !terms[dominant_term].sorted
-                && u32::try_from(n_obs_input).is_ok();
+            let should_sort =
+                locality_sort && !terms[dominant_term].sorted && u32::try_from(n_obs_input).is_ok();
 
             if should_sort {
                 let key = frame.level_column(dominant_term);
@@ -437,7 +415,7 @@ impl<'a> Design<'a> {
             rows,
             options,
         };
-        design.validate_weights(design.weights())?;
+        design.validate_weights(design.options().weights())?;
         Ok(design)
     }
 
@@ -452,7 +430,6 @@ impl<'a> Design<'a> {
             rows: self.rows,
             options: DesignOptions {
                 drop_singletons: self.options.drop_singletons,
-                locality_sort: self.options.locality_sort,
                 weights: self
                     .options
                     .weights
@@ -498,19 +475,23 @@ impl<'a> Design<'a> {
     /// Caller order → retained internal order: `out[k] = v[rows[k]]`.
     ///
     /// Borrows when every caller row is retained in its original order.
-    pub fn to_internal_order<'v, T: Clone>(&self, v: &'v [T]) -> Cow<'v, [T]> {
-        map_to_internal_order(self.rows.as_deref(), self.n_obs_input, v)
+    pub(crate) fn to_internal_row_order<'v, T: Clone>(&self, v: &'v [T]) -> Cow<'v, [T]> {
+        debug_assert_eq!(v.len(), self.n_obs_input);
+        match &self.rows {
+            None => Cow::Borrowed(v),
+            Some(rows) => Cow::Owned(
+                rows.iter()
+                    .map(|&caller| v[caller as usize].clone())
+                    .collect(),
+            ),
+        }
     }
 
     /// Retained internal order → original caller shape.
     ///
     /// Dropped caller rows are represented by `NaN`.
-    pub fn from_internal_order(&self, v: Vec<f64>) -> Vec<f64> {
-        assert_eq!(
-            v.len(),
-            self.n_obs,
-            "internal vector length must match retained observations"
-        );
+    pub(crate) fn to_input_row_order(&self, v: Vec<f64>) -> Vec<f64> {
+        debug_assert_eq!(v.len(), self.n_obs);
         match &self.rows {
             None => v,
             Some(rows) => {
@@ -555,12 +536,6 @@ impl<'a> Design<'a> {
     #[inline]
     pub fn options(&self) -> &DesignOptions<'a> {
         &self.options
-    }
-
-    /// Observation weights in caller row order.
-    #[inline]
-    pub fn weights(&self) -> Option<&[f64]> {
-        self.options.weights.as_deref()
     }
 
     /// Original caller row represented by an internal observation position.
@@ -634,8 +609,14 @@ mod tests {
 
     #[test]
     fn build_rejects_dof_space_exceeding_u32() {
-        // A single code of u32::MAX implies one level past the CSR column-index width.
-        let err = Design::from_frame(frame(vec![vec![u32::MAX]], vec![])).unwrap_err();
+        // A single code of u32::MAX implies u32::MAX + 1 levels — one past the
+        // CSR column-index width — the shape a raw entity ID takes. Rejected
+        // before any to_u32 conversion can panic.
+        let err = Design::from_frame(
+            frame(vec![vec![u32::MAX]], vec![]),
+            DesignOptions::default(),
+        )
+        .unwrap_err();
         assert!(matches!(
             err,
             BuildError::DofSpaceExceedsU32 { n_dofs } if n_dofs == u32::MAX as usize + 1
@@ -644,7 +625,11 @@ mod tests {
 
     #[test]
     fn validate_weights_checks_count_and_finiteness() {
-        let design = Design::from_frame(frame(vec![vec![0, 0, 0, 0, 0]], vec![])).unwrap();
+        let design = Design::from_frame(
+            frame(vec![vec![0, 0, 0, 0, 0]], vec![]),
+            DesignOptions::default(),
+        )
+        .unwrap();
         assert!(design.validate_weights(None).is_ok());
         assert!(design
             .validate_weights(Some(&[1.0, 2.0, 3.0, 4.0, 5.0]))
@@ -673,8 +658,11 @@ mod tests {
     #[test]
     fn from_frame_sorts_owned_unsorted_dominant() {
         // Factor 0 (3 levels) dominates and is unsorted; factor 1 starts sorted.
-        let design =
-            Design::from_frame(frame(vec![vec![2, 0, 1, 0], vec![0, 0, 1, 1]], vec![])).unwrap();
+        let design = Design::from_frame(
+            frame(vec![vec![2, 0, 1, 0], vec![0, 0, 1, 1]], vec![]),
+            DesignOptions::default(),
+        )
+        .unwrap();
 
         // Stable argsort of [2,0,1,0] → original indices [1,3,2,0].
         assert_eq!(design.rows.as_deref(), Some(&[1u32, 3, 2, 0][..]));
@@ -691,7 +679,8 @@ mod tests {
         // Factor 1 is nested in dominant factor 0, so the rescan must detect it stays sorted.
         let col0 = vec![3u32, 0, 2, 1];
         let col1: Vec<u32> = col0.iter().map(|&v| v / 2).collect();
-        let design = Design::from_frame(frame(vec![col0, col1], vec![])).unwrap();
+        let design =
+            Design::from_frame(frame(vec![col0, col1], vec![]), DesignOptions::default()).unwrap();
         assert!(design.rows.is_some());
         assert!(design.terms[0].sorted);
         assert!(design.terms[1].sorted);
@@ -699,8 +688,11 @@ mod tests {
 
     #[test]
     fn from_frame_keeps_sorted_input() {
-        let design =
-            Design::from_frame(frame(vec![vec![0, 0, 1, 2], vec![1, 0, 1, 0]], vec![])).unwrap();
+        let design = Design::from_frame(
+            frame(vec![vec![0, 0, 1, 2], vec![1, 0, 1, 0]], vec![]),
+            DesignOptions::default(),
+        )
+        .unwrap();
         assert!(design.rows.is_none());
         assert!(design.terms[0].sorted);
         assert!(!design.terms[1].sorted);
@@ -708,9 +700,11 @@ mod tests {
 
     #[test]
     fn design_options_default_preserves_singletons() {
-        let design = DesignOptions::default()
-            .from_frame(frame(vec![vec![0, 0, 1], vec![0, 1, 1]], vec![]))
-            .unwrap();
+        let design = Design::from_frame(
+            frame(vec![vec![0, 0, 1], vec![0, 1, 1]], vec![]),
+            DesignOptions::default(),
+        )
+        .unwrap();
 
         assert_eq!(design.input_n_obs(), 3);
         assert_eq!(design.n_obs(), 3);
@@ -759,13 +753,14 @@ mod tests {
         //
         // Its endpoint singleton levels trigger a cascading removal of all
         // three path observations, while the four-row core survives.
-        let design = DesignOptions::default()
-            .drop_singletons(true)
-            .from_frame(frame(
+        let design = Design::from_frame(
+            frame(
                 vec![vec![1, 0, 1, 0, 2, 2, 3], vec![1, 0, 0, 1, 2, 3, 3]],
                 vec![vec![10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]],
-            ))
-            .unwrap();
+            ),
+            DesignOptions::new(true, None),
+        )
+        .unwrap();
 
         // The surviving caller rows [0,1,2,3] are locality-sorted by the
         // dominant second factor in the same composed mapping.
@@ -776,26 +771,27 @@ mod tests {
         assert_eq!(design.frame.level_column(1), &[0, 0, 1, 1]);
         assert_eq!(design.frame.loading_column(0), &[11.0, 12.0, 10.0, 13.0]);
 
-        let restored = design.from_internal_order(vec![1.0, 2.0, 3.0, 4.0]);
+        let restored = design.to_input_row_order(vec![1.0, 2.0, 3.0, 4.0]);
         assert_eq!(&restored[..4], &[3.0, 1.0, 2.0, 4.0]);
         assert!(restored[4..].iter().all(|value| value.is_nan()));
     }
 
     #[test]
     fn design_options_reject_when_singletons_remove_every_observation() {
-        let result = DesignOptions::default()
-            .drop_singletons(true)
-            .from_frame(frame(vec![vec![0, 1], vec![0, 1]], vec![]));
+        let result = Design::from_frame(
+            frame(vec![vec![0, 1], vec![0, 1]], vec![]),
+            DesignOptions::new(true, None),
+        );
 
         assert!(matches!(result, Err(BuildError::EmptyObservations)));
     }
 
     #[test]
     fn continuous_column_stays_row_aligned_after_locality_sort() {
-        let design = Design::from_frame(frame(
-            vec![vec![2, 0, 1, 0]],
-            vec![vec![10.0, 20.0, 30.0, 40.0]],
-        ))
+        let design = Design::from_frame(
+            frame(vec![vec![2, 0, 1, 0]], vec![vec![10.0, 20.0, 30.0, 40.0]]),
+            DesignOptions::default(),
+        )
         .unwrap();
 
         let perm = design.rows.as_ref().expect("permutation applied");
@@ -807,23 +803,26 @@ mod tests {
     #[test]
     fn validation_ignores_weights_on_removed_rows() {
         let weights = [1.0, f64::NAN, 1.0, 1.0, f64::NAN];
-        let design = DesignOptions::default()
-            .drop_singletons(true)
-            .weights(&weights[..])
-            .from_frame(frame(vec![vec![0, 1, 0, 0, 2]], vec![]))
-            .unwrap();
+        let design = Design::from_frame(
+            frame(vec![vec![0, 1, 0, 0, 2]], vec![]),
+            DesignOptions::new(true, Some(Cow::Borrowed(&weights))),
+        )
+        .unwrap();
 
-        let stored = design.weights().expect("weights retained");
+        let stored = design.options().weights().expect("weights retained");
         assert_eq!(stored.len(), weights.len());
         assert_eq!(stored[0], 1.0);
         assert!(stored[1].is_nan());
         assert_eq!(&stored[2..4], &[1.0, 1.0]);
         assert!(stored[4].is_nan());
         assert!(matches!(
-            DesignOptions::default()
-                .drop_singletons(true)
-                .weights(&[1.0, f64::NAN, -1.0, 1.0, f64::NAN][..])
-                .from_frame(frame(vec![vec![0, 1, 0, 0, 2]], vec![])),
+            Design::from_frame(
+                frame(vec![vec![0, 1, 0, 0, 2]], vec![]),
+                DesignOptions::new(
+                    true,
+                    Some(Cow::Borrowed(&[1.0, f64::NAN, -1.0, 1.0, f64::NAN])),
+                ),
+            ),
             Err(BuildError::InvalidWeight {
                 index: 2,
                 value: -1.0
@@ -833,17 +832,23 @@ mod tests {
 
     #[test]
     fn ordering_is_generic_and_borrows_only_for_identity() {
-        let identity = Design::from_frame(frame(vec![vec![0, 0, 1]], vec![])).unwrap();
+        let identity =
+            Design::from_frame(frame(vec![vec![0, 0, 1]], vec![]), DesignOptions::default())
+                .unwrap();
         let values = ["a", "b", "c"];
         assert!(matches!(
-            identity.to_internal_order(&values),
+            identity.to_internal_row_order(&values),
             Cow::Borrowed(_)
         ));
 
-        let sorted = Design::from_frame(frame(vec![vec![2, 0, 1, 0]], vec![])).unwrap();
+        let sorted = Design::from_frame(
+            frame(vec![vec![2, 0, 1, 0]], vec![]),
+            DesignOptions::default(),
+        )
+        .unwrap();
         let values = ["a", "b", "c", "d"];
         assert_eq!(
-            sorted.to_internal_order(&values).as_ref(),
+            sorted.to_internal_row_order(&values).as_ref(),
             &["b", "d", "c", "a"]
         );
     }
@@ -851,14 +856,15 @@ mod tests {
     #[test]
     fn into_owned_detaches_option_weights() {
         let weights = vec![1.0, 2.0, 3.0];
-        let design = DesignOptions::default()
-            .weights(weights.as_slice())
-            .from_frame(frame(vec![vec![0, 0, 1]], vec![]))
-            .unwrap()
-            .into_owned();
+        let design = Design::from_frame(
+            frame(vec![vec![0, 0, 1]], vec![]),
+            DesignOptions::new(false, Some(Cow::Borrowed(weights.as_slice()))),
+        )
+        .unwrap()
+        .into_owned();
         drop(weights);
 
-        assert_eq!(design.weights(), Some(&[1.0, 2.0, 3.0][..]));
+        assert_eq!(design.options().weights(), Some(&[1.0, 2.0, 3.0][..]));
         assert!(matches!(
             design.options().weights.as_ref(),
             Some(Cow::Owned(_))
@@ -866,8 +872,9 @@ mod tests {
     }
 
     #[test]
-    fn new_lays_out_slope_terms_term_major() {
-        // Sorted levels keep the locality sort a no-op, so frame columns stay in caller order.
+    fn from_effects_lays_out_slope_terms_term_major() {
+        // Term 0 is dominant (most DOFs); sorted levels keep the locality
+        // sort a no-op so the frame columns stay in caller order.
         let f0 = [0u32, 0, 1, 1];
         let f1 = [0u32, 2, 1, 0];
         let z0 = [1.0, 2.0, 3.0, 4.0];
@@ -877,7 +884,7 @@ mod tests {
             Effect::new(&f1, true, []).unwrap(),
             Effect::new(&f0, false, [&z1[..]]).unwrap(),
         ];
-        let design = Design::new(effects).unwrap();
+        let design = Design::from_effects(effects, DesignOptions::default()).unwrap();
 
         // term 0: [intercept, z0, z1] over 2 levels; term 1: intercept over 3; term 2: slope.
         assert_eq!(design.terms[0].offset, 0);

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -145,10 +145,16 @@ pub struct Design<'a> {
     /// Columns in internal row order (caller's, or an owned locality-sorted copy).
     pub(crate) frame: ObservationFrame<'a>,
     pub(crate) terms: Vec<TermMeta>,
+    /// Number of rows expected in caller-provided observation vectors.
+    pub(crate) input_n_obs: usize,
+    /// Number of retained rows represented by the design and numerical operator.
     pub(crate) n_obs: usize,
     pub(crate) n_dofs: usize,
-    /// `obs_perm[k]` = caller's original index of the observation at internal position `k`.
-    pub(crate) obs_perm: Option<Vec<u32>>,
+    /// `rows[k]` = caller's original row represented at internal position `k`.
+    ///
+    /// This single map composes semantic row selection with locality sorting.
+    /// `None` is the identity map and preserves zero-copy observation input.
+    pub(crate) rows: Option<Vec<u32>>,
 }
 
 impl<'a> Design<'a> {
@@ -222,28 +228,66 @@ impl<'a> Design<'a> {
             return Err(BuildError::DofSpaceExceedsU32 { n_dofs: offset });
         }
 
-        // Sort by the term contributing the most DOFs so its gather/scatter runs sequentially.
+        // Sort by the term contributing the most DOFs (for plain factors, the
+        // highest-cardinality one) so its gather/scatter runs sequentially.
+        // `rows` indexes observations as u32; beyond u32::MAX rows skip
+        // the optimization — the solve itself has no such limit.
         let dominant = (0..terms.len()).max_by_key(|&q| terms[q].n_dofs());
-        let (frame, obs_perm) = match dominant {
+        let row_order = match dominant {
             Some(d) if locality_sort && !terms[d].sorted && u32::try_from(n_obs).is_ok() => {
                 let perm = stable_argsort(frame.level_column(d), terms[d].n_levels);
-                let sorted_frame = frame.permuted(&perm);
-                // Factors nested in the dominant one come out sorted, keeping coalesced scatter.
-                for (q, meta) in terms.iter_mut().enumerate() {
-                    meta.sorted = sorted_frame.level_column(q).is_sorted();
-                }
-                (sorted_frame, Some(perm))
+                Some(perm)
             }
-            _ => (frame, None),
+            _ => None,
         };
 
-        Ok(Design {
+        let mut design = Design {
             frame,
             terms,
+            input_n_obs: n_obs,
             n_obs,
             n_dofs: offset,
-            obs_perm,
-        })
+            rows: None,
+        };
+        if let Some(row_order) = row_order {
+            design.remap_internal_rows(&row_order)?;
+        }
+        Ok(design)
+    }
+
+    /// Replace the represented internal rows with a reordered subset.
+    ///
+    /// `internal_rows` indexes the current internal representation. Its mapping
+    /// to original caller rows is composed into [`Design::rows`] while every
+    /// observation column is gathered exactly once.
+    pub(crate) fn remap_internal_rows(&mut self, internal_rows: &[u32]) -> Result<(), BuildError> {
+        if internal_rows.is_empty() {
+            return Err(BuildError::EmptyObservations);
+        }
+        debug_assert!(internal_rows.iter().all(|&row| (row as usize) < self.n_obs));
+
+        self.frame = self.frame.permuted(internal_rows);
+        let composed: Vec<u32> = match &self.rows {
+            None => internal_rows.to_vec(),
+            Some(rows) => internal_rows
+                .iter()
+                .map(|&internal| rows[internal as usize])
+                .collect(),
+        };
+        self.n_obs = internal_rows.len();
+        self.rows = ((self.n_obs != self.input_n_obs)
+            || composed
+                .iter()
+                .enumerate()
+                .any(|(internal, &caller)| internal != caller as usize))
+        .then_some(composed);
+
+        // A subsequence can make a previously unsorted factor sorted. Rescan
+        // every term so gather/scatter can retain the coalesced fast path.
+        for (term, meta) in self.terms.iter_mut().enumerate() {
+            meta.sorted = self.frame.level_column(term).is_sorted();
+        }
+        Ok(())
     }
 
     /// Convert the frame's columns to owned, dropping ties to caller buffers.
@@ -251,50 +295,68 @@ impl<'a> Design<'a> {
         Design {
             frame: self.frame.into_owned(),
             terms: self.terms,
+            input_n_obs: self.input_n_obs,
             n_obs: self.n_obs,
             n_dofs: self.n_dofs,
-            obs_perm: self.obs_perm,
+            rows: self.rows,
         }
     }
 
     /// Validate that an optional weight slice matches this design's observation count.
     pub(crate) fn validate_weights(&self, weights: Option<&[f64]>) -> Result<(), BuildError> {
         if let Some(w) = weights {
-            if w.len() != self.n_obs {
+            if w.len() != self.input_n_obs {
                 return Err(BuildError::WeightCountMismatch {
-                    expected: self.n_obs,
+                    expected: self.input_n_obs,
                     got: w.len(),
                 });
             }
-            // `wi >= 0.0` already rejects NaN; `is_finite` additionally rejects `+∞`.
-            if let Some((index, &value)) = w
-                .iter()
-                .enumerate()
-                .find(|&(_, &wi)| !(wi >= 0.0 && wi.is_finite()))
-            {
+            // `W^{1/2}` is applied to the design, so each weight must be finite and
+            // non-negative; otherwise `sqrt(w)` is NaN and the solution is silently
+            // corrupted. `wi >= 0.0` already rejects NaN (comparisons with NaN are
+            // false); `is_finite` additionally rejects `+∞`.
+            let invalid = match &self.rows {
+                None => w
+                    .iter()
+                    .enumerate()
+                    .find(|&(_, &value)| !(value >= 0.0 && value.is_finite()))
+                    .map(|(caller, &value)| (caller, value)),
+                Some(rows) => rows
+                    .iter()
+                    .filter_map(|&caller| {
+                        let value = w[caller as usize];
+                        (!(value >= 0.0 && value.is_finite())).then_some((caller as usize, value))
+                    })
+                    .min_by_key(|&(caller, _)| caller),
+            };
+            if let Some((index, value)) = invalid {
                 return Err(BuildError::InvalidWeight { index, value });
             }
         }
         Ok(())
     }
 
-    /// Caller order → internal order: `out[k] = v[obs_perm[k]]`; borrows when unpermuted.
+    /// Caller order → retained internal order: `out[k] = v[rows[k]]`.
+    ///
+    /// Borrows when every caller row is retained in its original order.
     pub(crate) fn permute_obs_in<'v>(&self, v: &'v [f64]) -> Cow<'v, [f64]> {
-        debug_assert_eq!(v.len(), self.n_obs);
-        match &self.obs_perm {
+        debug_assert_eq!(v.len(), self.input_n_obs);
+        match &self.rows {
             None => Cow::Borrowed(v),
-            Some(perm) => Cow::Owned(perm.iter().map(|&i| v[i as usize]).collect()),
+            Some(rows) => Cow::Owned(rows.iter().map(|&i| v[i as usize]).collect()),
         }
     }
 
-    /// Internal order → caller order: `out[obs_perm[k]] = v[k]`.
+    /// Retained internal order → original caller shape.
+    ///
+    /// Dropped caller rows are represented by `NaN`.
     pub(crate) fn permute_obs_out(&self, v: Vec<f64>) -> Vec<f64> {
         debug_assert_eq!(v.len(), self.n_obs);
-        match &self.obs_perm {
+        match &self.rows {
             None => v,
-            Some(perm) => {
-                let mut out = vec![0.0; v.len()];
-                for (k, &orig) in perm.iter().enumerate() {
+            Some(rows) => {
+                let mut out = vec![f64::NAN; self.input_n_obs];
+                for (k, &orig) in rows.iter().enumerate() {
                     out[orig as usize] = v[k];
                 }
                 out
@@ -322,6 +384,20 @@ impl<'a> Design<'a> {
     #[inline]
     pub fn n_obs(&self) -> usize {
         self.n_obs
+    }
+
+    /// Number of rows expected in caller-provided observation vectors.
+    #[inline]
+    pub fn input_n_obs(&self) -> usize {
+        self.input_n_obs
+    }
+
+    /// Original caller row represented by an internal observation position.
+    #[inline]
+    pub(crate) fn caller_row(&self, internal: usize) -> usize {
+        self.rows
+            .as_ref()
+            .map_or(internal, |rows| rows[internal] as usize)
     }
 
     /// Total degrees of freedom (columns of D).
@@ -430,7 +506,7 @@ mod tests {
             Design::from_frame(frame(vec![vec![2, 0, 1, 0], vec![0, 0, 1, 1]], vec![])).unwrap();
 
         // Stable argsort of [2,0,1,0] → original indices [1,3,2,0].
-        assert_eq!(design.obs_perm.as_deref(), Some(&[1u32, 3, 2, 0][..]));
+        assert_eq!(design.rows.as_deref(), Some(&[1u32, 3, 2, 0][..]));
         assert!(design.terms[0].sorted);
         // Factor 1's permuted column [0,1,1,0] is no longer non-decreasing.
         assert!(!design.terms[1].sorted);
@@ -445,7 +521,7 @@ mod tests {
         let col0 = vec![3u32, 0, 2, 1];
         let col1: Vec<u32> = col0.iter().map(|&v| v / 2).collect();
         let design = Design::from_frame(frame(vec![col0, col1], vec![])).unwrap();
-        assert!(design.obs_perm.is_some());
+        assert!(design.rows.is_some());
         assert!(design.terms[0].sorted);
         assert!(design.terms[1].sorted);
     }
@@ -454,7 +530,7 @@ mod tests {
     fn from_frame_keeps_sorted_input() {
         let design =
             Design::from_frame(frame(vec![vec![0, 0, 1, 2], vec![1, 0, 1, 0]], vec![])).unwrap();
-        assert!(design.obs_perm.is_none());
+        assert!(design.rows.is_none());
         assert!(design.terms[0].sorted);
         assert!(!design.terms[1].sorted);
     }
@@ -467,10 +543,67 @@ mod tests {
         ))
         .unwrap();
 
-        let perm = design.obs_perm.as_ref().expect("permutation applied");
+        let perm = design.rows.as_ref().expect("permutation applied");
         assert_eq!(perm, &[1, 3, 2, 0]);
         assert_eq!(design.frame.level_column(0), [0, 0, 1, 2]);
         assert_eq!(design.frame.loading_column(0), [20.0, 40.0, 30.0, 10.0]);
+    }
+
+    #[test]
+    fn composed_rows_select_and_restore_without_intermediate_order() {
+        let mut design =
+            Design::from_frame_unsorted(frame(vec![vec![0, 1, 0, 1, 2]], vec![])).unwrap();
+        design.remap_internal_rows(&[3, 0, 2]).unwrap();
+
+        assert_eq!(design.input_n_obs, 5);
+        assert_eq!(design.n_obs, 3);
+        assert_eq!(design.rows.as_deref(), Some(&[3, 0, 2][..]));
+        assert_eq!(design.frame.level_column(0), &[1, 0, 0]);
+
+        let caller = [10.0, 20.0, 30.0, 40.0, 50.0];
+        assert_eq!(&*design.permute_obs_in(&caller), &[40.0, 10.0, 30.0]);
+
+        let restored = design.permute_obs_out(vec![4.0, 1.0, 3.0]);
+        assert_eq!(restored[0], 1.0);
+        assert!(restored[1].is_nan());
+        assert_eq!(restored[2], 3.0);
+        assert_eq!(restored[3], 4.0);
+        assert!(restored[4].is_nan());
+    }
+
+    #[test]
+    fn validation_ignores_weights_on_removed_rows() {
+        let mut design =
+            Design::from_frame_unsorted(frame(vec![vec![0, 1, 0, 1, 2]], vec![])).unwrap();
+        design.remap_internal_rows(&[3, 0, 2]).unwrap();
+
+        assert!(design
+            .validate_weights(Some(&[1.0, f64::NAN, 1.0, 1.0, f64::NAN]))
+            .is_ok());
+        assert!(matches!(
+            design.validate_weights(Some(&[1.0, f64::NAN, -1.0, 1.0, f64::NAN])),
+            Err(BuildError::InvalidWeight {
+                index: 2,
+                value: -1.0
+            })
+        ));
+    }
+
+    #[test]
+    fn repeated_row_remapping_composes_to_original_caller_rows() {
+        let mut design = Design::from_frame(frame(vec![vec![2, 0, 1, 0]], vec![])).unwrap();
+        assert_eq!(design.rows.as_deref(), Some(&[1, 3, 2, 0][..]));
+
+        design.remap_internal_rows(&[3, 0]).unwrap();
+
+        assert_eq!(design.input_n_obs, 4);
+        assert_eq!(design.n_obs, 2);
+        assert_eq!(design.rows.as_deref(), Some(&[0, 1][..]));
+        assert_eq!(design.frame.level_column(0), &[2, 0]);
+        assert_eq!(
+            &*design.permute_obs_in(&[10.0, 20.0, 30.0, 40.0]),
+            &[10.0, 20.0]
+        );
     }
 
     #[test]

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -84,23 +84,13 @@ impl<T> Loading<T> {
 /// order is finalized.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct DesignOptions<'a> {
-    drop_singletons: bool,
-    weights: Option<Cow<'a, [f64]>>,
+    /// Whether iterative singleton removal is enabled.
+    pub drop_singletons: bool,
+    /// Observation weights in caller row order.
+    pub weights: Option<Cow<'a, [f64]>>,
 }
 
 impl<'a> DesignOptions<'a> {
-    /// Create design-construction options.
-    ///
-    /// `weights` are recorded in caller row order. Borrowed slices remain
-    /// borrowed by the resulting [`Design`]; owned vectors are retained
-    /// without another copy.
-    pub fn new(drop_singletons: bool, weights: Option<Cow<'a, [f64]>>) -> Self {
-        Self {
-            drop_singletons,
-            weights,
-        }
-    }
-
     /// Whether iterative singleton removal is enabled.
     pub fn drop_singletons(&self) -> bool {
         self.drop_singletons
@@ -758,7 +748,10 @@ mod tests {
                 vec![vec![1, 0, 1, 0, 2, 2, 3], vec![1, 0, 0, 1, 2, 3, 3]],
                 vec![vec![10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]],
             ),
-            DesignOptions::new(true, None),
+            DesignOptions {
+                drop_singletons: true,
+                ..Default::default()
+            },
         )
         .unwrap();
 
@@ -780,7 +773,10 @@ mod tests {
     fn design_options_reject_when_singletons_remove_every_observation() {
         let result = Design::from_frame(
             frame(vec![vec![0, 1], vec![0, 1]], vec![]),
-            DesignOptions::new(true, None),
+            DesignOptions {
+                drop_singletons: true,
+                ..Default::default()
+            },
         );
 
         assert!(matches!(result, Err(BuildError::EmptyObservations)));
@@ -805,7 +801,10 @@ mod tests {
         let weights = [1.0, f64::NAN, 1.0, 1.0, f64::NAN];
         let design = Design::from_frame(
             frame(vec![vec![0, 1, 0, 0, 2]], vec![]),
-            DesignOptions::new(true, Some(Cow::Borrowed(&weights))),
+            DesignOptions {
+                drop_singletons: true,
+                weights: Some(Cow::Borrowed(&weights)),
+            },
         )
         .unwrap();
 
@@ -818,10 +817,10 @@ mod tests {
         assert!(matches!(
             Design::from_frame(
                 frame(vec![vec![0, 1, 0, 0, 2]], vec![]),
-                DesignOptions::new(
-                    true,
-                    Some(Cow::Borrowed(&[1.0, f64::NAN, -1.0, 1.0, f64::NAN])),
-                ),
+                DesignOptions {
+                    drop_singletons: true,
+                    weights: Some(Cow::Borrowed(&[1.0, f64::NAN, -1.0, 1.0, f64::NAN])),
+                },
             ),
             Err(BuildError::InvalidWeight {
                 index: 2,
@@ -858,7 +857,10 @@ mod tests {
         let weights = vec![1.0, 2.0, 3.0];
         let design = Design::from_frame(
             frame(vec![vec![0, 0, 1]], vec![]),
-            DesignOptions::new(false, Some(Cow::Borrowed(weights.as_slice()))),
+            DesignOptions {
+                weights: Some(Cow::Borrowed(weights.as_slice())),
+                ..Default::default()
+            },
         )
         .unwrap()
         .into_owned();

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -76,19 +76,40 @@ impl<T> Loading<T> {
     }
 }
 
+pub(crate) fn map_to_internal_order<'v, T: Clone>(
+    rows: Option<&[u32]>,
+    n_obs_input: usize,
+    values: &'v [T],
+) -> Cow<'v, [T]> {
+    assert_eq!(
+        values.len(),
+        n_obs_input,
+        "observation vector length must match the design input"
+    );
+    match rows {
+        None => Cow::Borrowed(values),
+        Some(rows) => Cow::Owned(
+            rows.iter()
+                .map(|&caller| values[caller as usize].clone())
+                .collect(),
+        ),
+    }
+}
+
 /// Configuration applied while constructing a [`Design`].
 ///
 /// Options operate on the observation data before the design's internal row
 /// order is finalized. Use [`DesignOptions::from_effects`] or
 /// [`DesignOptions::from_frame`] to construct a configured design; the
 /// convenience constructors on [`Design`] use [`DesignOptions::default`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct DesignOptions {
+#[derive(Clone, Debug, PartialEq)]
+pub struct DesignOptions<'a> {
     drop_singletons: bool,
     locality_sort: bool,
+    weights: Option<Cow<'a, [f64]>>,
 }
 
-impl DesignOptions {
+impl<'a> DesignOptions<'a> {
     /// Remove observations belonging to a singleton level in any fixed-effect
     /// term.
     ///
@@ -101,8 +122,18 @@ impl DesignOptions {
         self
     }
 
+    /// Record observation weights in caller row order.
+    ///
+    /// Borrowed slices remain borrowed by the resulting [`Design`]; owned
+    /// vectors are retained without another copy.
+    #[must_use]
+    pub fn weights(mut self, weights: impl Into<Cow<'a, [f64]>>) -> Self {
+        self.weights = Some(weights.into());
+        self
+    }
+
     /// Lower effect terms into a configured design.
-    pub fn from_effects<'a>(
+    pub fn from_effects(
         self,
         effects: impl IntoIterator<Item = Effect<'a>>,
     ) -> Result<Design<'a>, BuildError> {
@@ -123,22 +154,28 @@ impl DesignOptions {
     }
 
     /// Construct a configured design from a frame of plain factors.
-    pub fn from_frame<'a>(self, frame: ObservationFrame<'a>) -> Result<Design<'a>, BuildError> {
+    pub fn from_frame(self, frame: ObservationFrame<'a>) -> Result<Design<'a>, BuildError> {
         let structure = vec![NonEmpty::of(Loading::Constant); frame.n_factors()];
         Design::build(frame, structure, self)
     }
 
-    fn with_locality_sort(mut self, enabled: bool) -> Self {
+    #[doc(hidden)]
+    pub fn with_locality_sort(mut self, enabled: bool) -> Self {
         self.locality_sort = enabled;
         self
     }
+
+    pub(crate) fn weight_values(&self) -> Option<&[f64]> {
+        self.weights.as_deref()
+    }
 }
 
-impl Default for DesignOptions {
+impl Default for DesignOptions<'_> {
     fn default() -> Self {
         Self {
             drop_singletons: false,
             locality_sort: true,
+            weights: None,
         }
     }
 }
@@ -288,6 +325,8 @@ pub struct Design<'a> {
     /// This single map composes semantic row selection with locality sorting.
     /// `None` is the identity map and preserves zero-copy observation input.
     pub(crate) rows: Option<Vec<u32>>,
+    /// Construction configuration in caller order.
+    pub(crate) options: DesignOptions<'a>,
 }
 
 impl<'a> Design<'a> {
@@ -313,7 +352,7 @@ impl<'a> Design<'a> {
     fn build(
         frame: ObservationFrame<'a>,
         column_structure: Vec<NonEmpty<Loading<u32>>>,
-        options: DesignOptions,
+        options: DesignOptions<'a>,
     ) -> Result<Self, BuildError> {
         if frame.n_obs() == 0 {
             return Err(BuildError::EmptyObservations);
@@ -389,14 +428,17 @@ impl<'a> Design<'a> {
             meta.sorted = frame.level_column(term).is_sorted();
         }
 
-        Ok(Design {
+        let design = Design {
             frame,
             terms,
             n_obs_input,
             n_obs: n_obs_retained,
             n_dofs: offset,
             rows,
-        })
+            options,
+        };
+        design.validate_weights(design.weights())?;
+        Ok(design)
     }
 
     /// Convert the frame's columns to owned, dropping ties to caller buffers.
@@ -408,6 +450,14 @@ impl<'a> Design<'a> {
             n_obs: self.n_obs,
             n_dofs: self.n_dofs,
             rows: self.rows,
+            options: DesignOptions {
+                drop_singletons: self.options.drop_singletons,
+                locality_sort: self.options.locality_sort,
+                weights: self
+                    .options
+                    .weights
+                    .map(|weights| Cow::Owned(weights.into_owned())),
+            },
         }
     }
 
@@ -448,19 +498,19 @@ impl<'a> Design<'a> {
     /// Caller order → retained internal order: `out[k] = v[rows[k]]`.
     ///
     /// Borrows when every caller row is retained in its original order.
-    pub(crate) fn permute_obs_in<'v>(&self, v: &'v [f64]) -> Cow<'v, [f64]> {
-        debug_assert_eq!(v.len(), self.n_obs_input);
-        match &self.rows {
-            None => Cow::Borrowed(v),
-            Some(rows) => Cow::Owned(rows.iter().map(|&i| v[i as usize]).collect()),
-        }
+    pub fn to_internal_order<'v, T: Clone>(&self, v: &'v [T]) -> Cow<'v, [T]> {
+        map_to_internal_order(self.rows.as_deref(), self.n_obs_input, v)
     }
 
     /// Retained internal order → original caller shape.
     ///
     /// Dropped caller rows are represented by `NaN`.
-    pub(crate) fn permute_obs_out(&self, v: Vec<f64>) -> Vec<f64> {
-        debug_assert_eq!(v.len(), self.n_obs);
+    pub fn from_internal_order(&self, v: Vec<f64>) -> Vec<f64> {
+        assert_eq!(
+            v.len(),
+            self.n_obs,
+            "internal vector length must match retained observations"
+        );
         match &self.rows {
             None => v,
             Some(rows) => {
@@ -499,6 +549,18 @@ impl<'a> Design<'a> {
     #[inline]
     pub fn input_n_obs(&self) -> usize {
         self.n_obs_input
+    }
+
+    /// Construction options retained by this design.
+    #[inline]
+    pub fn options(&self) -> &DesignOptions<'a> {
+        &self.options
+    }
+
+    /// Observation weights in caller row order.
+    #[inline]
+    pub fn weights(&self) -> Option<&[f64]> {
+        self.options.weights.as_deref()
     }
 
     /// Original caller row represented by an internal observation position.
@@ -714,7 +776,7 @@ mod tests {
         assert_eq!(design.frame.level_column(1), &[0, 0, 1, 1]);
         assert_eq!(design.frame.loading_column(0), &[11.0, 12.0, 10.0, 13.0]);
 
-        let restored = design.permute_obs_out(vec![1.0, 2.0, 3.0, 4.0]);
+        let restored = design.from_internal_order(vec![1.0, 2.0, 3.0, 4.0]);
         assert_eq!(&restored[..4], &[3.0, 1.0, 2.0, 4.0]);
         assert!(restored[4..].iter().all(|value| value.is_nan()));
     }
@@ -744,20 +806,62 @@ mod tests {
 
     #[test]
     fn validation_ignores_weights_on_removed_rows() {
+        let weights = [1.0, f64::NAN, 1.0, 1.0, f64::NAN];
         let design = DesignOptions::default()
             .drop_singletons(true)
+            .weights(&weights[..])
             .from_frame(frame(vec![vec![0, 1, 0, 0, 2]], vec![]))
             .unwrap();
 
-        assert!(design
-            .validate_weights(Some(&[1.0, f64::NAN, 1.0, 1.0, f64::NAN]))
-            .is_ok());
+        let stored = design.weights().expect("weights retained");
+        assert_eq!(stored.len(), weights.len());
+        assert_eq!(stored[0], 1.0);
+        assert!(stored[1].is_nan());
+        assert_eq!(&stored[2..4], &[1.0, 1.0]);
+        assert!(stored[4].is_nan());
         assert!(matches!(
-            design.validate_weights(Some(&[1.0, f64::NAN, -1.0, 1.0, f64::NAN])),
+            DesignOptions::default()
+                .drop_singletons(true)
+                .weights(&[1.0, f64::NAN, -1.0, 1.0, f64::NAN][..])
+                .from_frame(frame(vec![vec![0, 1, 0, 0, 2]], vec![])),
             Err(BuildError::InvalidWeight {
                 index: 2,
                 value: -1.0
             })
+        ));
+    }
+
+    #[test]
+    fn ordering_is_generic_and_borrows_only_for_identity() {
+        let identity = Design::from_frame(frame(vec![vec![0, 0, 1]], vec![])).unwrap();
+        let values = ["a", "b", "c"];
+        assert!(matches!(
+            identity.to_internal_order(&values),
+            Cow::Borrowed(_)
+        ));
+
+        let sorted = Design::from_frame(frame(vec![vec![2, 0, 1, 0]], vec![])).unwrap();
+        let values = ["a", "b", "c", "d"];
+        assert_eq!(
+            sorted.to_internal_order(&values).as_ref(),
+            &["b", "d", "c", "a"]
+        );
+    }
+
+    #[test]
+    fn into_owned_detaches_option_weights() {
+        let weights = vec![1.0, 2.0, 3.0];
+        let design = DesignOptions::default()
+            .weights(weights.as_slice())
+            .from_frame(frame(vec![vec![0, 0, 1]], vec![]))
+            .unwrap()
+            .into_owned();
+        drop(weights);
+
+        assert_eq!(design.weights(), Some(&[1.0, 2.0, 3.0][..]));
+        assert!(matches!(
+            design.options().weights.as_ref(),
+            Some(Cow::Owned(_))
         ));
     }
 

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -392,7 +392,7 @@ impl<'a> Design<'a> {
         Ok(Design {
             frame,
             terms,
-            n_obs_input: n_obs_input,
+            n_obs_input,
             n_obs: n_obs_retained,
             n_dofs: offset,
             rows,

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -6,7 +6,7 @@ use super::accumulate::{
 use super::{build_compact_mapping, CrossTab};
 use crate::channel::{Channel, ChannelPair};
 use crate::domain::find_all_active_levels;
-use crate::domain::{Design, Effect};
+use crate::domain::{Design, DesignOptions, Effect};
 use crate::observation::ObservationFrame;
 
 /// Terms 0 and 1 paired on their intercept channels (plain cross-tab).
@@ -18,7 +18,7 @@ const INTERCEPT_PAIR: ChannelPair = ChannelPair {
 fn design_of(columns: Vec<Vec<u32>>) -> Design<'static> {
     let frame = ObservationFrame::new(columns.into_iter().map(Into::into).collect(), Vec::new())
         .expect("valid frame");
-    Design::from_frame(frame).expect("valid design")
+    Design::from_frame(frame, DesignOptions::default()).expect("valid design")
 }
 
 #[test]
@@ -304,7 +304,7 @@ fn dense_and_sparse_paths_agree_on_signed_data() {
         Effect::new(&f, true, [&z[..]]).unwrap(),
         Effect::new(&g, true, []).unwrap(),
     ];
-    let design = Design::new(effects).unwrap();
+    let design = Design::from_effects(effects, DesignOptions::default()).unwrap();
     let pair = ChannelPair {
         rows: Channel { term: 0, column: 1 },
         cols: Channel { term: 1, column: 0 },

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -196,7 +196,7 @@ fn compute_partition_weights(domain_pairs: &mut [LocalDomain], n_dofs: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::Design;
+    use crate::domain::{Design, DesignOptions};
     use crate::observation::ObservationFrame;
     use crate::Effect;
 
@@ -210,7 +210,7 @@ mod tests {
             Vec::new(),
         )
         .expect("valid frame");
-        Design::from_frame(frame).expect("valid test design")
+        Design::from_frame(frame, DesignOptions::default()).expect("valid test design")
     }
 
     #[test]
@@ -250,11 +250,14 @@ mod tests {
         let levels_b = [0u32, 1, 0, 1, 0, 1];
         let levels_c = [0u32, 0, 1, 1, 0, 1];
         let z = [1.0, -2.0, 0.5, 3.0, -1.5, 2.5];
-        let design = Design::new(vec![
-            Effect::new(&levels_a, true, [&z[..]]).expect("slope effect"),
-            Effect::new(&levels_b, true, []).expect("effect b"),
-            Effect::new(&levels_c, true, []).expect("effect c"),
-        ])
+        let design = Design::from_effects(
+            vec![
+                Effect::new(&levels_a, true, [&z[..]]).expect("slope effect"),
+                Effect::new(&levels_b, true, []).expect("effect b"),
+                Effect::new(&levels_c, true, []).expect("effect c"),
+            ],
+            DesignOptions::default(),
+        )
         .expect("valid slope design");
 
         let (domain_pairs, _) = build_local_domains(&design, None, &ScalingConfig::default())

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -110,10 +110,15 @@ pub enum BuildError {
     },
 }
 
-/// A non-fatal preconditioner-build event.
+/// A non-fatal event encountered while constructing a [`crate::Solver`].
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum BuildWarning {
+    /// Singleton removal changed the estimation sample.
+    SingletonObservationsRemoved {
+        /// Number of caller observations removed from the numerical design.
+        count: usize,
+    },
     /// Residual deficits were clamped, degrading only preconditioner quality.
     UnscalableComponent {
         /// The offending channel pair.
@@ -128,6 +133,9 @@ pub enum BuildWarning {
 impl std::fmt::Display for BuildWarning {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::SingletonObservationsRemoved { count } => {
+                write!(f, "{count} singleton observation(s) removed")
+            }
             Self::UnscalableComponent {
                 pair,
                 sweeps,

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -108,9 +108,6 @@ pub enum BuildError {
         /// Number of caller observations in the design input.
         n_obs: usize,
     },
-    /// Non-default construction options were supplied for an already-built design.
-    #[error("design options cannot be applied to a prebuilt Design")]
-    OptionsForPrebuiltDesign,
 }
 
 /// A non-fatal preconditioner-build event.

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -99,6 +99,15 @@ pub enum BuildError {
         /// Total degrees of freedom implied by the design.
         n_dofs: usize,
     },
+    /// Row processing requires an internal-to-caller map whose indices are
+    /// wider than the design's `u32` row-index representation.
+    #[error(
+        "design has {n_obs} observations, exceeding the u32 row-index limit for row processing"
+    )]
+    RowIndexSpaceExceedsU32 {
+        /// Number of caller observations in the design input.
+        n_obs: usize,
+    },
 }
 
 /// A non-fatal preconditioner-build event.

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -108,6 +108,9 @@ pub enum BuildError {
         /// Number of caller observations in the design input.
         n_obs: usize,
     },
+    /// Non-default construction options were supplied for an already-built design.
+    #[error("design options cannot be applied to a prebuilt Design")]
+    OptionsForPrebuiltDesign,
 }
 
 /// A non-fatal preconditioner-build event.

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -41,7 +41,7 @@ pub use config::{
     ApproxCholConfig, ApproxSchurConfig, LocalSolverConfig, LsmrOptions, PreconditionerConfig,
     ReductionStrategy, ScalingConfig, ScalingFailure, SchurMode,
 };
-pub use domain::{Design, Effect};
+pub use domain::{Design, DesignOptions, Effect};
 pub use error::{BuildError, BuildWarning, SolveError, WithinError};
 pub use operator::schwarz::Preconditioner;
 pub use solver::{

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -5,19 +5,15 @@
 //!
 //! ```
 //! use ndarray::Array2;
-//! use within::{solve, DesignOptions, LsmrOptions};
+//! use within::{solve, DesignOptions, IntoDesign, LsmrOptions};
 //!
 //! let categories = Array2::<u32>::zeros((10_000, 2));
 //! let y = vec![0.0; 10_000];
-//! let r = solve(
-//!     categories.view(),
-//!     DesignOptions::default(),
-//!     &y,
-//!     None,
-//!     &LsmrOptions::default(),
-//!     None,
-//! )
-//! .unwrap();
+//! let design = categories
+//!     .view()
+//!     .into_design(DesignOptions::default())
+//!     .unwrap();
+//! let r = solve(design, &y, &LsmrOptions::default(), None).unwrap();
 //! assert!(r.converged);
 //! ```
 //!

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -5,14 +5,11 @@
 //!
 //! ```
 //! use ndarray::Array2;
-//! use within::{solve, DesignOptions, IntoDesign, LsmrOptions};
+//! use within::{solve, Design, DesignOptions, LsmrOptions};
 //!
 //! let categories = Array2::<u32>::zeros((10_000, 2));
 //! let y = vec![0.0; 10_000];
-//! let design = categories
-//!     .view()
-//!     .into_design(DesignOptions::default())
-//!     .unwrap();
+//! let design = Design::from_categories(categories.view(), DesignOptions::default()).unwrap();
 //! let r = solve(design, &y, &LsmrOptions::default(), None).unwrap();
 //! assert!(r.converged);
 //! ```
@@ -49,6 +46,6 @@ pub use domain::{Design, DesignOptions, Effect};
 pub use error::{BuildError, BuildWarning, SolveError, WithinError};
 pub use operator::schwarz::Preconditioner;
 pub use solver::{
-    solve, solve_batch, BatchSolveResult, CoefficientAddress, CoefficientLayout, IntoDesign,
+    solve, solve_batch, BatchSolveResult, CoefficientAddress, CoefficientLayout,
     PreconditionerInput, SolveResult, Solver,
 };

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -5,11 +5,19 @@
 //!
 //! ```
 //! use ndarray::Array2;
-//! use within::{solve, LsmrOptions};
+//! use within::{solve, DesignOptions, LsmrOptions};
 //!
 //! let categories = Array2::<u32>::zeros((10_000, 2));
 //! let y = vec![0.0; 10_000];
-//! let r = solve(categories.view(), &y, None, &LsmrOptions::default(), None).unwrap();
+//! let r = solve(
+//!     categories.view(),
+//!     DesignOptions::default(),
+//!     &y,
+//!     None,
+//!     &LsmrOptions::default(),
+//!     None,
+//! )
+//! .unwrap();
 //! assert!(r.converged);
 //! ```
 //!

--- a/crates/within/src/observation.rs
+++ b/crates/within/src/observation.rs
@@ -92,7 +92,7 @@ impl<'a> ObservationFrame<'a> {
         }
     }
 
-    /// Owned copy with row `i` holding observation `perm[i]` (matches `Design::obs_perm`).
+    /// Owned copy with row `i` holding observation `perm[i]` (matches `Design::rows`).
     pub fn permuted(&self, perm: &[u32]) -> ObservationFrame<'static> {
         ObservationFrame {
             categorical: self

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -135,7 +135,7 @@ mod reentry_guard_tests {
     use schwarz_precond::Operator;
 
     use super::DesignOperator;
-    use crate::domain::Design;
+    use crate::domain::{Design, DesignOptions};
     use crate::observation::ObservationFrame;
 
     fn one_factor_design() -> Design<'static> {
@@ -144,7 +144,7 @@ mod reentry_guard_tests {
             Vec::new(),
         )
         .expect("valid frame");
-        Design::from_frame(frame).expect("valid design")
+        Design::from_frame(frame, DesignOptions::default()).expect("valid design")
     }
 
     #[test]

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -49,11 +49,25 @@ impl<'a> DesignOperator<'a> {
         }
     }
 
-    /// Observation-space RHS `b = W^{1/2} y`; borrows unweighted, owns weighted.
+    /// Map a caller-order response into the internal observation-space RHS.
+    ///
+    /// Selection, locality ordering, and optional `W^{1/2}` scaling are fused
+    /// into one pass and at most one allocation. The identity, unweighted case
+    /// borrows `y` without allocating.
     pub(crate) fn weighted_rhs<'y>(&self, y: &'y [f64]) -> Cow<'y, [f64]> {
-        match self.sqrt_weights {
-            None => Cow::Borrowed(y),
-            Some(sw) => Cow::Owned(y.iter().zip(sw).map(|(&yi, &swi)| swi * yi).collect()),
+        debug_assert_eq!(y.len(), self.design.input_n_obs);
+        match (&self.design.rows, self.sqrt_weights) {
+            (None, None) => Cow::Borrowed(y),
+            (None, Some(sw)) => Cow::Owned(y.iter().zip(sw).map(|(&yi, &swi)| swi * yi).collect()),
+            (Some(rows), None) => {
+                Cow::Owned(rows.iter().map(|&caller| y[caller as usize]).collect())
+            }
+            (Some(rows), Some(sw)) => Cow::Owned(
+                rows.iter()
+                    .zip(sw)
+                    .map(|(&caller, &swi)| swi * y[caller as usize])
+                    .collect(),
+            ),
         }
     }
 }

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -55,7 +55,7 @@ impl<'a> DesignOperator<'a> {
     /// into one pass and at most one allocation. The identity, unweighted case
     /// borrows `y` without allocating.
     pub(crate) fn weighted_rhs<'y>(&self, y: &'y [f64]) -> Cow<'y, [f64]> {
-        debug_assert_eq!(y.len(), self.design.input_n_obs);
+        debug_assert_eq!(y.len(), self.design.n_obs_input);
         match (&self.design.rows, self.sqrt_weights) {
             (None, None) => Cow::Borrowed(y),
             (None, Some(sw)) => Cow::Owned(y.iter().zip(sw).map(|(&yi, &swi)| swi * yi).collect()),

--- a/crates/within/src/operator/tests.rs
+++ b/crates/within/src/operator/tests.rs
@@ -77,7 +77,14 @@ mod design_tests {
         assert!(matches!(rhs, Cow::Borrowed(_)));
 
         let frame = ObservationFrame::new(vec![vec![0u32, 1, 0, 0, 2].into()], Vec::new()).unwrap();
-        let mapped = Design::from_frame(frame, DesignOptions::new(true, None)).unwrap();
+        let mapped = Design::from_frame(
+            frame,
+            DesignOptions {
+                drop_singletons: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
         let rhs = DesignOperator::new(&mapped, None).weighted_rhs(&caller);
         assert!(matches!(rhs, Cow::Owned(_)));
         assert_eq!(&*rhs, &[1.0, 3.0, 4.0]);

--- a/crates/within/src/operator/tests.rs
+++ b/crates/within/src/operator/tests.rs
@@ -8,6 +8,8 @@ fn design_of(columns: Vec<Vec<u32>>) -> Design<'static> {
 }
 
 mod design_tests {
+    use std::borrow::Cow;
+
     use super::design_of;
     use crate::domain::Design;
     use crate::operator::DesignOperator;
@@ -64,6 +66,24 @@ mod design_tests {
         op.apply_adjoint(&r, &mut x)
             .expect("apply_adjoint succeeds");
         assert_eq!(x, vec![6.0, 5.0, 4.0, 3.0, 3.0, 4.0, 5.0]);
+    }
+
+    #[test]
+    fn weighted_rhs_fuses_row_mapping_and_scaling() {
+        let identity = make_single_factor_design();
+        let caller = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let rhs = DesignOperator::new(&identity, None).weighted_rhs(&caller);
+        assert!(matches!(rhs, Cow::Borrowed(_)));
+
+        let mut mapped = identity;
+        mapped.remap_internal_rows(&[3, 0, 2]).unwrap();
+        let rhs = DesignOperator::new(&mapped, None).weighted_rhs(&caller);
+        assert!(matches!(rhs, Cow::Owned(_)));
+        assert_eq!(&*rhs, &[4.0, 1.0, 3.0]);
+
+        let sqrt_weights = [2.0, 3.0, 4.0];
+        let rhs = DesignOperator::new(&mapped, Some(&sqrt_weights)).weighted_rhs(&caller);
+        assert_eq!(&*rhs, &[8.0, 3.0, 12.0]);
     }
 
     fn dot(a: &[f64], b: &[f64]) -> f64 {
@@ -124,7 +144,7 @@ mod design_tests {
         let fa: Vec<u32> = (0..n_obs as u32).collect();
         let fb: Vec<u32> = (0..n_obs).map(|i| (i % 50) as u32).collect();
         let dm = design_of(vec![fa, fb]);
-        assert!(dm.obs_perm.is_none(), "dominant factor is sorted; no perm");
+        assert!(dm.rows.is_none(), "dominant factor is sorted; no perm");
 
         let op = DesignOperator::new(&dm, None);
         let x: Vec<f64> = (0..dm.n_dofs)
@@ -266,7 +286,7 @@ mod design_tests {
         let fa: Vec<u32> = (0..n_obs as u32).collect();
         let fb: Vec<u32> = (0..n_obs).map(|i| ((i * 7919) % 100_000) as u32).collect();
         let dm = design_of(vec![fa, fb]);
-        assert!(dm.obs_perm.is_none(), "dominant factor is sorted; no perm");
+        assert!(dm.rows.is_none(), "dominant factor is sorted; no perm");
         assert_scratch_reuse_matches_fresh(&dm, "atomic: non-dominant unsorted 100K levels");
     }
 
@@ -474,12 +494,18 @@ mod weighted_adjoint_proptests {
             op_unweighted.apply(&x, &mut dx).unwrap();
             let lhs: f64 = dx
                 .iter()
-                .zip(r.iter())
                 .enumerate()
-                .map(|(i, (dxi, ri))| weights[i] * dxi * ri)
+                .map(|(internal, dxi)| {
+                    let caller = dm.caller_row(internal);
+                    weights[caller] * dxi * r[caller]
+                })
                 .sum();
 
-            let sqrt_weights: Vec<f64> = weights.iter().map(|w| w.sqrt()).collect();
+            let sqrt_weights: Vec<f64> = dm
+                .permute_obs_in(&weights)
+                .iter()
+                .map(|w| w.sqrt())
+                .collect();
             let op_weighted = DesignOperator::new(&dm, Some(&sqrt_weights));
             let wr = op_weighted.weighted_rhs(&r);
             let mut wdtr = vec![0.0f64; n_dofs];

--- a/crates/within/src/operator/tests.rs
+++ b/crates/within/src/operator/tests.rs
@@ -11,7 +11,8 @@ mod design_tests {
     use std::borrow::Cow;
 
     use super::design_of;
-    use crate::domain::Design;
+    use crate::domain::{Design, DesignOptions};
+    use crate::observation::ObservationFrame;
     use crate::operator::DesignOperator;
     use schwarz_precond::Operator;
 
@@ -75,15 +76,18 @@ mod design_tests {
         let rhs = DesignOperator::new(&identity, None).weighted_rhs(&caller);
         assert!(matches!(rhs, Cow::Borrowed(_)));
 
-        let mut mapped = identity;
-        mapped.remap_internal_rows(&[3, 0, 2]).unwrap();
+        let frame = ObservationFrame::new(vec![vec![0u32, 1, 0, 0, 2].into()], Vec::new()).unwrap();
+        let mapped = DesignOptions::default()
+            .drop_singletons(true)
+            .from_frame(frame)
+            .unwrap();
         let rhs = DesignOperator::new(&mapped, None).weighted_rhs(&caller);
         assert!(matches!(rhs, Cow::Owned(_)));
-        assert_eq!(&*rhs, &[4.0, 1.0, 3.0]);
+        assert_eq!(&*rhs, &[1.0, 3.0, 4.0]);
 
         let sqrt_weights = [2.0, 3.0, 4.0];
         let rhs = DesignOperator::new(&mapped, Some(&sqrt_weights)).weighted_rhs(&caller);
-        assert_eq!(&*rhs, &[8.0, 3.0, 12.0]);
+        assert_eq!(&*rhs, &[2.0, 9.0, 16.0]);
     }
 
     fn dot(a: &[f64], b: &[f64]) -> f64 {

--- a/crates/within/src/operator/tests.rs
+++ b/crates/within/src/operator/tests.rs
@@ -1,10 +1,10 @@
-use crate::domain::Design;
+use crate::domain::{Design, DesignOptions};
 use crate::observation::ObservationFrame;
 
 fn design_of(columns: Vec<Vec<u32>>) -> Design<'static> {
     let frame = ObservationFrame::new(columns.into_iter().map(Into::into).collect(), Vec::new())
         .expect("valid frame");
-    Design::from_frame(frame).expect("valid design")
+    Design::from_frame(frame, DesignOptions::default()).expect("valid design")
 }
 
 mod design_tests {
@@ -77,10 +77,7 @@ mod design_tests {
         assert!(matches!(rhs, Cow::Borrowed(_)));
 
         let frame = ObservationFrame::new(vec![vec![0u32, 1, 0, 0, 2].into()], Vec::new()).unwrap();
-        let mapped = DesignOptions::default()
-            .drop_singletons(true)
-            .from_frame(frame)
-            .unwrap();
+        let mapped = Design::from_frame(frame, DesignOptions::new(true, None)).unwrap();
         let rhs = DesignOperator::new(&mapped, None).weighted_rhs(&caller);
         assert!(matches!(rhs, Cow::Owned(_)));
         assert_eq!(&*rhs, &[1.0, 3.0, 4.0]);
@@ -324,7 +321,7 @@ mod design_tests {
 }
 
 mod slope_design_tests {
-    use crate::domain::{Design, Effect, Loading};
+    use crate::domain::{Design, DesignOptions, Effect, Loading};
     use crate::operator::DesignOperator;
     use schwarz_precond::Operator;
 
@@ -385,7 +382,7 @@ mod slope_design_tests {
             Effect::new(&f3, true, []).unwrap(),
             Effect::new(&f4, true, [&zs[5][..], &zs[4][..]]).unwrap(),
         ];
-        let design = Design::new(effects).unwrap();
+        let design = Design::from_effects(effects, DesignOptions::default()).unwrap();
         let dense = dense_matrix(&design);
         let op = DesignOperator::new(&design, None);
 
@@ -430,7 +427,7 @@ mod slope_design_tests {
             Effect::new(&unsorted, true, [&z[1][..]]).unwrap(),
             Effect::new(&small, true, [&z[2][..], &z[3][..]]).unwrap(),
         ];
-        let design = Design::new(effects).unwrap();
+        let design = Design::from_effects(effects, DesignOptions::default()).unwrap();
         let sqrt_weights: Vec<f64> = (0..n).map(|i| (0.5 + noise(i).abs()).sqrt()).collect();
         let op = DesignOperator::new(&design, Some(&sqrt_weights));
 
@@ -506,7 +503,7 @@ mod weighted_adjoint_proptests {
                 .sum();
 
             let sqrt_weights: Vec<f64> = dm
-                .to_internal_order(&weights)
+                .to_internal_row_order(&weights)
                 .iter()
                 .map(|w| w.sqrt())
                 .collect();

--- a/crates/within/src/operator/tests.rs
+++ b/crates/within/src/operator/tests.rs
@@ -506,7 +506,7 @@ mod weighted_adjoint_proptests {
                 .sum();
 
             let sqrt_weights: Vec<f64> = dm
-                .permute_obs_in(&weights)
+                .to_internal_order(&weights)
                 .iter()
                 .map(|w| w.sqrt())
                 .collect();

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -320,7 +320,7 @@ pub struct Solver<'a> {
 impl std::fmt::Debug for Solver<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Solver")
-            .field("n_obs", &self.design.input_n_obs)
+            .field("n_obs", &self.design.n_obs_input)
             .field("n_retained_obs", &self.design.n_obs)
             .field("n_dofs", &self.design.n_dofs)
             .field("has_weights", &self.sqrt_weights.is_some())
@@ -429,13 +429,13 @@ impl<'a> Solver<'a> {
     fn solve_rhs(&self, y: &[f64], lsmr: &LsmrOptions) -> Result<RhsSolution, SolveError> {
         // Guard the silent-truncation hole: weighted_rhs zips y with sqrt-weights,
         // which would otherwise discard trailing values when y.len() > n_rows.
-        if y.len() != self.design.input_n_obs {
+        if y.len() != self.design.n_obs_input {
             return Err(SolveError::InvalidInput {
                 context: "Solver::solve",
                 message: format!(
                     "response vector length ({}) does not match number of observations ({})",
                     y.len(),
-                    self.design.input_n_obs
+                    self.design.n_obs_input
                 ),
             });
         }
@@ -555,7 +555,7 @@ impl<'a> Solver<'a> {
             .collect::<Result<Vec<_>, _>>()?;
 
         let mut x = Vec::with_capacity(self.design.n_dofs * n_rhs);
-        let mut demeaned = Vec::with_capacity(self.design.input_n_obs * n_rhs);
+        let mut demeaned = Vec::with_capacity(self.design.n_obs_input * n_rhs);
         let mut converged = Vec::with_capacity(n_rhs);
         let mut iterations = Vec::with_capacity(n_rhs);
         let mut residual = Vec::with_capacity(n_rhs);
@@ -583,7 +583,7 @@ impl<'a> Solver<'a> {
             time_setup: 0.0,
             time_total: t_start.elapsed().as_secs_f64(),
             n_dofs: self.design.n_dofs,
-            n_obs: self.design.input_n_obs,
+            n_obs: self.design.n_obs_input,
         })
     }
 

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -2,67 +2,23 @@
 //! multiple solves on the same design) and the one-shot [`solve`] / [`solve_batch`]
 //! convenience wrappers built on top of it.
 
-use std::borrow::Cow;
 use std::time::Instant;
 
-use ndarray::{ArrayView2, Axis};
 use rayon::prelude::*;
 use schwarz_precond::{lsmr as lsmr_solve, mlsmr};
 
 use crate::channel::Channel;
 use crate::config::{LsmrOptions, PreconditionerConfig};
-use crate::domain::{map_to_internal_order, Design, Effect};
-use crate::observation::ObservationFrame;
+use crate::domain::Design;
 use crate::operator::design::gather_apply;
 use crate::operator::schwarz::{build_preconditioner, Preconditioner};
 use crate::operator::DesignOperator;
-use crate::{BuildError, BuildWarning, DesignOptions, SolveError, WithinError};
+use crate::{BuildError, BuildWarning, SolveError, WithinError};
 
 mod reparam;
 #[cfg(test)]
 mod tests;
 use reparam::SlopeReparam;
-
-/// Fallible construction of a [`Design`] from a categories matrix
-/// (`ArrayView2<u32>`), a list of [`Effect`] terms, or a pass-through
-/// [`Design`].
-pub trait IntoDesign<'a> {
-    /// Build the [`Design`], validating inputs along the way.
-    fn into_design(self, options: DesignOptions<'a>) -> Result<Design<'a>, BuildError>;
-}
-
-impl<'a> IntoDesign<'a> for ArrayView2<'a, u32> {
-    fn into_design(self, options: DesignOptions<'a>) -> Result<Design<'a>, BuildError> {
-        // Borrow F-contiguous columns zero-copy; gather strided (C-order)
-        // columns once here so every downstream read is a contiguous slice.
-        let categorical = (0..self.ncols())
-            .map(|factor| {
-                let col = self.index_axis_move(Axis(1), factor);
-                match col.to_slice() {
-                    Some(s) => Cow::Borrowed(s),
-                    None => Cow::Owned(col.to_vec()),
-                }
-            })
-            .collect();
-        let frame = ObservationFrame::new(categorical, Vec::new())?;
-        options.from_frame(frame)
-    }
-}
-
-impl<'a> IntoDesign<'a> for Design<'a> {
-    fn into_design(self, options: DesignOptions<'a>) -> Result<Design<'a>, BuildError> {
-        if options != DesignOptions::default() {
-            return Err(BuildError::OptionsForPrebuiltDesign);
-        }
-        Ok(self)
-    }
-}
-
-impl<'a> IntoDesign<'a> for Vec<Effect<'a>> {
-    fn into_design(self, options: DesignOptions<'a>) -> Result<Design<'a>, BuildError> {
-        options.from_effects(self)
-    }
-}
 
 /// Preconditioner input for [`Solver::new`].
 ///
@@ -227,7 +183,7 @@ pub struct SolveResult {
     /// Rows removed during design processing are `NaN`.
     ///
     /// Invariant: any per-observation field added here must be translated
-    /// back from internal order via `Design::from_internal_order` before being
+    /// back to input row order via `Design::to_input_row_order` before being
     /// stored, or it leaks the locality-sorted row order to the caller.
     pub demeaned: Vec<f64>,
     /// Whether the iterative solver converged within `maxiter` iterations.
@@ -368,9 +324,10 @@ impl<'a> Solver<'a> {
     ) -> Result<Self, BuildError> {
         // Align caller-order weights with the design's retained internal rows.
         // Identity mappings stay borrowed through setup.
-        let weights = design.options.weight_values().map(|weights| {
-            map_to_internal_order(design.rows.as_deref(), design.n_obs_input, weights)
-        });
+        let weights = design
+            .options
+            .weights()
+            .map(|weights| design.to_internal_row_order(weights));
 
         // Reparametrize the slope columns (if any) before the preconditioner reads the frame.
         let reparam = SlopeReparam::build(&mut design.frame, &design.terms, weights.as_deref());
@@ -486,7 +443,7 @@ impl<'a> Solver<'a> {
         Ok(RhsSolution {
             x,
             // Back to the caller's observation order (no-op if not reordered).
-            demeaned: self.design.from_internal_order(demeaned),
+            demeaned: self.design.to_input_row_order(demeaned),
             converged: r.converged,
             iterations: r.iterations,
             // Read from the LSMR recurrence at no extra cost; see `SolveResult::residual`.
@@ -605,7 +562,7 @@ impl<'a> Solver<'a> {
 
 /// Solve fixed-effects least squares for a configured design.
 ///
-/// Construct `design` first through [`IntoDesign`] or [`DesignOptions`].
+/// Construct `design` first with one of the explicit [`Design`] constructors.
 /// `y` is in caller row order and has the design's input observation count.
 ///
 /// `preconditioner` accepts the same input shapes as [`Solver::new`]:

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -11,7 +11,7 @@ use schwarz_precond::{lsmr as lsmr_solve, mlsmr};
 
 use crate::channel::Channel;
 use crate::config::{LsmrOptions, PreconditionerConfig};
-use crate::domain::{Design, Effect};
+use crate::domain::{map_to_internal_order, Design, Effect};
 use crate::observation::ObservationFrame;
 use crate::operator::design::gather_apply;
 use crate::operator::schwarz::{build_preconditioner, Preconditioner};
@@ -23,16 +23,16 @@ mod reparam;
 mod tests;
 use reparam::SlopeReparam;
 
-/// Fallible conversion into a [`Design`] for [`Solver::new`]: a categories
-/// matrix (`ArrayView2<u32>`), a list of [`Effect`] terms, or a pass-through
+/// Fallible construction of a [`Design`] from a categories matrix
+/// (`ArrayView2<u32>`), a list of [`Effect`] terms, or a pass-through
 /// [`Design`].
 pub trait IntoDesign<'a> {
     /// Build the [`Design`], validating inputs along the way.
-    fn into_design(self, options: DesignOptions) -> Result<Design<'a>, BuildError>;
+    fn into_design(self, options: DesignOptions<'a>) -> Result<Design<'a>, BuildError>;
 }
 
 impl<'a> IntoDesign<'a> for ArrayView2<'a, u32> {
-    fn into_design(self, options: DesignOptions) -> Result<Design<'a>, BuildError> {
+    fn into_design(self, options: DesignOptions<'a>) -> Result<Design<'a>, BuildError> {
         // Borrow F-contiguous columns zero-copy; gather strided (C-order)
         // columns once here so every downstream read is a contiguous slice.
         let categorical = (0..self.ncols())
@@ -50,7 +50,7 @@ impl<'a> IntoDesign<'a> for ArrayView2<'a, u32> {
 }
 
 impl<'a> IntoDesign<'a> for Design<'a> {
-    fn into_design(self, options: DesignOptions) -> Result<Design<'a>, BuildError> {
+    fn into_design(self, options: DesignOptions<'a>) -> Result<Design<'a>, BuildError> {
         if options != DesignOptions::default() {
             return Err(BuildError::OptionsForPrebuiltDesign);
         }
@@ -59,7 +59,7 @@ impl<'a> IntoDesign<'a> for Design<'a> {
 }
 
 impl<'a> IntoDesign<'a> for Vec<Effect<'a>> {
-    fn into_design(self, options: DesignOptions) -> Result<Design<'a>, BuildError> {
+    fn into_design(self, options: DesignOptions<'a>) -> Result<Design<'a>, BuildError> {
         options.from_effects(self)
     }
 }
@@ -227,7 +227,7 @@ pub struct SolveResult {
     /// Rows removed during design processing are `NaN`.
     ///
     /// Invariant: any per-observation field added here must be translated
-    /// back from internal order via `Design::permute_obs_out` before being
+    /// back from internal order via `Design::from_internal_order` before being
     /// stored, or it leaks the locality-sorted row order to the caller.
     pub demeaned: Vec<f64>,
     /// Whether the iterative solver converged within `maxiter` iterations.
@@ -352,39 +352,28 @@ struct RhsSolution {
 impl<'a> Solver<'a> {
     /// Construct a solver.
     ///
-    /// `design` accepts raw categories (`ArrayView2<u32>`) or a pre-built
-    /// [`Design`]. `preconditioner` accepts:
+    /// `design` is a fully configured [`Design`]. `preconditioner` accepts:
     /// - `None` — build the library default Schwarz preconditioner
     /// - `&PreconditionerConfig` / `Some(&PreconditionerConfig)` — build from a tuned config
     /// - `PreconditionerConfig::Off` — solve unpreconditioned
     /// - `PreconditionerConfig::Diagonal` — use diagonal/Jacobi preconditioning
     /// - [`Preconditioner`] or `&Preconditioner` — reuse a previously built one
     ///
-    /// `weights` is `None` for unweighted, or an owned `Vec<f64>` that the
-    /// solver takes ownership of (it re-reads the weights on every solve). To
-    /// solve once from a borrowed slice, use the free [`solve`] function.
-    ///
     /// LSMR tuning ([`LsmrOptions`]) is supplied per call to [`Solver::solve`] /
     /// [`Solver::solve_batch`], not at construction; preconditioner factorization
     /// state is the only expensive thing built here.
     pub fn new(
-        design: impl IntoDesign<'a>,
-        weights: Option<Vec<f64>>,
+        mut design: Design<'a>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
-        let mut design = design.into_design(DesignOptions::default())?;
-        design.validate_weights(weights.as_deref())?;
-
-        // Align weights with the design's internal (possibly locality-sorted)
-        // observation order. The match keeps the unpermuted arm a plain move
-        // (`permute_obs_in` would borrow and `into_owned` would copy).
-        let weights = match &design.rows {
-            Some(_) => weights.map(|w| design.permute_obs_in(&w).into_owned()),
-            None => weights,
-        };
+        // Align caller-order weights with the design's retained internal rows.
+        // Identity mappings stay borrowed through setup.
+        let weights = design.options.weight_values().map(|weights| {
+            map_to_internal_order(design.rows.as_deref(), design.n_obs_input, weights)
+        });
 
         // Reparametrize the slope columns (if any) before the preconditioner reads the frame.
-        let reparam = SlopeReparam::build(&mut design, weights.as_deref());
+        let reparam = SlopeReparam::build(&mut design.frame, &design.terms, weights.as_deref());
 
         let (preconditioner, warnings) = match preconditioner.into() {
             PreconditionerInput::Default => {
@@ -405,11 +394,12 @@ impl<'a> Solver<'a> {
             }
         };
 
-        let sqrt_weights = weights.map(|mut w| {
-            for wi in &mut w {
+        let sqrt_weights = weights.map(|weights| {
+            let mut weights = weights.into_owned();
+            for wi in &mut weights {
                 *wi = wi.sqrt();
             }
-            w
+            weights
         });
 
         Ok(Self {
@@ -496,7 +486,7 @@ impl<'a> Solver<'a> {
         Ok(RhsSolution {
             x,
             // Back to the caller's observation order (no-op if not reordered).
-            demeaned: self.design.permute_obs_out(demeaned),
+            demeaned: self.design.from_internal_order(demeaned),
             converged: r.converged,
             iterations: r.iterations,
             // Read from the LSMR recurrence at no extra cost; see `SolveResult::residual`.
@@ -613,16 +603,10 @@ impl<'a> Solver<'a> {
     }
 }
 
-/// Solve fixed-effects least squares for a design input.
+/// Solve fixed-effects least squares for a configured design.
 ///
-/// `design` is anything implementing [`IntoDesign`]: an observation-major
-/// `(n_obs, n_factors)` categories array (levels `0..max_level` per factor,
-/// count inferred) or a list of [`Effect`] terms.
-/// `y` is the response vector (length = n_obs).
-///
-/// Zero-copy for F-order category arrays whose dominant factor is already
-/// sorted; otherwise columns are copied once (per column at ingest, or
-/// whole-frame by the locality sort).
+/// Construct `design` first through [`IntoDesign`] or [`DesignOptions`].
+/// `y` is in caller row order and has the design's input observation count.
 ///
 /// `preconditioner` accepts the same input shapes as [`Solver::new`]:
 /// `None`, a [`crate::PreconditionerConfig`] by reference or value, an owned
@@ -630,16 +614,13 @@ impl<'a> Solver<'a> {
 ///
 /// This is a convenience wrapper around [`Solver::new`] + [`Solver::solve`].
 pub fn solve<'a, 'o>(
-    design: impl IntoDesign<'a>,
-    options: DesignOptions,
+    design: Design<'a>,
     y: &[f64],
-    weights: Option<&[f64]>,
     lsmr: impl Into<Option<&'o LsmrOptions>>,
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<SolveResult, WithinError> {
     let t_start = Instant::now();
-    let design = design.into_design(options)?;
-    let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
+    let solver = Solver::new(design, preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve(y, lsmr)?;
     // Include solver construction (preconditioner build) in setup time
@@ -653,16 +634,13 @@ pub fn solve<'a, 'o>(
 /// Same as [`solve`] but solves all RHS vectors in parallel (via rayon),
 /// reusing the preconditioner across all solves.
 pub fn solve_batch<'a, 'o>(
-    design: impl IntoDesign<'a>,
-    options: DesignOptions,
+    design: Design<'a>,
     ys: &[&[f64]],
-    weights: Option<&[f64]>,
     lsmr: impl Into<Option<&'o LsmrOptions>>,
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<BatchSolveResult, WithinError> {
     let t_start = Instant::now();
-    let design = design.into_design(options)?;
-    let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
+    let solver = Solver::new(design, preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve_batch(ys, lsmr)?;
     result.time_setup += time_setup;

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -173,8 +173,7 @@ pub struct SolveResult {
     pub x: Vec<f64>,
     /// Per-level directions the data cannot identify.
     pub unidentified: Vec<CoefficientAddress>,
-    /// Non-fatal preconditioner-build warnings (see [`Solver::warnings`]);
-    /// empty when a pre-built preconditioner was reused.
+    /// Non-fatal solver-build warnings (see [`Solver::warnings`]).
     pub warnings: Vec<BuildWarning>,
     /// Address ↔ flat-`x`-index translation for this design's coefficients.
     pub layout: CoefficientLayout,
@@ -216,7 +215,7 @@ pub struct BatchSolveResult {
     /// Per-level directions the data cannot identify, shared across all RHS:
     /// identification depends only on the design and weights, never on `y`.
     pub unidentified: Vec<CoefficientAddress>,
-    /// Non-fatal preconditioner-build warnings, shared across all RHS; see
+    /// Non-fatal solver-build warnings, shared across all RHS; see
     /// [`SolveResult::warnings`].
     pub warnings: Vec<BuildWarning>,
     /// Address ↔ flat-`x`-index translation for this design's coefficients.
@@ -322,6 +321,8 @@ impl<'a> Solver<'a> {
         mut design: Design<'a>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
+        let n_removed = design.n_obs_input - design.n_obs;
+
         // Align caller-order weights with the design's retained internal rows.
         // Identity mappings stay borrowed through setup.
         let weights = design
@@ -332,7 +333,7 @@ impl<'a> Solver<'a> {
         // Reparametrize the slope columns (if any) before the preconditioner reads the frame.
         let reparam = SlopeReparam::build(&mut design.frame, &design.terms, weights.as_deref());
 
-        let (preconditioner, warnings) = match preconditioner.into() {
+        let (preconditioner, mut warnings) = match preconditioner.into() {
             PreconditionerInput::Default => {
                 build_preconditioner(&design, weights.as_deref(), None)?
             }
@@ -351,6 +352,13 @@ impl<'a> Solver<'a> {
             }
         };
 
+        if n_removed != 0 {
+            warnings.insert(
+                0,
+                BuildWarning::SingletonObservationsRemoved { count: n_removed },
+            );
+        }
+
         let sqrt_weights = weights.map(|weights| {
             let mut weights = weights.into_owned();
             for wi in &mut weights {
@@ -368,8 +376,10 @@ impl<'a> Solver<'a> {
         })
     }
 
-    /// Non-fatal events from the preconditioner build; empty when reusing a
-    /// pre-built preconditioner (its warnings were reported when it was built).
+    /// Non-fatal events from design and preconditioner construction.
+    ///
+    /// Reusing a pre-built preconditioner suppresses only its original build
+    /// warnings; warnings arising from this design are still reported.
     pub fn warnings(&self) -> &[BuildWarning] {
         &self.warnings
     }

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -16,7 +16,7 @@ use crate::observation::ObservationFrame;
 use crate::operator::design::gather_apply;
 use crate::operator::schwarz::{build_preconditioner, Preconditioner};
 use crate::operator::DesignOperator;
-use crate::{BuildError, BuildWarning, SolveError, WithinError};
+use crate::{BuildError, BuildWarning, DesignOptions, SolveError, WithinError};
 
 mod reparam;
 #[cfg(test)]
@@ -28,12 +28,13 @@ use reparam::SlopeReparam;
 /// [`Design`].
 pub trait IntoDesign<'a> {
     /// Build the [`Design`], validating inputs along the way.
-    fn into_design(self) -> Result<Design<'a>, BuildError>;
+    fn into_design(self, options: DesignOptions) -> Result<Design<'a>, BuildError>;
 }
 
 impl<'a> IntoDesign<'a> for ArrayView2<'a, u32> {
-    fn into_design(self) -> Result<Design<'a>, BuildError> {
-        // Gather strided (C-order) columns once so every downstream read is contiguous.
+    fn into_design(self, options: DesignOptions) -> Result<Design<'a>, BuildError> {
+        // Borrow F-contiguous columns zero-copy; gather strided (C-order)
+        // columns once here so every downstream read is a contiguous slice.
         let categorical = (0..self.ncols())
             .map(|factor| {
                 let col = self.index_axis_move(Axis(1), factor);
@@ -43,19 +44,23 @@ impl<'a> IntoDesign<'a> for ArrayView2<'a, u32> {
                 }
             })
             .collect();
-        Design::from_frame(ObservationFrame::new(categorical, Vec::new())?)
+        let frame = ObservationFrame::new(categorical, Vec::new())?;
+        options.from_frame(frame)
     }
 }
 
 impl<'a> IntoDesign<'a> for Design<'a> {
-    fn into_design(self) -> Result<Design<'a>, BuildError> {
+    fn into_design(self, options: DesignOptions) -> Result<Design<'a>, BuildError> {
+        if options != DesignOptions::default() {
+            return Err(BuildError::OptionsForPrebuiltDesign);
+        }
         Ok(self)
     }
 }
 
 impl<'a> IntoDesign<'a> for Vec<Effect<'a>> {
-    fn into_design(self) -> Result<Design<'a>, BuildError> {
-        Design::new(self)
+    fn into_design(self, options: DesignOptions) -> Result<Design<'a>, BuildError> {
+        options.from_effects(self)
     }
 }
 
@@ -367,7 +372,7 @@ impl<'a> Solver<'a> {
         weights: Option<Vec<f64>>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
-        let mut design = design.into_design()?;
+        let mut design = design.into_design(DesignOptions::default())?;
         design.validate_weights(weights.as_deref())?;
 
         // Align weights with the design's internal (possibly locality-sorted)
@@ -626,12 +631,14 @@ impl<'a> Solver<'a> {
 /// This is a convenience wrapper around [`Solver::new`] + [`Solver::solve`].
 pub fn solve<'a, 'o>(
     design: impl IntoDesign<'a>,
+    options: DesignOptions,
     y: &[f64],
     weights: Option<&[f64]>,
     lsmr: impl Into<Option<&'o LsmrOptions>>,
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<SolveResult, WithinError> {
     let t_start = Instant::now();
+    let design = design.into_design(options)?;
     let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve(y, lsmr)?;
@@ -647,12 +654,14 @@ pub fn solve<'a, 'o>(
 /// reusing the preconditioner across all solves.
 pub fn solve_batch<'a, 'o>(
     design: impl IntoDesign<'a>,
+    options: DesignOptions,
     ys: &[&[f64]],
     weights: Option<&[f64]>,
     lsmr: impl Into<Option<&'o LsmrOptions>>,
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<BatchSolveResult, WithinError> {
     let t_start = Instant::now();
+    let design = design.into_design(options)?;
     let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve_batch(ys, lsmr)?;

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -217,7 +217,9 @@ pub struct SolveResult {
     pub warnings: Vec<BuildWarning>,
     /// Address ↔ flat-`x`-index translation for this design's coefficients.
     pub layout: CoefficientLayout,
-    /// Demeaned response: `y - D x` (length = n_obs), in caller order.
+    /// Demeaned response: `y - D x` in the original caller shape.
+    ///
+    /// Rows removed during design processing are `NaN`.
     ///
     /// Invariant: any per-observation field added here must be translated
     /// back from internal order via `Design::permute_obs_out` before being
@@ -258,7 +260,8 @@ pub struct BatchSolveResult {
     pub warnings: Vec<BuildWarning>,
     /// Address ↔ flat-`x`-index translation for this design's coefficients.
     pub layout: CoefficientLayout,
-    /// All demeaned responses concatenated (length = n_obs * n_rhs).
+    /// All demeaned responses concatenated in original caller shape
+    /// (length = n_obs * n_rhs). Removed rows are `NaN`.
     pub demeaned: Vec<f64>,
     /// Per-RHS convergence flags.
     pub converged: Vec<bool>,
@@ -277,7 +280,7 @@ pub struct BatchSolveResult {
     pub time_total: f64,
     /// Number of coefficients per RHS (rows of the underlying design).
     pub n_dofs: usize,
-    /// Number of observations (columns of the underlying design).
+    /// Number of caller observations per RHS, including removed rows.
     pub n_obs: usize,
 }
 
@@ -317,7 +320,8 @@ pub struct Solver<'a> {
 impl std::fmt::Debug for Solver<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Solver")
-            .field("n_obs", &self.design.n_obs)
+            .field("n_obs", &self.design.input_n_obs)
+            .field("n_retained_obs", &self.design.n_obs)
             .field("n_dofs", &self.design.n_dofs)
             .field("has_weights", &self.sqrt_weights.is_some())
             .field("has_preconditioner", &self.preconditioner.is_some())
@@ -366,8 +370,10 @@ impl<'a> Solver<'a> {
         let mut design = design.into_design()?;
         design.validate_weights(weights.as_deref())?;
 
-        // The match keeps the unpermuted arm a plain move rather than a borrow-and-copy.
-        let weights = match &design.obs_perm {
+        // Align weights with the design's internal (possibly locality-sorted)
+        // observation order. The match keeps the unpermuted arm a plain move
+        // (`permute_obs_in` would borrow and `into_owned` would copy).
+        let weights = match &design.rows {
             Some(_) => weights.map(|w| design.permute_obs_in(&w).into_owned()),
             None => weights,
         };
@@ -421,18 +427,33 @@ impl<'a> Solver<'a> {
     /// `unidentified`, which the public entry points attach once (see
     /// [`RhsSolution`]).
     fn solve_rhs(&self, y: &[f64], lsmr: &LsmrOptions) -> Result<RhsSolution, SolveError> {
-        // `weighted_rhs` zips y with sqrt-weights, silently truncating when `y.len() > n_rows`.
-        if y.len() != self.design.n_obs {
+        // Guard the silent-truncation hole: weighted_rhs zips y with sqrt-weights,
+        // which would otherwise discard trailing values when y.len() > n_rows.
+        if y.len() != self.design.input_n_obs {
             return Err(SolveError::InvalidInput {
                 context: "Solver::solve",
                 message: format!(
                     "response vector length ({}) does not match number of observations ({})",
                     y.len(),
-                    self.design.n_obs
+                    self.design.input_n_obs
                 ),
             });
         }
-        if let Some((index, &value)) = y.iter().enumerate().find(|&(_, &v)| !v.is_finite()) {
+        let invalid = match &self.design.rows {
+            None => y
+                .iter()
+                .enumerate()
+                .find(|&(_, &value)| !value.is_finite())
+                .map(|(caller, &value)| (caller, value)),
+            Some(rows) => rows
+                .iter()
+                .filter_map(|&caller| {
+                    let value = y[caller as usize];
+                    (!value.is_finite()).then_some((caller as usize, value))
+                })
+                .min_by_key(|&(caller, _)| caller),
+        };
+        if let Some((index, value)) = invalid {
             return Err(SolveError::InvalidInput {
                 context: "Solver::solve",
                 message: format!("response at index {index} must be finite, got {value}"),
@@ -440,10 +461,6 @@ impl<'a> Solver<'a> {
         }
 
         let t_start = Instant::now();
-
-        // The gather is a recurring per-solve cost of the locality sort, so it counts as setup.
-        let y_internal = self.design.permute_obs_in(y);
-        let y: &[f64] = &y_internal;
 
         let rect_op = DesignOperator::new(&self.design, self.sqrt_weights.as_deref());
         let b = rect_op.weighted_rhs(y);
@@ -462,8 +479,8 @@ impl<'a> Solver<'a> {
         // Shapes are guaranteed here, so the bare `D x` matvec is infallible.
         let mut demeaned = vec![0.0; self.design.n_obs];
         gather_apply(&self.design, &r.x, &mut demeaned, None);
-        for (d, &yi) in demeaned.iter_mut().zip(y.iter()) {
-            *d = yi - *d;
+        for (internal, d) in demeaned.iter_mut().enumerate() {
+            *d = y[self.design.caller_row(internal)] - *d;
         }
 
         let mut x = r.x;
@@ -538,7 +555,7 @@ impl<'a> Solver<'a> {
             .collect::<Result<Vec<_>, _>>()?;
 
         let mut x = Vec::with_capacity(self.design.n_dofs * n_rhs);
-        let mut demeaned = Vec::with_capacity(self.design.n_obs * n_rhs);
+        let mut demeaned = Vec::with_capacity(self.design.input_n_obs * n_rhs);
         let mut converged = Vec::with_capacity(n_rhs);
         let mut iterations = Vec::with_capacity(n_rhs);
         let mut residual = Vec::with_capacity(n_rhs);
@@ -566,7 +583,7 @@ impl<'a> Solver<'a> {
             time_setup: 0.0,
             time_total: t_start.elapsed().as_secs_f64(),
             n_dofs: self.design.n_dofs,
-            n_obs: self.design.n_obs,
+            n_obs: self.design.input_n_obs,
         })
     }
 
@@ -580,8 +597,13 @@ impl<'a> Solver<'a> {
         self.design.n_dofs
     }
 
-    /// Number of observations.
+    /// Number of observations expected in each caller-provided RHS.
     pub fn n_obs(&self) -> usize {
+        self.design.input_n_obs()
+    }
+
+    /// Number of observations retained by the numerical design.
+    pub fn n_retained_obs(&self) -> usize {
         self.design.n_obs
     }
 }

--- a/crates/within/src/solver/reparam.rs
+++ b/crates/within/src/solver/reparam.rs
@@ -1,6 +1,9 @@
 //! Within-level reparametrization of a design's varying-slope terms.
 
-use crate::domain::Design;
+use crate::domain::TermMeta;
+use crate::observation::ObservationFrame;
+#[cfg(test)]
+use crate::Design;
 
 use super::CoefficientAddress;
 use crate::channel::Channel;
@@ -45,18 +48,24 @@ impl SlopeReparam {
     /// `None` for slope-free designs. Unidentified directions become
     /// exact-zero columns, so the minimal-norm solve leaves exact-`0`
     /// coefficients.
-    pub(crate) fn build(design: &mut Design<'_>, weights: Option<&[f64]>) -> Option<Self> {
+    pub(crate) fn build(
+        frame: &mut ObservationFrame<'_>,
+        term_meta: &[TermMeta],
+        weights: Option<&[f64]>,
+    ) -> Option<Self> {
         let mut terms = Vec::new();
         let mut unidentified = Vec::new();
-        for term in 0..design.terms.len() {
-            if !design.terms[term]
-                .columns
-                .iter()
-                .any(|c| c.covariate().is_some())
-            {
+        for (term, meta) in term_meta.iter().enumerate() {
+            if !meta.columns.iter().any(|c| c.covariate().is_some()) {
                 continue;
             }
-            terms.push(TermReparam::build(design, term, weights, &mut unidentified));
+            terms.push(TermReparam::build(
+                frame,
+                meta,
+                term,
+                weights,
+                &mut unidentified,
+            ));
         }
         (!terms.is_empty()).then_some(Self {
             terms,
@@ -76,12 +85,12 @@ impl TermReparam {
     /// Whiten one term's loading columns in place, appending its unidentified
     /// directions ascending in `(level, column)`.
     fn build(
-        design: &mut Design<'_>,
+        frame: &mut ObservationFrame<'_>,
+        meta: &TermMeta,
         term: usize,
         weights: Option<&[f64]>,
         unidentified: &mut Vec<CoefficientAddress>,
     ) -> Self {
-        let meta = &design.terms[term];
         let (offset, n_levels) = (meta.offset, meta.n_levels);
         let mut intercept_column = None;
         let mut slope_columns = Vec::new();
@@ -97,11 +106,8 @@ impl TermReparam {
         }
         let intercept = intercept_column.is_some();
         let v = z_cols.len();
-        let levels = design.frame.level_column(term);
-        let zs: Vec<&[f64]> = z_cols
-            .iter()
-            .map(|&c| design.frame.loading_column(c))
-            .collect();
+        let levels = frame.level_column(term);
+        let zs: Vec<&[f64]> = z_cols.iter().map(|&c| frame.loading_column(c)).collect();
 
         let mut moments = LevelMoments::new(n_levels, v);
         let mut z_row = vec![0.0; v];
@@ -156,7 +162,7 @@ impl TermReparam {
             }
         }
         for (out, &c) in u_cols.into_iter().zip(&z_cols) {
-            design.frame.set_loading_column(c, out);
+            frame.set_loading_column(c, out);
         }
 
         Self {

--- a/crates/within/src/solver/reparam/tests.rs
+++ b/crates/within/src/solver/reparam/tests.rs
@@ -3,7 +3,7 @@
 //! for the per-term independence of the multi-term whitening.
 
 use crate::channel::Channel;
-use crate::domain::Effect;
+use crate::domain::{DesignOptions, Effect};
 
 use super::*;
 
@@ -59,7 +59,7 @@ fn three_term_effects() -> Vec<Effect<'static>> {
 
 #[test]
 fn build_whitens_each_slope_bearing_term() {
-    let mut design = Design::new(three_term_effects()).unwrap();
+    let mut design = Design::from_effects(three_term_effects(), DesignOptions::default()).unwrap();
     let rp = SlopeReparam::build(&mut design.frame, &design.terms, None).unwrap();
     assert!(rp.unidentified.is_empty());
 
@@ -103,7 +103,7 @@ fn unidentified_directions_ascend_across_terms() {
         Effect::new(&f0, true, [&z0[..]]).unwrap(),
         Effect::new(&f1, true, [&z1[..]]).unwrap(),
     ];
-    let mut design = Design::new(effects).unwrap();
+    let mut design = Design::from_effects(effects, DesignOptions::default()).unwrap();
     let rp = SlopeReparam::build(&mut design.frame, &design.terms, None).unwrap();
     assert_eq!(
         rp.unidentified,
@@ -122,7 +122,7 @@ fn unidentified_directions_ascend_across_terms() {
 
 #[test]
 fn back_transform_leaves_other_terms_untouched() {
-    let mut design = Design::new(three_term_effects()).unwrap();
+    let mut design = Design::from_effects(three_term_effects(), DesignOptions::default()).unwrap();
     let rp = SlopeReparam::build(&mut design.frame, &design.terms, None).unwrap();
 
     let mut x: Vec<f64> = (0..design.n_dofs).map(|i| 1.0 + i as f64).collect();

--- a/crates/within/src/solver/reparam/tests.rs
+++ b/crates/within/src/solver/reparam/tests.rs
@@ -60,7 +60,7 @@ fn three_term_effects() -> Vec<Effect<'static>> {
 #[test]
 fn build_whitens_each_slope_bearing_term() {
     let mut design = Design::new(three_term_effects()).unwrap();
-    let rp = SlopeReparam::build(&mut design, None).unwrap();
+    let rp = SlopeReparam::build(&mut design.frame, &design.terms, None).unwrap();
     assert!(rp.unidentified.is_empty());
 
     for term in [0, 2] {
@@ -104,7 +104,7 @@ fn unidentified_directions_ascend_across_terms() {
         Effect::new(&f1, true, [&z1[..]]).unwrap(),
     ];
     let mut design = Design::new(effects).unwrap();
-    let rp = SlopeReparam::build(&mut design, None).unwrap();
+    let rp = SlopeReparam::build(&mut design.frame, &design.terms, None).unwrap();
     assert_eq!(
         rp.unidentified,
         vec![
@@ -123,7 +123,7 @@ fn unidentified_directions_ascend_across_terms() {
 #[test]
 fn back_transform_leaves_other_terms_untouched() {
     let mut design = Design::new(three_term_effects()).unwrap();
-    let rp = SlopeReparam::build(&mut design, None).unwrap();
+    let rp = SlopeReparam::build(&mut design.frame, &design.terms, None).unwrap();
 
     let mut x: Vec<f64> = (0..design.n_dofs).map(|i| 1.0 + i as f64).collect();
     let before = x.clone();

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -35,7 +35,7 @@ fn positive_slope_only_pair_grounds_beyond_dense_threshold() {
         Effect::new(&g, true, []).expect("plain effect"),
     ];
     let mut design = Design::new(effects).expect("design");
-    let _reparam = SlopeReparam::build(&mut design, None);
+    let _reparam = SlopeReparam::build(&mut design.frame, &design.terms, None);
     let (domains, warnings) =
         build_local_domains(&design, None, &ScalingConfig::default()).expect("domains");
     assert!(
@@ -99,7 +99,7 @@ fn solver_filters_caller_rhs_and_restores_removed_rows_as_nan() {
         .from_frame(frame)
         .unwrap();
 
-    let solver = Solver::new(design, None, PreconditionerConfig::default()).unwrap();
+    let solver = Solver::new(design, PreconditionerConfig::default()).unwrap();
     let y = [1.0, f64::NAN, 3.0, 4.0, f64::NAN];
     let result = solver.solve(&y, None).unwrap();
 

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -34,7 +34,7 @@ fn positive_slope_only_pair_grounds_beyond_dense_threshold() {
         Effect::new(&f, false, [&z[..]]).expect("slope effect"),
         Effect::new(&g, true, []).expect("plain effect"),
     ];
-    let mut design = Design::new(effects).expect("design");
+    let mut design = Design::from_effects(effects, DesignOptions::default()).expect("design");
     let _reparam = SlopeReparam::build(&mut design.frame, &design.terms, None);
     let (domains, warnings) =
         build_local_domains(&design, None, &ScalingConfig::default()).expect("domains");
@@ -55,10 +55,13 @@ fn coefficient_layout_translates_addresses_both_ways() {
     let f = [0u32, 1, 2, 0, 1, 2];
     let g = [0u32, 0, 1, 1, 0, 1];
     let z = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let design = Design::new(vec![
-        Effect::new(&f, true, []).expect("plain effect"),
-        Effect::new(&g, true, [&z[..]]).expect("slope effect"),
-    ])
+    let design = Design::from_effects(
+        vec![
+            Effect::new(&f, true, []).expect("plain effect"),
+            Effect::new(&g, true, [&z[..]]).expect("slope effect"),
+        ],
+        DesignOptions::default(),
+    )
     .expect("design");
     let layout = CoefficientLayout::from_design(&design);
 
@@ -94,10 +97,7 @@ fn coefficient_layout_translates_addresses_both_ways() {
 #[test]
 fn solver_filters_caller_rhs_and_restores_removed_rows_as_nan() {
     let frame = ObservationFrame::new(vec![vec![0u32, 1, 0, 0, 2].into()], Vec::new()).unwrap();
-    let design = DesignOptions::default()
-        .drop_singletons(true)
-        .from_frame(frame)
-        .unwrap();
+    let design = Design::from_frame(frame, DesignOptions::new(true, None)).unwrap();
 
     let solver = Solver::new(design, PreconditionerConfig::default()).unwrap();
     let y = [1.0, f64::NAN, 3.0, 4.0, f64::NAN];

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -1,10 +1,8 @@
-use std::borrow::Cow;
-
 use super::reparam::SlopeReparam;
 use super::{CoefficientAddress, CoefficientLayout, Solver};
 use crate::channel::Channel;
 use crate::config::{PreconditionerConfig, ScalingConfig, DEFAULT_DENSE_SCHUR_THRESHOLD};
-use crate::domain::{build_local_domains, Design, Grounding, MatrixForm};
+use crate::domain::{build_local_domains, Design, DesignOptions, Grounding, MatrixForm};
 use crate::observation::ObservationFrame;
 use crate::Effect;
 
@@ -95,9 +93,11 @@ fn coefficient_layout_translates_addresses_both_ways() {
 
 #[test]
 fn solver_filters_caller_rhs_and_restores_removed_rows_as_nan() {
-    let frame = ObservationFrame::new(vec![Cow::Owned(vec![0, 1, 0, 1, 2])], Vec::new()).unwrap();
-    let mut design = Design::from_frame_unsorted(frame).unwrap();
-    design.remap_internal_rows(&[3, 0, 2]).unwrap();
+    let frame = ObservationFrame::new(vec![vec![0u32, 1, 0, 0, 2].into()], Vec::new()).unwrap();
+    let design = DesignOptions::default()
+        .drop_singletons(true)
+        .from_frame(frame)
+        .unwrap();
 
     let solver = Solver::new(design, None, PreconditionerConfig::default()).unwrap();
     let y = [1.0, f64::NAN, 3.0, 4.0, f64::NAN];
@@ -106,19 +106,19 @@ fn solver_filters_caller_rhs_and_restores_removed_rows_as_nan() {
     assert_eq!(solver.n_obs(), 5);
     assert_eq!(solver.n_retained_obs(), 3);
     assert_eq!(result.demeaned.len(), 5);
-    assert!((result.demeaned[0] + 1.0).abs() < 1e-10);
+    assert!((result.demeaned[0] + 5.0 / 3.0).abs() < 1e-10);
     assert!(result.demeaned[1].is_nan());
-    assert!((result.demeaned[2] - 1.0).abs() < 1e-10);
-    assert!(result.demeaned[3].abs() < 1e-10);
+    assert!((result.demeaned[2] - 1.0 / 3.0).abs() < 1e-10);
+    assert!((result.demeaned[3] - 4.0 / 3.0).abs() < 1e-10);
     assert!(result.demeaned[4].is_nan());
 
     let batch = solver.solve_batch(&[&y, &y], None).unwrap();
     assert_eq!(batch.n_obs, 5);
     for demeaned in [batch.demeaned(0), batch.demeaned(1)] {
-        assert!((demeaned[0] + 1.0).abs() < 1e-10);
+        assert!((demeaned[0] + 5.0 / 3.0).abs() < 1e-10);
         assert!(demeaned[1].is_nan());
-        assert!((demeaned[2] - 1.0).abs() < 1e-10);
-        assert!(demeaned[3].abs() < 1e-10);
+        assert!((demeaned[2] - 1.0 / 3.0).abs() < 1e-10);
+        assert!((demeaned[3] - 4.0 / 3.0).abs() < 1e-10);
         assert!(demeaned[4].is_nan());
     }
 }

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -1,8 +1,11 @@
+use std::borrow::Cow;
+
 use super::reparam::SlopeReparam;
-use super::{CoefficientAddress, CoefficientLayout};
+use super::{CoefficientAddress, CoefficientLayout, Solver};
 use crate::channel::Channel;
-use crate::config::{ScalingConfig, DEFAULT_DENSE_SCHUR_THRESHOLD};
+use crate::config::{PreconditionerConfig, ScalingConfig, DEFAULT_DENSE_SCHUR_THRESHOLD};
 use crate::domain::{build_local_domains, Design, Grounding, MatrixForm};
+use crate::observation::ObservationFrame;
 use crate::Effect;
 
 /// DGP kept in lockstep with `surplus_component_sampled_matches_exact_reduction`
@@ -87,5 +90,35 @@ fn coefficient_layout_translates_addresses_both_ways() {
     // `address` inverts `index` for every flat slot.
     for i in 0..layout.n_dofs() {
         assert_eq!(layout.index(layout.address(i).expect("in range")), Some(i));
+    }
+}
+
+#[test]
+fn solver_filters_caller_rhs_and_restores_removed_rows_as_nan() {
+    let frame = ObservationFrame::new(vec![Cow::Owned(vec![0, 1, 0, 1, 2])], Vec::new()).unwrap();
+    let mut design = Design::from_frame_unsorted(frame).unwrap();
+    design.remap_internal_rows(&[3, 0, 2]).unwrap();
+
+    let solver = Solver::new(design, None, PreconditionerConfig::default()).unwrap();
+    let y = [1.0, f64::NAN, 3.0, 4.0, f64::NAN];
+    let result = solver.solve(&y, None).unwrap();
+
+    assert_eq!(solver.n_obs(), 5);
+    assert_eq!(solver.n_retained_obs(), 3);
+    assert_eq!(result.demeaned.len(), 5);
+    assert!((result.demeaned[0] + 1.0).abs() < 1e-10);
+    assert!(result.demeaned[1].is_nan());
+    assert!((result.demeaned[2] - 1.0).abs() < 1e-10);
+    assert!(result.demeaned[3].abs() < 1e-10);
+    assert!(result.demeaned[4].is_nan());
+
+    let batch = solver.solve_batch(&[&y, &y], None).unwrap();
+    assert_eq!(batch.n_obs, 5);
+    for demeaned in [batch.demeaned(0), batch.demeaned(1)] {
+        assert!((demeaned[0] + 1.0).abs() < 1e-10);
+        assert!(demeaned[1].is_nan());
+        assert!((demeaned[2] - 1.0).abs() < 1e-10);
+        assert!(demeaned[3].abs() < 1e-10);
+        assert!(demeaned[4].is_nan());
     }
 }

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -97,7 +97,14 @@ fn coefficient_layout_translates_addresses_both_ways() {
 #[test]
 fn solver_filters_caller_rhs_and_restores_removed_rows_as_nan() {
     let frame = ObservationFrame::new(vec![vec![0u32, 1, 0, 0, 2].into()], Vec::new()).unwrap();
-    let design = Design::from_frame(frame, DesignOptions::new(true, None)).unwrap();
+    let design = Design::from_frame(
+        frame,
+        DesignOptions {
+            drop_singletons: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     let solver = Solver::new(design, PreconditionerConfig::default()).unwrap();
     let y = [1.0, f64::NAN, 3.0, 4.0, f64::NAN];

--- a/crates/within/tests/api_pinning.rs
+++ b/crates/within/tests/api_pinning.rs
@@ -2,10 +2,20 @@
 //! argument shapes: if any call form below stops compiling, the public surface shifted.
 
 use ndarray::Array2;
-use within::{solve, solve_batch, LsmrOptions, PreconditionerConfig, Solver};
+use within::{
+    solve, solve_batch, Design, DesignOptions, IntoDesign, LsmrOptions, PreconditionerConfig,
+    Solver,
+};
 
 fn cats() -> Array2<u32> {
     Array2::from_shape_vec((4, 2), vec![0u32, 0, 1, 1, 2, 0, 3, 1]).expect("cats")
+}
+
+fn design(categories: &Array2<u32>) -> Design<'_> {
+    categories
+        .view()
+        .into_design(DesignOptions::default())
+        .expect("design")
 }
 
 #[test]
@@ -14,29 +24,29 @@ fn precond_input_call_shapes_compile() {
     let cfg = PreconditionerConfig::default();
 
     // Obtain a prebuilt preconditioner through the public path.
-    let setup = Solver::new(categories.view(), None, &cfg).unwrap();
+    let setup = Solver::new(design(&categories), &cfg).unwrap();
     let prec = setup
         .preconditioner()
         .expect("default solver has a preconditioner")
         .clone();
 
     // Shape 1: bare `None` — resolves through `From<Option<&PreconditionerConfig>>`.
-    let _ = Solver::new(categories.view(), None, None).expect("None form");
+    let _ = Solver::new(design(&categories), None).expect("None form");
 
     // Shape 2: `&PreconditionerConfig` — resolves through `From<&PreconditionerConfig>`.
-    let _ = Solver::new(categories.view(), None, &cfg).expect("&Cfg form");
+    let _ = Solver::new(design(&categories), &cfg).expect("&Cfg form");
 
     // Shape 3: `Option<&PreconditionerConfig>` — explicit `Some(&cfg)`.
-    let _ = Solver::new(categories.view(), None, Some(&cfg)).expect("Some(&Cfg) form");
+    let _ = Solver::new(design(&categories), Some(&cfg)).expect("Some(&Cfg) form");
 
     // Shape 4: owned `Preconditioner` — resolves through `From<Preconditioner>`.
-    let _ = Solver::new(categories.view(), None, prec.clone()).expect("owned Prec form");
+    let _ = Solver::new(design(&categories), prec.clone()).expect("owned Prec form");
 
     // Shape 5: `&Preconditioner` — resolves through `From<&Preconditioner>` (cheap clone).
-    let _ = Solver::new(categories.view(), None, &prec).expect("&Prec form");
+    let _ = Solver::new(design(&categories), &prec).expect("&Prec form");
 
     // Shape 6: owned `Preconditioner` again, consumed last so `prec` is moved here.
-    let _ = Solver::new(categories.view(), None, prec).expect("owned Prec form (move)");
+    let _ = Solver::new(design(&categories), prec).expect("owned Prec form (move)");
 }
 
 #[test]
@@ -45,7 +55,7 @@ fn precond_input_owned_config_form() {
     // Kept separate so the main shape sweep stays focused on the &/None variants.
     let categories = cats();
     let cfg = PreconditionerConfig::default();
-    let _ = Solver::new(categories.view(), None, cfg).expect("owned Cfg form");
+    let _ = Solver::new(design(&categories), cfg).expect("owned Cfg form");
 }
 
 #[test]
@@ -55,100 +65,29 @@ fn solve_free_function_precond_call_shapes_compile() {
     let lsmr = LsmrOptions::default();
     let cfg = PreconditionerConfig::default();
 
-    let setup = Solver::new(categories.view(), None, &cfg).unwrap();
+    let setup = Solver::new(design(&categories), &cfg).unwrap();
     let prec = setup
         .preconditioner()
         .expect("default solver has a preconditioner")
         .clone();
 
-    let _ = solve(categories.view(), Default::default(), &y, None, &lsmr, None).expect("None form");
-    let _ = solve(categories.view(), Default::default(), &y, None, &lsmr, &cfg).expect("&Cfg form");
-    let _ = solve(
-        categories.view(),
-        Default::default(),
-        &y,
-        None,
-        &lsmr,
-        Some(&cfg),
-    )
-    .expect("Some(&Cfg) form");
-    let _ = solve(
-        categories.view(),
-        Default::default(),
-        &y,
-        None,
-        &lsmr,
-        prec.clone(),
-    )
-    .expect("owned Prec form");
-    let _ = solve(
-        categories.view(),
-        Default::default(),
-        &y,
-        None,
-        &lsmr,
-        &prec,
-    )
-    .expect("&Prec form");
-    let _ = solve(
-        categories.view(),
-        Default::default(),
-        &y,
-        None,
-        &lsmr,
-        cfg.clone(),
-    )
-    .expect("owned Cfg form");
+    let _ = solve(design(&categories), &y, &lsmr, None).expect("None form");
+    let _ = solve(design(&categories), &y, &lsmr, &cfg).expect("&Cfg form");
+    let _ = solve(design(&categories), &y, &lsmr, Some(&cfg)).expect("Some(&Cfg) form");
+    let _ = solve(design(&categories), &y, &lsmr, prec.clone()).expect("owned Prec form");
+    let _ = solve(design(&categories), &y, &lsmr, &prec).expect("&Prec form");
+    let _ = solve(design(&categories), &y, &lsmr, cfg.clone()).expect("owned Cfg form");
 
     // solve_batch accepts the same shapes.
     let ys: Vec<&[f64]> = vec![&y];
-    let _ = solve_batch(
-        categories.view(),
-        Default::default(),
-        &ys,
-        None,
-        &lsmr,
-        None,
-    )
-    .expect("batch None form");
-    let _ = solve_batch(
-        categories.view(),
-        Default::default(),
-        &ys,
-        None,
-        &lsmr,
-        &cfg,
-    )
-    .expect("batch &Cfg form");
-    let _ = solve_batch(
-        categories.view(),
-        Default::default(),
-        &ys,
-        None,
-        &lsmr,
-        Some(&cfg),
-    )
-    .expect("batch Some(&Cfg) form");
-    let _ = solve_batch(
-        categories.view(),
-        Default::default(),
-        &ys,
-        None,
-        &lsmr,
-        prec.clone(),
-    )
-    .expect("batch owned Prec form");
-    let _ = solve_batch(
-        categories.view(),
-        Default::default(),
-        &ys,
-        None,
-        &lsmr,
-        &prec,
-    )
-    .expect("batch &Prec form");
-    let _ = solve_batch(categories.view(), Default::default(), &ys, None, &lsmr, cfg)
-        .expect("batch owned Cfg form");
+    let _ = solve_batch(design(&categories), &ys, &lsmr, None).expect("batch None form");
+    let _ = solve_batch(design(&categories), &ys, &lsmr, &cfg).expect("batch &Cfg form");
+    let _ =
+        solve_batch(design(&categories), &ys, &lsmr, Some(&cfg)).expect("batch Some(&Cfg) form");
+    let _ =
+        solve_batch(design(&categories), &ys, &lsmr, prec.clone()).expect("batch owned Prec form");
+    let _ = solve_batch(design(&categories), &ys, &lsmr, &prec).expect("batch &Prec form");
+    let _ = solve_batch(design(&categories), &ys, &lsmr, cfg).expect("batch owned Cfg form");
 }
 
 #[test]
@@ -159,10 +98,14 @@ fn solver_new_weights_call_shapes_compile() {
     // Bare `None` — infers, because `weights` is the concrete `Option<Vec<f64>>`
     // (no turbofish needed). The persistent solver owns its weights; borrow-based
     // one-shot weighting lives on the free `solve` function instead.
-    let _ = Solver::new(categories.view(), None, None).expect("None weights");
+    let _ = Solver::new(design(&categories), None).expect("None weights");
 
     // Owned `Vec<f64>` weights — moved into the solver.
-    let _ = Solver::new(categories.view(), Some(w_vec), None).expect("Vec<f64> weights");
+    let weighted = categories
+        .view()
+        .into_design(DesignOptions::default().weights(w_vec))
+        .expect("weighted design");
+    let _ = Solver::new(weighted, None).expect("Vec<f64> weights");
 }
 
 #[test]
@@ -186,7 +129,7 @@ fn options_are_optional_and_tuned_additive_builds_from_crate_root() {
         },
         reduction: ReductionStrategy::Auto,
     };
-    let solver = Solver::new(categories.view(), None, tuned).expect("tuned Additive builds");
+    let solver = Solver::new(design(&categories), tuned).expect("tuned Additive builds");
 
     // `None` accepts the default options; `&opts` still works.
     let _ = solver.solve(&y, None).expect("solve, default options");
@@ -197,8 +140,7 @@ fn options_are_optional_and_tuned_additive_builds_from_crate_root() {
         .expect("solve_batch, default options");
 
     // Free functions accept `None` options too (previously `&LsmrOptions::default()`).
-    let _ = solve(categories.view(), Default::default(), &y, None, None, None)
-        .expect("free solve, None options");
-    let _ = solve_batch(categories.view(), Default::default(), &ys, None, None, None)
-        .expect("free solve_batch, None options");
+    let _ = solve(design(&categories), &y, None, None).expect("free solve, None options");
+    let _ =
+        solve_batch(design(&categories), &ys, None, None).expect("free solve_batch, None options");
 }

--- a/crates/within/tests/api_pinning.rs
+++ b/crates/within/tests/api_pinning.rs
@@ -3,8 +3,7 @@
 
 use ndarray::Array2;
 use within::{
-    solve, solve_batch, Design, DesignOptions, IntoDesign, LsmrOptions, PreconditionerConfig,
-    Solver,
+    solve, solve_batch, Design, DesignOptions, LsmrOptions, PreconditionerConfig, Solver,
 };
 
 fn cats() -> Array2<u32> {
@@ -12,10 +11,7 @@ fn cats() -> Array2<u32> {
 }
 
 fn design(categories: &Array2<u32>) -> Design<'_> {
-    categories
-        .view()
-        .into_design(DesignOptions::default())
-        .expect("design")
+    Design::from_categories(categories.view(), DesignOptions::default()).expect("design")
 }
 
 #[test]
@@ -101,10 +97,11 @@ fn solver_new_weights_call_shapes_compile() {
     let _ = Solver::new(design(&categories), None).expect("None weights");
 
     // Owned `Vec<f64>` weights — moved into the solver.
-    let weighted = categories
-        .view()
-        .into_design(DesignOptions::default().weights(w_vec))
-        .expect("weighted design");
+    let weighted = Design::from_categories(
+        categories.view(),
+        DesignOptions::new(false, Some(w_vec.into())),
+    )
+    .expect("weighted design");
     let _ = Solver::new(weighted, None).expect("Vec<f64> weights");
 }
 

--- a/crates/within/tests/api_pinning.rs
+++ b/crates/within/tests/api_pinning.rs
@@ -61,23 +61,94 @@ fn solve_free_function_precond_call_shapes_compile() {
         .expect("default solver has a preconditioner")
         .clone();
 
-    let _ = solve(categories.view(), &y, None, &lsmr, None).expect("None form");
-    let _ = solve(categories.view(), &y, None, &lsmr, &cfg).expect("&Cfg form");
-    let _ = solve(categories.view(), &y, None, &lsmr, Some(&cfg)).expect("Some(&Cfg) form");
-    let _ = solve(categories.view(), &y, None, &lsmr, prec.clone()).expect("owned Prec form");
-    let _ = solve(categories.view(), &y, None, &lsmr, &prec).expect("&Prec form");
-    let _ = solve(categories.view(), &y, None, &lsmr, cfg.clone()).expect("owned Cfg form");
+    let _ = solve(categories.view(), Default::default(), &y, None, &lsmr, None).expect("None form");
+    let _ = solve(categories.view(), Default::default(), &y, None, &lsmr, &cfg).expect("&Cfg form");
+    let _ = solve(
+        categories.view(),
+        Default::default(),
+        &y,
+        None,
+        &lsmr,
+        Some(&cfg),
+    )
+    .expect("Some(&Cfg) form");
+    let _ = solve(
+        categories.view(),
+        Default::default(),
+        &y,
+        None,
+        &lsmr,
+        prec.clone(),
+    )
+    .expect("owned Prec form");
+    let _ = solve(
+        categories.view(),
+        Default::default(),
+        &y,
+        None,
+        &lsmr,
+        &prec,
+    )
+    .expect("&Prec form");
+    let _ = solve(
+        categories.view(),
+        Default::default(),
+        &y,
+        None,
+        &lsmr,
+        cfg.clone(),
+    )
+    .expect("owned Cfg form");
 
     // solve_batch accepts the same shapes.
     let ys: Vec<&[f64]> = vec![&y];
-    let _ = solve_batch(categories.view(), &ys, None, &lsmr, None).expect("batch None form");
-    let _ = solve_batch(categories.view(), &ys, None, &lsmr, &cfg).expect("batch &Cfg form");
-    let _ = solve_batch(categories.view(), &ys, None, &lsmr, Some(&cfg))
-        .expect("batch Some(&Cfg) form");
-    let _ = solve_batch(categories.view(), &ys, None, &lsmr, prec.clone())
-        .expect("batch owned Prec form");
-    let _ = solve_batch(categories.view(), &ys, None, &lsmr, &prec).expect("batch &Prec form");
-    let _ = solve_batch(categories.view(), &ys, None, &lsmr, cfg).expect("batch owned Cfg form");
+    let _ = solve_batch(
+        categories.view(),
+        Default::default(),
+        &ys,
+        None,
+        &lsmr,
+        None,
+    )
+    .expect("batch None form");
+    let _ = solve_batch(
+        categories.view(),
+        Default::default(),
+        &ys,
+        None,
+        &lsmr,
+        &cfg,
+    )
+    .expect("batch &Cfg form");
+    let _ = solve_batch(
+        categories.view(),
+        Default::default(),
+        &ys,
+        None,
+        &lsmr,
+        Some(&cfg),
+    )
+    .expect("batch Some(&Cfg) form");
+    let _ = solve_batch(
+        categories.view(),
+        Default::default(),
+        &ys,
+        None,
+        &lsmr,
+        prec.clone(),
+    )
+    .expect("batch owned Prec form");
+    let _ = solve_batch(
+        categories.view(),
+        Default::default(),
+        &ys,
+        None,
+        &lsmr,
+        &prec,
+    )
+    .expect("batch &Prec form");
+    let _ = solve_batch(categories.view(), Default::default(), &ys, None, &lsmr, cfg)
+        .expect("batch owned Cfg form");
 }
 
 #[test]
@@ -126,7 +197,8 @@ fn options_are_optional_and_tuned_additive_builds_from_crate_root() {
         .expect("solve_batch, default options");
 
     // Free functions accept `None` options too (previously `&LsmrOptions::default()`).
-    let _ = solve(categories.view(), &y, None, None, None).expect("free solve, None options");
-    let _ = solve_batch(categories.view(), &ys, None, None, None)
+    let _ = solve(categories.view(), Default::default(), &y, None, None, None)
+        .expect("free solve, None options");
+    let _ = solve_batch(categories.view(), Default::default(), &ys, None, None, None)
         .expect("free solve_batch, None options");
 }

--- a/crates/within/tests/api_pinning.rs
+++ b/crates/within/tests/api_pinning.rs
@@ -15,6 +15,19 @@ fn design(categories: &Array2<u32>) -> Design<'_> {
 }
 
 #[test]
+fn design_options_fields_are_public() {
+    let options = DesignOptions {
+        drop_singletons: true,
+        weights: Some(vec![1.0, 2.0, 3.0].into()),
+    };
+
+    assert!(options.drop_singletons);
+    assert_eq!(options.weights.as_deref(), Some(&[1.0, 2.0, 3.0][..]));
+    assert!(options.drop_singletons());
+    assert_eq!(options.weights(), Some(&[1.0, 2.0, 3.0][..]));
+}
+
+#[test]
 fn precond_input_call_shapes_compile() {
     let categories = cats();
     let cfg = PreconditionerConfig::default();
@@ -99,7 +112,10 @@ fn solver_new_weights_call_shapes_compile() {
     // Owned `Vec<f64>` weights — moved into the solver.
     let weighted = Design::from_categories(
         categories.view(),
-        DesignOptions::new(false, Some(w_vec.into())),
+        DesignOptions {
+            weights: Some(w_vec.into()),
+            ..Default::default()
+        },
     )
     .expect("weighted design");
     let _ = Solver::new(weighted, None).expect("Vec<f64> weights");

--- a/crates/within/tests/common/orchestrate_helpers.rs
+++ b/crates/within/tests/common/orchestrate_helpers.rs
@@ -2,7 +2,7 @@
 
 use ndarray::Array2;
 use within::observation::ObservationFrame;
-use within::{Design, SolveResult};
+use within::{Design, DesignOptions, SolveResult};
 
 /// The canonical 2-factor, 5-observation categorical structure used across the
 /// orchestration tests. `categories[f][i]` is observation `i`'s level in factor `f`.
@@ -25,7 +25,7 @@ pub fn make_test_design() -> Design<'static> {
 pub fn make_design(categories: Vec<Vec<u32>>) -> Result<Design<'static>, within::BuildError> {
     let frame =
         ObservationFrame::new(categories.into_iter().map(Into::into).collect(), Vec::new())?;
-    Design::from_frame(frame)
+    Design::from_frame(frame, DesignOptions::default())
 }
 
 /// Deterministic, non-trivial RHS sized to the design's observation count.

--- a/crates/within/tests/domain.rs
+++ b/crates/within/tests/domain.rs
@@ -40,7 +40,8 @@ fn test_three_factor_design_solve_converges() {
         ..LsmrOptions::default()
     };
     let precond = PreconditionerConfig::default();
-    let result = solve(cats.view(), &y, None, &params, &precond).expect("solve should not error");
+    let result = solve(cats.view(), Default::default(), &y, None, &params, &precond)
+        .expect("solve should not error");
 
     assert!(
         result.converged,
@@ -78,7 +79,8 @@ fn test_disconnected_design_larger_converges() {
         ..LsmrOptions::default()
     };
     let precond = PreconditionerConfig::default();
-    let result = solve(cats.view(), &y, None, &params, &precond).expect("solve should not error");
+    let result = solve(cats.view(), Default::default(), &y, None, &params, &precond)
+        .expect("solve should not error");
 
     assert!(
         result.converged,
@@ -110,7 +112,8 @@ fn test_disconnected_design_solve_converges() {
         ..LsmrOptions::default()
     };
     let precond = PreconditionerConfig::default();
-    let result = solve(cats.view(), &y, None, &params, &precond).expect("solve should not error");
+    let result = solve(cats.view(), Default::default(), &y, None, &params, &precond)
+        .expect("solve should not error");
 
     assert!(
         result.converged,
@@ -155,7 +158,8 @@ fn test_single_factor_design_solve_without_precond() {
         maxiter: 500,
         ..LsmrOptions::default()
     };
-    let result = solve(cats.view(), &y, None, &params, None).expect("solve should not error");
+    let result = solve(cats.view(), Default::default(), &y, None, &params, None)
+        .expect("solve should not error");
 
     assert!(
         result.converged,

--- a/crates/within/tests/domain.rs
+++ b/crates/within/tests/domain.rs
@@ -3,7 +3,7 @@
 //! and disconnected bipartite structure.
 
 use within::observation::ObservationFrame;
-use within::Design;
+use within::{Design, DesignOptions, IntoDesign};
 
 // Three-factor design: shared DOFs across factor pairs force NonUniform
 // partition weights; verified via the public solve API.
@@ -40,8 +40,11 @@ fn test_three_factor_design_solve_converges() {
         ..LsmrOptions::default()
     };
     let precond = PreconditionerConfig::default();
-    let result = solve(cats.view(), Default::default(), &y, None, &params, &precond)
-        .expect("solve should not error");
+    let design = cats
+        .view()
+        .into_design(DesignOptions::default())
+        .expect("design");
+    let result = solve(design, &y, &params, &precond).expect("solve should not error");
 
     assert!(
         result.converged,
@@ -79,8 +82,11 @@ fn test_disconnected_design_larger_converges() {
         ..LsmrOptions::default()
     };
     let precond = PreconditionerConfig::default();
-    let result = solve(cats.view(), Default::default(), &y, None, &params, &precond)
-        .expect("solve should not error");
+    let design = cats
+        .view()
+        .into_design(DesignOptions::default())
+        .expect("design");
+    let result = solve(design, &y, &params, &precond).expect("solve should not error");
 
     assert!(
         result.converged,
@@ -112,8 +118,11 @@ fn test_disconnected_design_solve_converges() {
         ..LsmrOptions::default()
     };
     let precond = PreconditionerConfig::default();
-    let result = solve(cats.view(), Default::default(), &y, None, &params, &precond)
-        .expect("solve should not error");
+    let design = cats
+        .view()
+        .into_design(DesignOptions::default())
+        .expect("design");
+    let result = solve(design, &y, &params, &precond).expect("solve should not error");
 
     assert!(
         result.converged,
@@ -158,8 +167,11 @@ fn test_single_factor_design_solve_without_precond() {
         maxiter: 500,
         ..LsmrOptions::default()
     };
-    let result = solve(cats.view(), Default::default(), &y, None, &params, None)
-        .expect("solve should not error");
+    let design = cats
+        .view()
+        .into_design(DesignOptions::default())
+        .expect("design");
+    let result = solve(design, &y, &params, None).expect("solve should not error");
 
     assert!(
         result.converged,
@@ -194,22 +206,19 @@ fn test_intercept_only_effects_match_categories_bitwise() {
             .expect("frame"),
     )
     .expect("categories design");
-    let cat = Solver::new(categories, None, &precond)
+    let cat = Solver::new(categories, &precond)
         .expect("categories solver")
         .solve(&y, &params)
         .expect("categories solve");
 
-    let eff = Solver::new(
-        vec![
-            Effect::new(&col0, true, []).expect("effect 0"),
-            Effect::new(&col1, true, []).expect("effect 1"),
-        ],
-        None,
-        &precond,
-    )
-    .expect("effect solver")
-    .solve(&y, &params)
-    .expect("effect solve");
+    let effects = vec![
+        Effect::new(&col0, true, []).expect("effect 0"),
+        Effect::new(&col1, true, []).expect("effect 1"),
+    ];
+    let eff = Solver::new(Design::new(effects).expect("effect design"), &precond)
+        .expect("effect solver")
+        .solve(&y, &params)
+        .expect("effect solve");
 
     // Bit-identity is only meaningful if both solves actually converged:
     // `Solver::solve` returns `Ok` even at `maxiter`, so without this the
@@ -258,7 +267,11 @@ fn test_slope_chain_design_converges_fast() {
         Effect::new(&worker, true, [&z[..]]).expect("slope effect"),
         Effect::new(&firm, true, []).expect("plain effect"),
     ];
-    let solver = Solver::new(effects, None, PreconditionerConfig::default()).expect("solver build");
+    let solver = Solver::new(
+        Design::new(effects).expect("design"),
+        PreconditionerConfig::default(),
+    )
+    .expect("solver build");
     let params = LsmrOptions {
         tol: 1e-8,
         maxiter: 500,

--- a/crates/within/tests/domain.rs
+++ b/crates/within/tests/domain.rs
@@ -3,7 +3,7 @@
 //! and disconnected bipartite structure.
 
 use within::observation::ObservationFrame;
-use within::{Design, DesignOptions, IntoDesign};
+use within::{Design, DesignOptions};
 
 // Three-factor design: shared DOFs across factor pairs force NonUniform
 // partition weights; verified via the public solve API.
@@ -20,7 +20,7 @@ fn test_three_factor_design_solve_converges() {
 
     let frame = ObservationFrame::new(vec![fa.into(), fb.into(), fc.into()], Vec::new())
         .expect("valid 3-factor frame");
-    let dm = Design::from_frame(frame).expect("valid 3-factor design");
+    let dm = Design::from_frame(frame, DesignOptions::default()).expect("valid 3-factor design");
 
     assert_eq!(dm.n_factors(), 3);
 
@@ -40,10 +40,7 @@ fn test_three_factor_design_solve_converges() {
         ..LsmrOptions::default()
     };
     let precond = PreconditionerConfig::default();
-    let design = cats
-        .view()
-        .into_design(DesignOptions::default())
-        .expect("design");
+    let design = Design::from_categories(cats.view(), DesignOptions::default()).expect("design");
     let result = solve(design, &y, &params, &precond).expect("solve should not error");
 
     assert!(
@@ -82,10 +79,7 @@ fn test_disconnected_design_larger_converges() {
         ..LsmrOptions::default()
     };
     let precond = PreconditionerConfig::default();
-    let design = cats
-        .view()
-        .into_design(DesignOptions::default())
-        .expect("design");
+    let design = Design::from_categories(cats.view(), DesignOptions::default()).expect("design");
     let result = solve(design, &y, &params, &precond).expect("solve should not error");
 
     assert!(
@@ -118,10 +112,7 @@ fn test_disconnected_design_solve_converges() {
         ..LsmrOptions::default()
     };
     let precond = PreconditionerConfig::default();
-    let design = cats
-        .view()
-        .into_design(DesignOptions::default())
-        .expect("design");
+    let design = Design::from_categories(cats.view(), DesignOptions::default()).expect("design");
     let result = solve(design, &y, &params, &precond).expect("solve should not error");
 
     assert!(
@@ -139,7 +130,8 @@ fn test_disconnected_design_solve_converges() {
 fn test_single_factor_design_construction() {
     let frame = ObservationFrame::new(vec![vec![0u32, 1, 2, 0, 1].into()], Vec::new())
         .expect("valid frame");
-    let dm = Design::from_frame(frame).expect("valid single-factor design");
+    let dm =
+        Design::from_frame(frame, DesignOptions::default()).expect("valid single-factor design");
 
     assert_eq!(dm.n_factors(), 1, "expected 1 factor");
     assert_eq!(dm.n_dofs(), 3, "expected 3 DOFs (levels 0,1,2)");
@@ -167,10 +159,7 @@ fn test_single_factor_design_solve_without_precond() {
         maxiter: 500,
         ..LsmrOptions::default()
     };
-    let design = cats
-        .view()
-        .into_design(DesignOptions::default())
-        .expect("design");
+    let design = Design::from_categories(cats.view(), DesignOptions::default()).expect("design");
     let result = solve(design, &y, &params, None).expect("solve should not error");
 
     assert!(
@@ -204,6 +193,7 @@ fn test_intercept_only_effects_match_categories_bitwise() {
     let categories = Design::from_frame(
         ObservationFrame::new(vec![col0.clone().into(), col1.clone().into()], Vec::new())
             .expect("frame"),
+        DesignOptions::default(),
     )
     .expect("categories design");
     let cat = Solver::new(categories, &precond)
@@ -215,10 +205,13 @@ fn test_intercept_only_effects_match_categories_bitwise() {
         Effect::new(&col0, true, []).expect("effect 0"),
         Effect::new(&col1, true, []).expect("effect 1"),
     ];
-    let eff = Solver::new(Design::new(effects).expect("effect design"), &precond)
-        .expect("effect solver")
-        .solve(&y, &params)
-        .expect("effect solve");
+    let eff = Solver::new(
+        Design::from_effects(effects, DesignOptions::default()).expect("effect design"),
+        &precond,
+    )
+    .expect("effect solver")
+    .solve(&y, &params)
+    .expect("effect solve");
 
     // Bit-identity is only meaningful if both solves actually converged:
     // `Solver::solve` returns `Ok` even at `maxiter`, so without this the
@@ -268,7 +261,7 @@ fn test_slope_chain_design_converges_fast() {
         Effect::new(&firm, true, []).expect("plain effect"),
     ];
     let solver = Solver::new(
-        Design::new(effects).expect("design"),
+        Design::from_effects(effects, DesignOptions::default()).expect("design"),
         PreconditionerConfig::default(),
     )
     .expect("solver build");

--- a/crates/within/tests/edge_cases.rs
+++ b/crates/within/tests/edge_cases.rs
@@ -1,13 +1,21 @@
-use ndarray::array;
+use ndarray::{array, ArrayView2};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
-use within::{solve, LsmrOptions, PreconditionerConfig, Solver};
+use within::{solve, Design, DesignOptions, IntoDesign, LsmrOptions, PreconditionerConfig, Solver};
 
 #[path = "common/orchestrate_helpers.rs"]
 mod common;
 
 fn additive_precond() -> PreconditionerConfig {
     PreconditionerConfig::default()
+}
+
+fn design<'a>(categories: ArrayView2<'a, u32>, weights: Option<&'a [f64]>) -> Design<'a> {
+    let options = match weights {
+        Some(weights) => DesignOptions::default().weights(weights),
+        None => DesignOptions::default(),
+    };
+    categories.into_design(options).expect("design")
 }
 
 // ---------------------------------------------------------------------------
@@ -23,8 +31,7 @@ fn test_single_observation() {
     let y = vec![5.0f64];
     let params = LsmrOptions::default();
 
-    let result =
-        solve(cats.view(), Default::default(), &y, None, &params, None).expect("single-obs solve");
+    let result = solve(design(cats.view(), None), &y, &params, None).expect("single-obs solve");
     assert!(
         result.x.iter().all(|v| v.is_finite()),
         "non-finite x for single observation"
@@ -50,8 +57,8 @@ fn test_trivial_factor_all_same_level() {
     let params = LsmrOptions::default();
     let precond = additive_precond();
 
-    let result = solve(cats.view(), Default::default(), &y, None, &params, &precond)
-        .expect("trivial-factor solve");
+    let result =
+        solve(design(cats.view(), None), &y, &params, &precond).expect("trivial-factor solve");
     assert!(
         result.converged,
         "solver did not converge with constant factor"
@@ -80,10 +87,8 @@ fn test_zero_weight_additive_preconditioner_returns_zero() {
     let precond = additive_precond();
 
     let result = solve(
-        cats.view(),
-        Default::default(),
+        design(cats.view(), Some(&weights)),
         &y,
-        Some(&weights),
         &LsmrOptions::default(),
         &precond,
     )
@@ -109,10 +114,8 @@ fn test_zero_weight_diagonal_preconditioner_returns_zero() {
     let weights = vec![0.0f64; 5];
 
     let result = solve(
-        cats.view(),
-        Default::default(),
+        design(cats.view(), Some(&weights)),
         &y,
-        Some(&weights),
         &LsmrOptions::default(),
         &PreconditionerConfig::Diagonal,
     )
@@ -137,10 +140,8 @@ fn test_zero_weight_no_preconditioner_returns_zero() {
     let weights = vec![0.0f64; 5];
 
     let result = solve(
-        cats.view(),
-        Default::default(),
+        design(cats.view(), Some(&weights)),
         &y,
-        Some(&weights),
         &LsmrOptions::default(),
         &PreconditionerConfig::Off,
     )
@@ -170,19 +171,15 @@ fn test_diagonal_matches_unpreconditioned_solution() {
     let params = LsmrOptions::default();
 
     let diagonal = solve(
-        cats.view(),
-        Default::default(),
+        design(cats.view(), None),
         &y,
-        None,
         &params,
         &PreconditionerConfig::Diagonal,
     )
     .expect("diagonal solve");
     let unpreconditioned = solve(
-        cats.view(),
-        Default::default(),
+        design(cats.view(), None),
         &y,
-        None,
         &params,
         &PreconditionerConfig::Off,
     )
@@ -206,19 +203,15 @@ fn test_diagonal_matches_unpreconditioned_on_gap_design() {
     let params = LsmrOptions::default();
 
     let diagonal = solve(
-        cats.view(),
-        Default::default(),
+        design(cats.view(), None),
         &y,
-        None,
         &params,
         &PreconditionerConfig::Diagonal,
     )
     .expect("diagonal solve must succeed on a gap design (pseudo-inverse of zero diagonal)");
     let unpreconditioned = solve(
-        cats.view(),
-        Default::default(),
+        design(cats.view(), None),
         &y,
-        None,
         &params,
         &PreconditionerConfig::Off,
     )
@@ -255,7 +248,7 @@ fn test_maxiter_1_partial_result() {
         maxiter: 1,
         ..LsmrOptions::default()
     };
-    let solver = Solver::new(design, None, None).expect("solver build");
+    let solver = Solver::new(design, None).expect("solver build");
     let result = solver.solve(&y, &params).expect("solve with maxiter=1");
 
     // Convergence is not expected (tolerance is unreachable in 1 iteration),
@@ -300,7 +293,7 @@ fn test_large_design_convergence() {
         ..LsmrOptions::default()
     };
     let precond = additive_precond();
-    let solver = Solver::new(design, None, &precond).expect("solver build");
+    let solver = Solver::new(design, &precond).expect("solver build");
     let result = solver.solve(&y, &params).expect("large design solve");
 
     assert!(
@@ -323,7 +316,7 @@ fn test_zero_rhs_zero_solution() {
     let y = vec![0.0f64; design.n_obs()];
 
     let params = LsmrOptions::default();
-    let solver = Solver::new(design, None, None).expect("solver build");
+    let solver = Solver::new(design, None).expect("solver build");
     let result = solver.solve(&y, &params).expect("zero RHS solve");
 
     assert!(result.converged, "zero RHS should trivially converge");
@@ -349,13 +342,10 @@ fn test_uniform_weights_matches_unweighted() {
     let params = LsmrOptions::default();
     let precond = additive_precond();
 
-    let r_unit = solve(cats.view(), Default::default(), &y, None, &params, &precond)
-        .expect("unweighted solve");
+    let r_unit = solve(design(cats.view(), None), &y, &params, &precond).expect("unweighted solve");
     let r_uniform = solve(
-        cats.view(),
-        Default::default(),
+        design(cats.view(), Some(&uniform_weights)),
         &y,
-        Some(&uniform_weights),
         &params,
         &precond,
     )
@@ -386,7 +376,7 @@ fn test_repeated_solve_is_deterministic() {
 
     let params = LsmrOptions::default();
     let precond = additive_precond();
-    let solver = Solver::new(design, None, &precond).expect("solver build");
+    let solver = Solver::new(design, &precond).expect("solver build");
 
     let r1 = solver.solve(&y, &params).expect("first solve");
     let r2 = solver.solve(&y, &params).expect("second solve");

--- a/crates/within/tests/edge_cases.rs
+++ b/crates/within/tests/edge_cases.rs
@@ -1,7 +1,7 @@
 use ndarray::{array, ArrayView2};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
-use within::{solve, Design, DesignOptions, IntoDesign, LsmrOptions, PreconditionerConfig, Solver};
+use within::{solve, Design, DesignOptions, LsmrOptions, PreconditionerConfig, Solver};
 
 #[path = "common/orchestrate_helpers.rs"]
 mod common;
@@ -11,11 +11,8 @@ fn additive_precond() -> PreconditionerConfig {
 }
 
 fn design<'a>(categories: ArrayView2<'a, u32>, weights: Option<&'a [f64]>) -> Design<'a> {
-    let options = match weights {
-        Some(weights) => DesignOptions::default().weights(weights),
-        None => DesignOptions::default(),
-    };
-    categories.into_design(options).expect("design")
+    let options = DesignOptions::new(false, weights.map(Into::into));
+    Design::from_categories(categories, options).expect("design")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/within/tests/edge_cases.rs
+++ b/crates/within/tests/edge_cases.rs
@@ -23,7 +23,8 @@ fn test_single_observation() {
     let y = vec![5.0f64];
     let params = LsmrOptions::default();
 
-    let result = solve(cats.view(), &y, None, &params, None).expect("single-obs solve");
+    let result =
+        solve(cats.view(), Default::default(), &y, None, &params, None).expect("single-obs solve");
     assert!(
         result.x.iter().all(|v| v.is_finite()),
         "non-finite x for single observation"
@@ -49,7 +50,8 @@ fn test_trivial_factor_all_same_level() {
     let params = LsmrOptions::default();
     let precond = additive_precond();
 
-    let result = solve(cats.view(), &y, None, &params, &precond).expect("trivial-factor solve");
+    let result = solve(cats.view(), Default::default(), &y, None, &params, &precond)
+        .expect("trivial-factor solve");
     assert!(
         result.converged,
         "solver did not converge with constant factor"
@@ -79,6 +81,7 @@ fn test_zero_weight_additive_preconditioner_returns_zero() {
 
     let result = solve(
         cats.view(),
+        Default::default(),
         &y,
         Some(&weights),
         &LsmrOptions::default(),
@@ -107,6 +110,7 @@ fn test_zero_weight_diagonal_preconditioner_returns_zero() {
 
     let result = solve(
         cats.view(),
+        Default::default(),
         &y,
         Some(&weights),
         &LsmrOptions::default(),
@@ -134,6 +138,7 @@ fn test_zero_weight_no_preconditioner_returns_zero() {
 
     let result = solve(
         cats.view(),
+        Default::default(),
         &y,
         Some(&weights),
         &LsmrOptions::default(),
@@ -166,14 +171,22 @@ fn test_diagonal_matches_unpreconditioned_solution() {
 
     let diagonal = solve(
         cats.view(),
+        Default::default(),
         &y,
         None,
         &params,
         &PreconditionerConfig::Diagonal,
     )
     .expect("diagonal solve");
-    let unpreconditioned = solve(cats.view(), &y, None, &params, &PreconditionerConfig::Off)
-        .expect("unpreconditioned solve");
+    let unpreconditioned = solve(
+        cats.view(),
+        Default::default(),
+        &y,
+        None,
+        &params,
+        &PreconditionerConfig::Off,
+    )
+    .expect("unpreconditioned solve");
 
     common::assert_solution_finite(&diagonal);
     common::assert_solutions_close(&diagonal.x, &unpreconditioned.x, 1e-6);
@@ -194,14 +207,22 @@ fn test_diagonal_matches_unpreconditioned_on_gap_design() {
 
     let diagonal = solve(
         cats.view(),
+        Default::default(),
         &y,
         None,
         &params,
         &PreconditionerConfig::Diagonal,
     )
     .expect("diagonal solve must succeed on a gap design (pseudo-inverse of zero diagonal)");
-    let unpreconditioned = solve(cats.view(), &y, None, &params, &PreconditionerConfig::Off)
-        .expect("unpreconditioned solve");
+    let unpreconditioned = solve(
+        cats.view(),
+        Default::default(),
+        &y,
+        None,
+        &params,
+        &PreconditionerConfig::Off,
+    )
+    .expect("unpreconditioned solve");
 
     assert!(diagonal.converged, "diagonal solve must converge");
     common::assert_solutions_close(&diagonal.x, &unpreconditioned.x, 1e-6);
@@ -328,9 +349,17 @@ fn test_uniform_weights_matches_unweighted() {
     let params = LsmrOptions::default();
     let precond = additive_precond();
 
-    let r_unit = solve(cats.view(), &y, None, &params, &precond).expect("unweighted solve");
-    let r_uniform = solve(cats.view(), &y, Some(&uniform_weights), &params, &precond)
-        .expect("uniform-weight solve");
+    let r_unit = solve(cats.view(), Default::default(), &y, None, &params, &precond)
+        .expect("unweighted solve");
+    let r_uniform = solve(
+        cats.view(),
+        Default::default(),
+        &y,
+        Some(&uniform_weights),
+        &params,
+        &precond,
+    )
+    .expect("uniform-weight solve");
 
     // Constant scaling of W leaves G and D^T W y proportional, so the solution
     // is identical.

--- a/crates/within/tests/edge_cases.rs
+++ b/crates/within/tests/edge_cases.rs
@@ -11,7 +11,10 @@ fn additive_precond() -> PreconditionerConfig {
 }
 
 fn design<'a>(categories: ArrayView2<'a, u32>, weights: Option<&'a [f64]>) -> Design<'a> {
-    let options = DesignOptions::new(false, weights.map(Into::into));
+    let options = DesignOptions {
+        weights: weights.map(Into::into),
+        ..Default::default()
+    };
     Design::from_categories(categories, options).expect("design")
 }
 

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -4,8 +4,8 @@ use ndarray::Array2;
 use schwarz_precond::SolveError;
 use within::observation::ObservationFrame;
 use within::{
-    solve, solve_batch, BuildError, Design, Effect, LsmrOptions, PreconditionerConfig, Solver,
-    WithinError,
+    solve, solve_batch, BuildError, Design, DesignOptions, Effect, IntoDesign, LsmrOptions,
+    PreconditionerConfig, Solver, WithinError,
 };
 
 // The Display/source()/From plumbing has one wiring check per enum, not per message.
@@ -39,14 +39,15 @@ fn test_observation_count_mismatch_error() {
 
 #[test]
 fn test_weight_count_mismatch_error() {
-    // Weights of wrong length are caught at Solver construction time.
+    // Weights of wrong length are caught at Design construction time.
     let frame = ObservationFrame::new(
         vec![vec![0u32, 1, 2].into(), vec![0u32, 1, 0].into()],
         Vec::new(),
     )
     .expect("frame ok");
-    let design = Design::from_frame(frame).expect("valid design");
-    let result = Solver::new(design, Some(vec![1.0, 2.0]), None);
+    let result = DesignOptions::default()
+        .weights(vec![1.0, 2.0])
+        .from_frame(frame);
     let err = result.expect_err("expected WeightCountMismatch error, got Ok");
     match err {
         BuildError::WeightCountMismatch { .. } => {}
@@ -57,18 +58,8 @@ fn test_weight_count_mismatch_error() {
 #[test]
 fn test_empty_categories_via_solve() {
     let cats = Array2::<u32>::zeros((0, 2));
-    let y: Vec<f64> = vec![];
-    let params = LsmrOptions::default();
-    let precond = PreconditionerConfig::default();
-    let result = solve(cats.view(), Default::default(), &y, None, &params, &precond);
-    assert!(result.is_err());
-    match result.unwrap_err() {
-        WithinError::Build(BuildError::EmptyObservations) => {}
-        other => panic!(
-            "Expected Build(EmptyObservations) via solve(), got: {:?}",
-            other
-        ),
-    }
+    let result = cats.view().into_design(DesignOptions::default());
+    assert!(matches!(result, Err(BuildError::EmptyObservations)));
 }
 
 #[test]
@@ -77,13 +68,21 @@ fn test_preconditioner_dimension_mismatch_error() {
     let big = Array2::from_shape_vec((4, 2), vec![0u32, 0, 1, 1, 2, 0, 3, 1]).expect("big array");
     let small = Array2::from_shape_vec((3, 2), vec![0u32, 0, 1, 1, 0, 0]).expect("small array");
 
-    let big_solver = Solver::new(big.view(), None, None).expect("big solver");
+    let big_design = big
+        .view()
+        .into_design(DesignOptions::default())
+        .expect("big design");
+    let big_solver = Solver::new(big_design, None).expect("big solver");
     let prebuilt = big_solver
         .preconditioner()
         .expect("default solver has a preconditioner")
         .clone();
 
-    let result = Solver::new(small.view(), None, prebuilt);
+    let small_design = small
+        .view()
+        .into_design(DesignOptions::default())
+        .expect("small design");
+    let result = Solver::new(small_design, prebuilt);
     let err = result.expect_err("expected PreconditionerDimensionMismatch, got Ok");
     match err {
         BuildError::PreconditionerDimensionMismatch {
@@ -105,7 +104,11 @@ fn test_non_finite_response_rejected() {
     let precond = PreconditionerConfig::default();
 
     let y = [1.0, f64::NAN, 3.0];
-    match solve(cats.view(), Default::default(), &y, None, &params, &precond).unwrap_err() {
+    let design = cats
+        .view()
+        .into_design(DesignOptions::default())
+        .expect("design");
+    match solve(design, &y, &params, &precond).unwrap_err() {
         WithinError::Solve(SolveError::InvalidInput { message, .. }) => {
             assert!(
                 message.contains("index 1"),
@@ -115,8 +118,13 @@ fn test_non_finite_response_rejected() {
         other => panic!("Expected Solve(InvalidInput) via solve(), got: {other:?}"),
     }
 
-    // The persistent Solver API funnels through the same guard, so it cannot be bypassed.
-    let solver = Solver::new(cats.view(), None, &precond).expect("solver");
+    // The persistent Solver API funnels through the same Solver::solve guard, so
+    // the check cannot be bypassed by constructing a Solver and solving in place.
+    let design = cats
+        .view()
+        .into_design(DesignOptions::default())
+        .expect("design");
+    let solver = Solver::new(design, &precond).expect("solver");
     match solver.solve(&y, &params).unwrap_err() {
         SolveError::InvalidInput { message, .. } => {
             assert!(
@@ -131,10 +139,10 @@ fn test_non_finite_response_rejected() {
     let good = [1.0, 2.0, 3.0];
     let bad = [1.0, 2.0, f64::INFINITY];
     match solve_batch(
-        cats.view(),
-        Default::default(),
+        cats.view()
+            .into_design(DesignOptions::default())
+            .expect("design"),
         &[&good[..], &bad[..]],
-        None,
         &params,
         &precond,
     )
@@ -160,7 +168,7 @@ fn test_collinear_finite_slope_is_unidentified_not_rejected() {
     let params = LsmrOptions::default();
     let precond = PreconditionerConfig::default();
 
-    let r = solve(effects, Default::default(), &y, None, &params, &precond)
+    let r = solve(Design::new(effects).expect("design"), &y, &params, &precond)
         .expect("collinear-but-finite must solve");
     assert!(
         !r.unidentified.is_empty(),
@@ -178,7 +186,7 @@ fn test_solver_accepts_slope_bearing_design_alongside_other_terms() {
     ];
     // Cross-factor routing (#61): slope terms alongside other terms build.
     let design = Design::new(effects).expect("slope design builds");
-    Solver::new(design, None, None).expect("signed routing builds");
+    Solver::new(design, None).expect("signed routing builds");
 }
 
 // One wiring check per enum: From conversions and the transparent source() forward.

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -4,7 +4,7 @@ use ndarray::Array2;
 use schwarz_precond::SolveError;
 use within::observation::ObservationFrame;
 use within::{
-    solve, solve_batch, BuildError, Design, DesignOptions, Effect, IntoDesign, LsmrOptions,
+    solve, solve_batch, BuildError, Design, DesignOptions, Effect, LsmrOptions,
     PreconditionerConfig, Solver, WithinError,
 };
 
@@ -15,7 +15,7 @@ fn test_empty_observations_error() {
     // A zero-row frame is valid; EmptyObservations is raised by Design::from_frame.
     let frame =
         ObservationFrame::new(vec![vec![].into(), vec![].into()], Vec::new()).expect("frame ok");
-    let result = Design::from_frame(frame);
+    let result = Design::from_frame(frame, DesignOptions::default());
     assert!(result.is_err());
     match result.unwrap_err() {
         BuildError::EmptyObservations => {}
@@ -45,9 +45,10 @@ fn test_weight_count_mismatch_error() {
         Vec::new(),
     )
     .expect("frame ok");
-    let result = DesignOptions::default()
-        .weights(vec![1.0, 2.0])
-        .from_frame(frame);
+    let result = Design::from_frame(
+        frame,
+        DesignOptions::new(false, Some(vec![1.0, 2.0].into())),
+    );
     let err = result.expect_err("expected WeightCountMismatch error, got Ok");
     match err {
         BuildError::WeightCountMismatch { .. } => {}
@@ -58,7 +59,7 @@ fn test_weight_count_mismatch_error() {
 #[test]
 fn test_empty_categories_via_solve() {
     let cats = Array2::<u32>::zeros((0, 2));
-    let result = cats.view().into_design(DesignOptions::default());
+    let result = Design::from_categories(cats.view(), DesignOptions::default());
     assert!(matches!(result, Err(BuildError::EmptyObservations)));
 }
 
@@ -68,20 +69,16 @@ fn test_preconditioner_dimension_mismatch_error() {
     let big = Array2::from_shape_vec((4, 2), vec![0u32, 0, 1, 1, 2, 0, 3, 1]).expect("big array");
     let small = Array2::from_shape_vec((3, 2), vec![0u32, 0, 1, 1, 0, 0]).expect("small array");
 
-    let big_design = big
-        .view()
-        .into_design(DesignOptions::default())
-        .expect("big design");
+    let big_design =
+        Design::from_categories(big.view(), DesignOptions::default()).expect("big design");
     let big_solver = Solver::new(big_design, None).expect("big solver");
     let prebuilt = big_solver
         .preconditioner()
         .expect("default solver has a preconditioner")
         .clone();
 
-    let small_design = small
-        .view()
-        .into_design(DesignOptions::default())
-        .expect("small design");
+    let small_design =
+        Design::from_categories(small.view(), DesignOptions::default()).expect("small design");
     let result = Solver::new(small_design, prebuilt);
     let err = result.expect_err("expected PreconditionerDimensionMismatch, got Ok");
     match err {
@@ -104,10 +101,7 @@ fn test_non_finite_response_rejected() {
     let precond = PreconditionerConfig::default();
 
     let y = [1.0, f64::NAN, 3.0];
-    let design = cats
-        .view()
-        .into_design(DesignOptions::default())
-        .expect("design");
+    let design = Design::from_categories(cats.view(), DesignOptions::default()).expect("design");
     match solve(design, &y, &params, &precond).unwrap_err() {
         WithinError::Solve(SolveError::InvalidInput { message, .. }) => {
             assert!(
@@ -120,10 +114,7 @@ fn test_non_finite_response_rejected() {
 
     // The persistent Solver API funnels through the same Solver::solve guard, so
     // the check cannot be bypassed by constructing a Solver and solving in place.
-    let design = cats
-        .view()
-        .into_design(DesignOptions::default())
-        .expect("design");
+    let design = Design::from_categories(cats.view(), DesignOptions::default()).expect("design");
     let solver = Solver::new(design, &precond).expect("solver");
     match solver.solve(&y, &params).unwrap_err() {
         SolveError::InvalidInput { message, .. } => {
@@ -139,9 +130,7 @@ fn test_non_finite_response_rejected() {
     let good = [1.0, 2.0, 3.0];
     let bad = [1.0, 2.0, f64::INFINITY];
     match solve_batch(
-        cats.view()
-            .into_design(DesignOptions::default())
-            .expect("design"),
+        Design::from_categories(cats.view(), DesignOptions::default()).expect("design"),
         &[&good[..], &bad[..]],
         &params,
         &precond,
@@ -168,8 +157,13 @@ fn test_collinear_finite_slope_is_unidentified_not_rejected() {
     let params = LsmrOptions::default();
     let precond = PreconditionerConfig::default();
 
-    let r = solve(Design::new(effects).expect("design"), &y, &params, &precond)
-        .expect("collinear-but-finite must solve");
+    let r = solve(
+        Design::from_effects(effects, DesignOptions::default()).expect("design"),
+        &y,
+        &params,
+        &precond,
+    )
+    .expect("collinear-but-finite must solve");
     assert!(
         !r.unidentified.is_empty(),
         "a duplicated finite slope must report an unidentified direction"
@@ -185,7 +179,8 @@ fn test_solver_accepts_slope_bearing_design_alongside_other_terms() {
         within::Effect::new(&levels, true, [&slope[..]]).expect("slope effect"),
     ];
     // Cross-factor routing (#61): slope terms alongside other terms build.
-    let design = Design::new(effects).expect("slope design builds");
+    let design =
+        Design::from_effects(effects, DesignOptions::default()).expect("slope design builds");
     Solver::new(design, None).expect("signed routing builds");
 }
 

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -47,7 +47,10 @@ fn test_weight_count_mismatch_error() {
     .expect("frame ok");
     let result = Design::from_frame(
         frame,
-        DesignOptions::new(false, Some(vec![1.0, 2.0].into())),
+        DesignOptions {
+            weights: Some(vec![1.0, 2.0].into()),
+            ..Default::default()
+        },
     );
     let err = result.expect_err("expected WeightCountMismatch error, got Ok");
     match err {

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -60,7 +60,7 @@ fn test_empty_categories_via_solve() {
     let y: Vec<f64> = vec![];
     let params = LsmrOptions::default();
     let precond = PreconditionerConfig::default();
-    let result = solve(cats.view(), &y, None, &params, &precond);
+    let result = solve(cats.view(), Default::default(), &y, None, &params, &precond);
     assert!(result.is_err());
     match result.unwrap_err() {
         WithinError::Build(BuildError::EmptyObservations) => {}
@@ -105,7 +105,7 @@ fn test_non_finite_response_rejected() {
     let precond = PreconditionerConfig::default();
 
     let y = [1.0, f64::NAN, 3.0];
-    match solve(cats.view(), &y, None, &params, &precond).unwrap_err() {
+    match solve(cats.view(), Default::default(), &y, None, &params, &precond).unwrap_err() {
         WithinError::Solve(SolveError::InvalidInput { message, .. }) => {
             assert!(
                 message.contains("index 1"),
@@ -130,7 +130,16 @@ fn test_non_finite_response_rejected() {
     // solve_batch funnels every column through Solver::solve; the bad value is in the 2nd RHS.
     let good = [1.0, 2.0, 3.0];
     let bad = [1.0, 2.0, f64::INFINITY];
-    match solve_batch(cats.view(), &[&good[..], &bad[..]], None, &params, &precond).unwrap_err() {
+    match solve_batch(
+        cats.view(),
+        Default::default(),
+        &[&good[..], &bad[..]],
+        None,
+        &params,
+        &precond,
+    )
+    .unwrap_err()
+    {
         WithinError::Solve(SolveError::InvalidInput { message, .. }) => {
             assert!(
                 message.contains("index 2"),
@@ -151,7 +160,8 @@ fn test_collinear_finite_slope_is_unidentified_not_rejected() {
     let params = LsmrOptions::default();
     let precond = PreconditionerConfig::default();
 
-    let r = solve(effects, &y, None, &params, &precond).expect("collinear-but-finite must solve");
+    let r = solve(effects, Default::default(), &y, None, &params, &precond)
+        .expect("collinear-but-finite must solve");
     assert!(
         !r.unidentified.is_empty(),
         "a duplicated finite slope must report an unidentified direction"

--- a/crates/within/tests/ingest.rs
+++ b/crates/within/tests/ingest.rs
@@ -43,6 +43,7 @@ fn f_order_view_matches_owned_columns() {
 
     let result_view = solve(
         cats_f.view(),
+        Default::default(),
         &y,
         None,
         &default_params(),
@@ -74,10 +75,18 @@ fn c_order_view_matches_f_order_bitwise() {
         f
     };
 
-    let result_c =
-        solve(cats.view(), &y, None, &default_params(), additive_precond()).expect("C-order solve");
+    let result_c = solve(
+        cats.view(),
+        Default::default(),
+        &y,
+        None,
+        &default_params(),
+        additive_precond(),
+    )
+    .expect("C-order solve");
     let result_f = solve(
         cats_f.view(),
+        Default::default(),
         &y,
         None,
         &default_params(),
@@ -105,8 +114,15 @@ fn column_reversed_view_ingests_in_logical_order() {
     assert!(reversed.strides()[1] < 1, "column stride must be negative");
 
     let y = vec![1.0, 2.0, 3.0, 4.0, 5.0];
-    let result_rev =
-        solve(reversed, &y, None, &default_params(), additive_precond()).expect("reversed solve");
+    let result_rev = solve(
+        reversed,
+        Default::default(),
+        &y,
+        None,
+        &default_params(),
+        additive_precond(),
+    )
+    .expect("reversed solve");
 
     // Oracle: the same columns handed over owned, in swapped order.
     let design =
@@ -124,6 +140,7 @@ fn weighted_view_solve_converges() {
 
     let result = solve(
         cats.view(),
+        Default::default(),
         &y,
         Some(&weights),
         &default_params(),

--- a/crates/within/tests/ingest.rs
+++ b/crates/within/tests/ingest.rs
@@ -1,8 +1,8 @@
 //! Ingest boundary: `ArrayView2<u32>` categories arrays of any layout
 //! normalize to the same contiguous-column frame.
 
-use ndarray::{array, Array2, Axis, ShapeBuilder, Slice};
-use within::{solve, LsmrOptions, PreconditionerConfig};
+use ndarray::{array, Array2, ArrayView2, Axis, ShapeBuilder, Slice};
+use within::{solve, Design, DesignOptions, IntoDesign, LsmrOptions, PreconditionerConfig};
 
 #[path = "common/orchestrate_helpers.rs"]
 mod common;
@@ -13,6 +13,14 @@ fn default_params() -> LsmrOptions {
 
 fn additive_precond() -> PreconditionerConfig {
     PreconditionerConfig::default()
+}
+
+fn design<'a>(categories: ArrayView2<'a, u32>, weights: Option<&'a [f64]>) -> Design<'a> {
+    let options = match weights {
+        Some(weights) => DesignOptions::default().weights(weights),
+        None => DesignOptions::default(),
+    };
+    categories.into_design(options).expect("design")
 }
 
 /// Build a larger problem for more meaningful convergence tests.
@@ -42,10 +50,8 @@ fn f_order_view_matches_owned_columns() {
     };
 
     let result_view = solve(
-        cats_f.view(),
-        Default::default(),
+        design(cats_f.view(), None),
         &y,
-        None,
         &default_params(),
         additive_precond(),
     )
@@ -55,7 +61,7 @@ fn f_order_view_matches_owned_columns() {
         .map(|f| cats.column(f).iter().copied().collect())
         .collect();
     let design = common::make_design(factor_cols).expect("valid design");
-    let solver = within::Solver::new(design, None, additive_precond()).expect("solver");
+    let solver = within::Solver::new(design, additive_precond()).expect("solver");
     let result_owned = solver.solve(&y, &default_params()).expect("owned solve");
 
     assert!(result_view.converged);
@@ -76,19 +82,15 @@ fn c_order_view_matches_f_order_bitwise() {
     };
 
     let result_c = solve(
-        cats.view(),
-        Default::default(),
+        design(cats.view(), None),
         &y,
-        None,
         &default_params(),
         additive_precond(),
     )
     .expect("C-order solve");
     let result_f = solve(
-        cats_f.view(),
-        Default::default(),
+        design(cats_f.view(), None),
         &y,
-        None,
         &default_params(),
         additive_precond(),
     )
@@ -115,10 +117,8 @@ fn column_reversed_view_ingests_in_logical_order() {
 
     let y = vec![1.0, 2.0, 3.0, 4.0, 5.0];
     let result_rev = solve(
-        reversed,
-        Default::default(),
+        design(reversed, None),
         &y,
-        None,
         &default_params(),
         additive_precond(),
     )
@@ -127,7 +127,7 @@ fn column_reversed_view_ingests_in_logical_order() {
     // Oracle: the same columns handed over owned, in swapped order.
     let design =
         common::make_design(vec![vec![1, 0, 1, 0, 2], vec![0, 1, 0, 1, 2]]).expect("valid design");
-    let solver = within::Solver::new(design, None, additive_precond()).expect("solver");
+    let solver = within::Solver::new(design, additive_precond()).expect("solver");
     let result_owned = solver.solve(&y, &default_params()).expect("owned solve");
 
     assert_eq!(result_rev.x, result_owned.x, "must be bit-identical");
@@ -139,10 +139,8 @@ fn weighted_view_solve_converges() {
     let weights: Vec<f64> = (0..cats.nrows()).map(|i| 1.0 + (i as f64) * 0.01).collect();
 
     let result = solve(
-        cats.view(),
-        Default::default(),
+        design(cats.view(), Some(&weights)),
         &y,
-        Some(&weights),
         &default_params(),
         additive_precond(),
     )

--- a/crates/within/tests/ingest.rs
+++ b/crates/within/tests/ingest.rs
@@ -2,7 +2,7 @@
 //! normalize to the same contiguous-column frame.
 
 use ndarray::{array, Array2, ArrayView2, Axis, ShapeBuilder, Slice};
-use within::{solve, Design, DesignOptions, IntoDesign, LsmrOptions, PreconditionerConfig};
+use within::{solve, Design, DesignOptions, LsmrOptions, PreconditionerConfig};
 
 #[path = "common/orchestrate_helpers.rs"]
 mod common;
@@ -16,11 +16,8 @@ fn additive_precond() -> PreconditionerConfig {
 }
 
 fn design<'a>(categories: ArrayView2<'a, u32>, weights: Option<&'a [f64]>) -> Design<'a> {
-    let options = match weights {
-        Some(weights) => DesignOptions::default().weights(weights),
-        None => DesignOptions::default(),
-    };
-    categories.into_design(options).expect("design")
+    let options = DesignOptions::new(false, weights.map(Into::into));
+    Design::from_categories(categories, options).expect("design")
 }
 
 /// Build a larger problem for more meaningful convergence tests.

--- a/crates/within/tests/ingest.rs
+++ b/crates/within/tests/ingest.rs
@@ -16,7 +16,10 @@ fn additive_precond() -> PreconditionerConfig {
 }
 
 fn design<'a>(categories: ArrayView2<'a, u32>, weights: Option<&'a [f64]>) -> Design<'a> {
-    let options = DesignOptions::new(false, weights.map(Into::into));
+    let options = DesignOptions {
+        weights: weights.map(Into::into),
+        ..Default::default()
+    };
     Design::from_categories(categories, options).expect("design")
 }
 

--- a/crates/within/tests/metamorphic.rs
+++ b/crates/within/tests/metamorphic.rs
@@ -53,11 +53,19 @@ proptest! {
         let params = tight_params();
         let precond = additive_precond();
 
-        let base = solve(cats.view(), &y, None, &params, &precond).unwrap();
+        let base = solve(cats.view(), Default::default(), &y, None, &params, &precond).unwrap();
         prop_assert!(base.converged);
 
         let y_scaled: Vec<f64> = y.iter().map(|v| c * v).collect();
-        let scaled = solve(cats.view(), &y_scaled, None, &params, &precond).unwrap();
+        let scaled = solve(
+            cats.view(),
+            Default::default(),
+            &y_scaled,
+            None,
+            &params,
+            &precond,
+        )
+        .unwrap();
         prop_assert!(scaled.converged);
 
         let expected: Vec<f64> = base.demeaned.iter().map(|v| c * v).collect();
@@ -82,11 +90,27 @@ proptest! {
         let params = tight_params();
         let precond = additive_precond();
 
-        let base = solve(cats.view(), &y, Some(w.as_slice()), &params, &precond).unwrap();
+        let base = solve(
+            cats.view(),
+            Default::default(),
+            &y,
+            Some(w.as_slice()),
+            &params,
+            &precond,
+        )
+        .unwrap();
         prop_assert!(base.converged);
 
         let w_scaled: Vec<f64> = w.iter().map(|v| k * v).collect();
-        let scaled = solve(cats.view(), &y, Some(w_scaled.as_slice()), &params, &precond).unwrap();
+        let scaled = solve(
+            cats.view(),
+            Default::default(),
+            &y,
+            Some(w_scaled.as_slice()),
+            &params,
+            &precond,
+        )
+        .unwrap();
         prop_assert!(scaled.converged);
 
         let (num, tol) = l2_close(&scaled.demeaned, &base.demeaned);
@@ -113,11 +137,20 @@ proptest! {
         let precond = additive_precond();
 
         let refs: Vec<&[f64]> = ys.iter().map(Vec::as_slice).collect();
-        let batch = solve_batch(cats.view(), &refs, None, &params, &precond).unwrap();
+        let batch = solve_batch(
+            cats.view(),
+            Default::default(),
+            &refs,
+            None,
+            &params,
+            &precond,
+        )
+        .unwrap();
         prop_assert!(batch.converged.iter().all(|&c| c));
 
         for (j, y) in ys.iter().enumerate() {
-            let single = solve(cats.view(), y, None, &params, &precond).unwrap();
+            let single =
+                solve(cats.view(), Default::default(), y, None, &params, &precond).unwrap();
             prop_assert!(single.converged);
             let (num, tol) = l2_close(batch.demeaned(j), &single.demeaned);
             prop_assert!(
@@ -136,7 +169,8 @@ proptest! {
     fn prop_unidentified_slots_are_zero((cats, y) in random_fe_problem_strategy()) {
         let params = tight_params();
         let precond = additive_precond();
-        let result = solve(cats.view(), &y, None, &params, &precond).unwrap();
+        let result =
+            solve(cats.view(), Default::default(), &y, None, &params, &precond).unwrap();
         prop_assert!(result.converged);
 
         for u in &result.unidentified {
@@ -167,7 +201,7 @@ fn saturated_single_factor_recovers_level_means() {
     let y = vec![1.0, 3.0, 2.0, 4.0, 6.0, 5.0];
     let params = tight_params();
     let precond = additive_precond();
-    let result = solve(cats.view(), &y, None, &params, &precond).unwrap();
+    let result = solve(cats.view(), Default::default(), &y, None, &params, &precond).unwrap();
     assert!(result.converged);
 
     for (level, &mean) in [2.0, 4.0, 5.0].iter().enumerate() {

--- a/crates/within/tests/metamorphic.rs
+++ b/crates/within/tests/metamorphic.rs
@@ -23,7 +23,10 @@ fn tight_params() -> LsmrOptions {
 }
 
 fn design<'a>(categories: ArrayView2<'a, u32>, weights: Option<&'a [f64]>) -> Design<'a> {
-    let options = DesignOptions::new(false, weights.map(Into::into));
+    let options = DesignOptions {
+        weights: weights.map(Into::into),
+        ..Default::default()
+    };
     Design::from_categories(categories, options).expect("design")
 }
 

--- a/crates/within/tests/metamorphic.rs
+++ b/crates/within/tests/metamorphic.rs
@@ -1,8 +1,6 @@
 use ndarray::{Array2, ArrayView2};
 use proptest::prelude::*;
-use within::{
-    solve, solve_batch, Channel, CoefficientAddress, Design, DesignOptions, IntoDesign, LsmrOptions,
-};
+use within::{solve, solve_batch, Channel, CoefficientAddress, Design, DesignOptions, LsmrOptions};
 
 #[path = "common/property_strategies.rs"]
 mod strategies;
@@ -25,11 +23,8 @@ fn tight_params() -> LsmrOptions {
 }
 
 fn design<'a>(categories: ArrayView2<'a, u32>, weights: Option<&'a [f64]>) -> Design<'a> {
-    let options = match weights {
-        Some(weights) => DesignOptions::default().weights(weights),
-        None => DesignOptions::default(),
-    };
-    categories.into_design(options).expect("design")
+    let options = DesignOptions::new(false, weights.map(Into::into));
+    Design::from_categories(categories, options).expect("design")
 }
 
 /// L2 agreement with a mixed absolute+relative tolerance: returns the actual

--- a/crates/within/tests/metamorphic.rs
+++ b/crates/within/tests/metamorphic.rs
@@ -1,6 +1,8 @@
-use ndarray::Array2;
+use ndarray::{Array2, ArrayView2};
 use proptest::prelude::*;
-use within::{solve, solve_batch, Channel, CoefficientAddress, LsmrOptions};
+use within::{
+    solve, solve_batch, Channel, CoefficientAddress, Design, DesignOptions, IntoDesign, LsmrOptions,
+};
 
 #[path = "common/property_strategies.rs"]
 mod strategies;
@@ -20,6 +22,14 @@ fn tight_params() -> LsmrOptions {
         maxiter: 3000,
         local_size: Some(10),
     }
+}
+
+fn design<'a>(categories: ArrayView2<'a, u32>, weights: Option<&'a [f64]>) -> Design<'a> {
+    let options = match weights {
+        Some(weights) => DesignOptions::default().weights(weights),
+        None => DesignOptions::default(),
+    };
+    categories.into_design(options).expect("design")
 }
 
 /// L2 agreement with a mixed absolute+relative tolerance: returns the actual
@@ -53,15 +63,13 @@ proptest! {
         let params = tight_params();
         let precond = additive_precond();
 
-        let base = solve(cats.view(), Default::default(), &y, None, &params, &precond).unwrap();
+        let base = solve(design(cats.view(), None), &y, &params, &precond).unwrap();
         prop_assert!(base.converged);
 
         let y_scaled: Vec<f64> = y.iter().map(|v| c * v).collect();
         let scaled = solve(
-            cats.view(),
-            Default::default(),
+            design(cats.view(), None),
             &y_scaled,
-            None,
             &params,
             &precond,
         )
@@ -91,10 +99,8 @@ proptest! {
         let precond = additive_precond();
 
         let base = solve(
-            cats.view(),
-            Default::default(),
+            design(cats.view(), Some(w.as_slice())),
             &y,
-            Some(w.as_slice()),
             &params,
             &precond,
         )
@@ -103,10 +109,8 @@ proptest! {
 
         let w_scaled: Vec<f64> = w.iter().map(|v| k * v).collect();
         let scaled = solve(
-            cats.view(),
-            Default::default(),
+            design(cats.view(), Some(w_scaled.as_slice())),
             &y,
-            Some(w_scaled.as_slice()),
             &params,
             &precond,
         )
@@ -138,10 +142,8 @@ proptest! {
 
         let refs: Vec<&[f64]> = ys.iter().map(Vec::as_slice).collect();
         let batch = solve_batch(
-            cats.view(),
-            Default::default(),
+            design(cats.view(), None),
             &refs,
-            None,
             &params,
             &precond,
         )
@@ -149,8 +151,7 @@ proptest! {
         prop_assert!(batch.converged.iter().all(|&c| c));
 
         for (j, y) in ys.iter().enumerate() {
-            let single =
-                solve(cats.view(), Default::default(), y, None, &params, &precond).unwrap();
+            let single = solve(design(cats.view(), None), y, &params, &precond).unwrap();
             prop_assert!(single.converged);
             let (num, tol) = l2_close(batch.demeaned(j), &single.demeaned);
             prop_assert!(
@@ -169,8 +170,7 @@ proptest! {
     fn prop_unidentified_slots_are_zero((cats, y) in random_fe_problem_strategy()) {
         let params = tight_params();
         let precond = additive_precond();
-        let result =
-            solve(cats.view(), Default::default(), &y, None, &params, &precond).unwrap();
+        let result = solve(design(cats.view(), None), &y, &params, &precond).unwrap();
         prop_assert!(result.converged);
 
         for u in &result.unidentified {
@@ -201,7 +201,7 @@ fn saturated_single_factor_recovers_level_means() {
     let y = vec![1.0, 3.0, 2.0, 4.0, 6.0, 5.0];
     let params = tight_params();
     let precond = additive_precond();
-    let result = solve(cats.view(), Default::default(), &y, None, &params, &precond).unwrap();
+    let result = solve(design(cats.view(), None), &y, &params, &precond).unwrap();
     assert!(result.converged);
 
     for (level, &mean) in [2.0, 4.0, 5.0].iter().enumerate() {

--- a/crates/within/tests/orchestrate_high_level.rs
+++ b/crates/within/tests/orchestrate_high_level.rs
@@ -1,17 +1,12 @@
 use ndarray::ArrayView2;
-use within::{
-    solve, solve_batch, Design, DesignOptions, IntoDesign, LsmrOptions, PreconditionerConfig,
-};
+use within::{solve, solve_batch, Design, DesignOptions, LsmrOptions, PreconditionerConfig};
 
 #[path = "common/orchestrate_helpers.rs"]
 mod common;
 
 fn design<'a>(categories: ArrayView2<'a, u32>, weights: Option<&'a [f64]>) -> Design<'a> {
-    let options = match weights {
-        Some(weights) => DesignOptions::default().weights(weights),
-        None => DesignOptions::default(),
-    };
-    categories.into_design(options).expect("design")
+    let options = DesignOptions::new(false, weights.map(Into::into));
+    Design::from_categories(categories, options).expect("design")
 }
 
 #[test]

--- a/crates/within/tests/orchestrate_high_level.rs
+++ b/crates/within/tests/orchestrate_high_level.rs
@@ -10,7 +10,15 @@ fn test_high_level_solve() {
 
     let params = LsmrOptions::default();
     let precond = PreconditionerConfig::default();
-    let result = solve(categories.view(), &y, None, &params, &precond).expect("solve");
+    let result = solve(
+        categories.view(),
+        Default::default(),
+        &y,
+        None,
+        &params,
+        &precond,
+    )
+    .expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_solution_finite(&result);
     common::assert_normal_equations_satisfied(&common::test_categories(), None, &y, &result, 1e-6);
@@ -24,8 +32,15 @@ fn test_high_level_solve_weighted() {
 
     let params = LsmrOptions::default();
     let precond = PreconditionerConfig::default();
-    let result =
-        solve(categories.view(), &y, Some(&weights), &params, &precond).expect("solve weighted");
+    let result = solve(
+        categories.view(),
+        Default::default(),
+        &y,
+        Some(&weights),
+        &params,
+        &precond,
+    )
+    .expect("solve weighted");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_solution_finite(&result);
     common::assert_normal_equations_satisfied(
@@ -46,11 +61,34 @@ fn test_solve_batch_matches_individual() {
     let params = LsmrOptions::default();
     let precond = PreconditionerConfig::default();
 
-    let r1 = solve(categories.view(), &y1, None, &params, &precond).expect("solve y1");
-    let r2 = solve(categories.view(), &y2, None, &params, &precond).expect("solve y2");
+    let r1 = solve(
+        categories.view(),
+        Default::default(),
+        &y1,
+        None,
+        &params,
+        &precond,
+    )
+    .expect("solve y1");
+    let r2 = solve(
+        categories.view(),
+        Default::default(),
+        &y2,
+        None,
+        &params,
+        &precond,
+    )
+    .expect("solve y2");
 
-    let batch =
-        solve_batch(categories.view(), &[&y1, &y2], None, &params, &precond).expect("solve batch");
+    let batch = solve_batch(
+        categories.view(),
+        Default::default(),
+        &[&y1, &y2],
+        None,
+        &params,
+        &precond,
+    )
+    .expect("solve batch");
 
     assert_eq!(batch.converged.len(), 2);
     for (a, b) in batch.x(0).iter().zip(r1.x.iter()) {
@@ -69,8 +107,15 @@ fn test_solve_batch_single_rhs() {
     let params = LsmrOptions::default();
     let precond = PreconditionerConfig::default();
 
-    let batch = solve_batch(categories.view(), &[&y[..]], None, &params, &precond)
-        .expect("solve batch single");
+    let batch = solve_batch(
+        categories.view(),
+        Default::default(),
+        &[&y[..]],
+        None,
+        &params,
+        &precond,
+    )
+    .expect("solve batch single");
 
     assert_eq!(batch.converged.len(), 1);
     assert!(batch.converged[0]);
@@ -89,6 +134,7 @@ fn test_solve_batch_weighted() {
 
     let batch = solve_batch(
         categories.view(),
+        Default::default(),
         &[&y1, &y2],
         Some(&weights),
         &params,
@@ -109,8 +155,15 @@ fn test_batch_result_accessors() {
     let params = LsmrOptions::default();
     let precond = PreconditionerConfig::default();
 
-    let batch =
-        solve_batch(categories.view(), &[&y1, &y2], None, &params, &precond).expect("solve batch");
+    let batch = solve_batch(
+        categories.view(),
+        Default::default(),
+        &[&y1, &y2],
+        None,
+        &params,
+        &precond,
+    )
+    .expect("solve batch");
 
     // n_rhs
     assert_eq!(batch.converged.len(), 2);

--- a/crates/within/tests/orchestrate_high_level.rs
+++ b/crates/within/tests/orchestrate_high_level.rs
@@ -1,7 +1,18 @@
-use within::{solve, solve_batch, LsmrOptions, PreconditionerConfig};
+use ndarray::ArrayView2;
+use within::{
+    solve, solve_batch, Design, DesignOptions, IntoDesign, LsmrOptions, PreconditionerConfig,
+};
 
 #[path = "common/orchestrate_helpers.rs"]
 mod common;
+
+fn design<'a>(categories: ArrayView2<'a, u32>, weights: Option<&'a [f64]>) -> Design<'a> {
+    let options = match weights {
+        Some(weights) => DesignOptions::default().weights(weights),
+        None => DesignOptions::default(),
+    };
+    categories.into_design(options).expect("design")
+}
 
 #[test]
 fn test_high_level_solve() {
@@ -10,15 +21,7 @@ fn test_high_level_solve() {
 
     let params = LsmrOptions::default();
     let precond = PreconditionerConfig::default();
-    let result = solve(
-        categories.view(),
-        Default::default(),
-        &y,
-        None,
-        &params,
-        &precond,
-    )
-    .expect("solve");
+    let result = solve(design(categories.view(), None), &y, &params, &precond).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_solution_finite(&result);
     common::assert_normal_equations_satisfied(&common::test_categories(), None, &y, &result, 1e-6);
@@ -33,10 +36,8 @@ fn test_high_level_solve_weighted() {
     let params = LsmrOptions::default();
     let precond = PreconditionerConfig::default();
     let result = solve(
-        categories.view(),
-        Default::default(),
+        design(categories.view(), Some(&weights)),
         &y,
-        Some(&weights),
         &params,
         &precond,
     )
@@ -61,30 +62,12 @@ fn test_solve_batch_matches_individual() {
     let params = LsmrOptions::default();
     let precond = PreconditionerConfig::default();
 
-    let r1 = solve(
-        categories.view(),
-        Default::default(),
-        &y1,
-        None,
-        &params,
-        &precond,
-    )
-    .expect("solve y1");
-    let r2 = solve(
-        categories.view(),
-        Default::default(),
-        &y2,
-        None,
-        &params,
-        &precond,
-    )
-    .expect("solve y2");
+    let r1 = solve(design(categories.view(), None), &y1, &params, &precond).expect("solve y1");
+    let r2 = solve(design(categories.view(), None), &y2, &params, &precond).expect("solve y2");
 
     let batch = solve_batch(
-        categories.view(),
-        Default::default(),
+        design(categories.view(), None),
         &[&y1, &y2],
-        None,
         &params,
         &precond,
     )
@@ -108,10 +91,8 @@ fn test_solve_batch_single_rhs() {
     let precond = PreconditionerConfig::default();
 
     let batch = solve_batch(
-        categories.view(),
-        Default::default(),
+        design(categories.view(), None),
         &[&y[..]],
-        None,
         &params,
         &precond,
     )
@@ -133,10 +114,8 @@ fn test_solve_batch_weighted() {
     let precond = PreconditionerConfig::default();
 
     let batch = solve_batch(
-        categories.view(),
-        Default::default(),
+        design(categories.view(), Some(&weights)),
         &[&y1, &y2],
-        Some(&weights),
         &params,
         &precond,
     )
@@ -156,10 +135,8 @@ fn test_batch_result_accessors() {
     let precond = PreconditionerConfig::default();
 
     let batch = solve_batch(
-        categories.view(),
-        Default::default(),
+        design(categories.view(), None),
         &[&y1, &y2],
-        None,
         &params,
         &precond,
     )

--- a/crates/within/tests/orchestrate_high_level.rs
+++ b/crates/within/tests/orchestrate_high_level.rs
@@ -5,7 +5,10 @@ use within::{solve, solve_batch, Design, DesignOptions, LsmrOptions, Preconditio
 mod common;
 
 fn design<'a>(categories: ArrayView2<'a, u32>, weights: Option<&'a [f64]>) -> Design<'a> {
-    let options = DesignOptions::new(false, weights.map(Into::into));
+    let options = DesignOptions {
+        weights: weights.map(Into::into),
+        ..Default::default()
+    };
     Design::from_categories(categories, options).expect("design")
 }
 

--- a/crates/within/tests/orchestrate_solve.rs
+++ b/crates/within/tests/orchestrate_solve.rs
@@ -85,7 +85,10 @@ fn test_lsmr_least_squares_weighted_preconditioned() {
     .expect("valid frame");
     let design = Design::from_frame(
         frame,
-        DesignOptions::new(false, Some(weights.clone().into())),
+        DesignOptions {
+            weights: Some(weights.clone().into()),
+            ..Default::default()
+        },
     )
     .expect("valid design");
     let y = vec![1.0, 2.0, 3.0, 4.0, 5.0];

--- a/crates/within/tests/orchestrate_solve.rs
+++ b/crates/within/tests/orchestrate_solve.rs
@@ -1,5 +1,5 @@
 use within::config::{LocalSolverConfig, ReductionStrategy};
-use within::{LsmrOptions, PreconditionerConfig, Solver};
+use within::{DesignOptions, LsmrOptions, PreconditionerConfig, Solver};
 
 #[path = "common/orchestrate_helpers.rs"]
 mod common;
@@ -14,7 +14,7 @@ fn test_lsmr_unpreconditioned() {
         maxiter: 1000,
         ..Default::default()
     };
-    let solver = Solver::new(design, None, None).expect("build solver");
+    let solver = Solver::new(design, None).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_normal_equations_satisfied(&common::test_categories(), None, &y, &result, 1e-6);
@@ -34,7 +34,7 @@ fn test_lsmr_preconditioned() {
         local_solver: LocalSolverConfig::default(),
         reduction: ReductionStrategy::Auto,
     };
-    let solver = Solver::new(design, None, &precond).expect("build solver");
+    let solver = Solver::new(design, &precond).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_normal_equations_satisfied(&common::test_categories(), None, &y, &result, 1e-6);
@@ -51,7 +51,7 @@ fn test_lsmr_diagonal_preconditioned() {
         ..Default::default()
     };
     let precond = PreconditionerConfig::Diagonal;
-    let solver = Solver::new(design, None, &precond).expect("build solver");
+    let solver = Solver::new(design, &precond).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_solution_finite(&result);
@@ -68,7 +68,7 @@ fn test_lsmr_least_squares() {
         maxiter: 1000,
         ..Default::default()
     };
-    let solver = Solver::new(design, None, None).expect("build solver");
+    let solver = Solver::new(design, None).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     assert!(result.converged, "LSMR LS did not converge");
     common::assert_solution_finite(&result);
@@ -77,9 +77,16 @@ fn test_lsmr_least_squares() {
 
 #[test]
 fn test_lsmr_least_squares_weighted_preconditioned() {
-    let design =
-        common::make_design(vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]).expect("valid design");
     let weights = vec![1.0, 2.0, 1.5, 0.5, 3.0];
+    let frame = within::observation::ObservationFrame::new(
+        vec![vec![0, 1, 0, 1, 2].into(), vec![0, 0, 1, 1, 0].into()],
+        Vec::new(),
+    )
+    .expect("valid frame");
+    let design = DesignOptions::default()
+        .weights(weights.clone())
+        .from_frame(frame)
+        .expect("valid design");
     let y = vec![1.0, 2.0, 3.0, 4.0, 5.0];
 
     let params = LsmrOptions {
@@ -88,7 +95,7 @@ fn test_lsmr_least_squares_weighted_preconditioned() {
         ..Default::default()
     };
     let precond = PreconditionerConfig::default();
-    let solver = Solver::new(design, Some(weights.clone()), &precond).expect("build solver");
+    let solver = Solver::new(design, &precond).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_solution_finite(&result);

--- a/crates/within/tests/orchestrate_solve.rs
+++ b/crates/within/tests/orchestrate_solve.rs
@@ -1,5 +1,5 @@
 use within::config::{LocalSolverConfig, ReductionStrategy};
-use within::{DesignOptions, LsmrOptions, PreconditionerConfig, Solver};
+use within::{Design, DesignOptions, LsmrOptions, PreconditionerConfig, Solver};
 
 #[path = "common/orchestrate_helpers.rs"]
 mod common;
@@ -83,10 +83,11 @@ fn test_lsmr_least_squares_weighted_preconditioned() {
         Vec::new(),
     )
     .expect("valid frame");
-    let design = DesignOptions::default()
-        .weights(weights.clone())
-        .from_frame(frame)
-        .expect("valid design");
+    let design = Design::from_frame(
+        frame,
+        DesignOptions::new(false, Some(weights.clone().into())),
+    )
+    .expect("valid design");
     let y = vec![1.0, 2.0, 3.0, 4.0, 5.0];
 
     let params = LsmrOptions {

--- a/crates/within/tests/properties.rs
+++ b/crates/within/tests/properties.rs
@@ -1,7 +1,7 @@
 use proptest::prelude::*;
 use within::{
-    solve, Channel, CoefficientAddress, Effect, LsmrOptions, Preconditioner, PreconditionerConfig,
-    Solver,
+    solve, Channel, CoefficientAddress, DesignOptions, Effect, IntoDesign, LsmrOptions,
+    Preconditioner, PreconditionerConfig, Solver,
 };
 
 #[path = "common/property_strategies.rs"]
@@ -26,7 +26,8 @@ proptest! {
     fn prop_preconditioner_serde_roundtrip((cats, _y) in random_fe_problem_strategy()) {
         let precond = additive_precond();
 
-        let solver = within::Solver::new(cats.view(), None, &precond).unwrap();
+        let design = cats.view().into_design(DesignOptions::default()).unwrap();
+        let solver = within::Solver::new(design, &precond).unwrap();
         let fe_precond = solver.preconditioner().unwrap();
 
         let bytes = postcard::to_stdvec(fe_precond).unwrap();
@@ -53,14 +54,8 @@ proptest! {
             ..default_params()
         };
         let precond = additive_precond();
-        let result = solve(
-            cats.view(),
-            Default::default(),
-            &y,
-            None,
-            &params,
-            &precond,
-        )
+        let design = cats.view().into_design(DesignOptions::default()).unwrap();
+        let result = solve(design, &y, &params, &precond)
         .unwrap();
 
         prop_assert!(
@@ -74,14 +69,8 @@ proptest! {
     fn prop_demeaned_orthogonality((cats, y) in random_fe_problem_strategy()) {
         let params = default_params();
         let precond = additive_precond();
-        let result = solve(
-            cats.view(),
-            Default::default(),
-            &y,
-            None,
-            &params,
-            &precond,
-        )
+        let design = cats.view().into_design(DesignOptions::default()).unwrap();
+        let result = solve(design, &y, &params, &precond)
         .unwrap();
 
         prop_assume!(result.converged);
@@ -137,7 +126,11 @@ proptest! {
             maxiter: 2000,
             local_size: Some(10),
         };
-        let result = Solver::new(effects, Some(weights.clone()), PreconditionerConfig::default())
+        let design = DesignOptions::default()
+            .weights(weights.clone())
+            .from_effects(effects)
+            .expect("design");
+        let result = Solver::new(design, PreconditionerConfig::default())
             .expect("build solver")
             .solve(y.as_slice(), &params)
             .expect("solve");

--- a/crates/within/tests/properties.rs
+++ b/crates/within/tests/properties.rs
@@ -53,7 +53,15 @@ proptest! {
             ..default_params()
         };
         let precond = additive_precond();
-        let result = solve(cats.view(), &y, None, &params, &precond).unwrap();
+        let result = solve(
+            cats.view(),
+            Default::default(),
+            &y,
+            None,
+            &params,
+            &precond,
+        )
+        .unwrap();
 
         prop_assert!(
             result.converged,
@@ -66,7 +74,15 @@ proptest! {
     fn prop_demeaned_orthogonality((cats, y) in random_fe_problem_strategy()) {
         let params = default_params();
         let precond = additive_precond();
-        let result = solve(cats.view(), &y, None, &params, &precond).unwrap();
+        let result = solve(
+            cats.view(),
+            Default::default(),
+            &y,
+            None,
+            &params,
+            &precond,
+        )
+        .unwrap();
 
         prop_assume!(result.converged);
 

--- a/crates/within/tests/properties.rs
+++ b/crates/within/tests/properties.rs
@@ -1,7 +1,7 @@
 use proptest::prelude::*;
 use within::{
-    solve, Channel, CoefficientAddress, DesignOptions, Effect, IntoDesign, LsmrOptions,
-    Preconditioner, PreconditionerConfig, Solver,
+    solve, Channel, CoefficientAddress, Design, DesignOptions, Effect, LsmrOptions, Preconditioner,
+    PreconditionerConfig, Solver,
 };
 
 #[path = "common/property_strategies.rs"]
@@ -26,7 +26,7 @@ proptest! {
     fn prop_preconditioner_serde_roundtrip((cats, _y) in random_fe_problem_strategy()) {
         let precond = additive_precond();
 
-        let design = cats.view().into_design(DesignOptions::default()).unwrap();
+        let design = Design::from_categories(cats.view(), DesignOptions::default()).unwrap();
         let solver = within::Solver::new(design, &precond).unwrap();
         let fe_precond = solver.preconditioner().unwrap();
 
@@ -54,7 +54,7 @@ proptest! {
             ..default_params()
         };
         let precond = additive_precond();
-        let design = cats.view().into_design(DesignOptions::default()).unwrap();
+        let design = Design::from_categories(cats.view(), DesignOptions::default()).unwrap();
         let result = solve(design, &y, &params, &precond)
         .unwrap();
 
@@ -69,7 +69,7 @@ proptest! {
     fn prop_demeaned_orthogonality((cats, y) in random_fe_problem_strategy()) {
         let params = default_params();
         let precond = additive_precond();
-        let design = cats.view().into_design(DesignOptions::default()).unwrap();
+        let design = Design::from_categories(cats.view(), DesignOptions::default()).unwrap();
         let result = solve(design, &y, &params, &precond)
         .unwrap();
 
@@ -126,10 +126,11 @@ proptest! {
             maxiter: 2000,
             local_size: Some(10),
         };
-        let design = DesignOptions::default()
-            .weights(weights.clone())
-            .from_effects(effects)
-            .expect("design");
+        let design = Design::from_effects(
+            effects,
+            DesignOptions::new(false, Some(weights.clone().into())),
+        )
+        .expect("design");
         let result = Solver::new(design, PreconditionerConfig::default())
             .expect("build solver")
             .solve(y.as_slice(), &params)

--- a/crates/within/tests/properties.rs
+++ b/crates/within/tests/properties.rs
@@ -128,7 +128,10 @@ proptest! {
         };
         let design = Design::from_effects(
             effects,
-            DesignOptions::new(false, Some(weights.clone().into())),
+            DesignOptions {
+                weights: Some(weights.clone().into()),
+                ..Default::default()
+            },
         )
         .expect("design");
         let result = Solver::new(design, PreconditionerConfig::default())

--- a/crates/within/tests/property_gaps.rs
+++ b/crates/within/tests/property_gaps.rs
@@ -66,7 +66,15 @@ proptest! {
         };
         let precond = additive_precond();
         // LSMR converges on the least-squares system min ||y - Dx||^2 for any y.
-        let result = solve(cats.view(), &y, None, &params, &precond).unwrap();
+        let result = solve(
+            cats.view(),
+            Default::default(),
+            &y,
+            None,
+            &params,
+            &precond,
+        )
+        .unwrap();
         prop_assert!(
             result.converged,
             "4-factor solve did not converge (n_obs={}, residual={:.2e})",
@@ -89,7 +97,15 @@ proptest! {
         let precond = additive_precond();
 
         // Path A: convenience `solve()` (ingests the view internally)
-        let result_a = solve(cats.view(), &y, None, &params, &precond).unwrap();
+        let result_a = solve(
+            cats.view(),
+            Default::default(),
+            &y,
+            None,
+            &params,
+            &precond,
+        )
+        .unwrap();
 
         // Path B: Solver::new() — identical to solve() but without timing wrapper
         let solver_b = Solver::new(cats.view(), None, &precond).unwrap();
@@ -118,7 +134,15 @@ proptest! {
             ..LsmrOptions::default()
         };
         let precond = additive_precond();
-        let result = solve(cats.view(), &y, None, &params, &precond).unwrap();
+        let result = solve(
+            cats.view(),
+            Default::default(),
+            &y,
+            None,
+            &params,
+            &precond,
+        )
+        .unwrap();
 
         if !result.converged {
             return Ok(());
@@ -163,7 +187,15 @@ proptest! {
             maxiter: n_levels + 10,
             ..LsmrOptions::default()
         };
-        let result = solve(cats.view(), &y, None, &params, None).unwrap();
+        let result = solve(
+            cats.view(),
+            Default::default(),
+            &y,
+            None,
+            &params,
+            None,
+        )
+        .unwrap();
 
         prop_assert!(
             result.converged,

--- a/crates/within/tests/property_gaps.rs
+++ b/crates/within/tests/property_gaps.rs
@@ -1,6 +1,6 @@
 use ndarray::Array2;
 use proptest::prelude::*;
-use within::{solve, LsmrOptions, Solver};
+use within::{solve, DesignOptions, IntoDesign, LsmrOptions, Solver};
 
 #[path = "common/property_strategies.rs"]
 mod strategies;
@@ -66,14 +66,8 @@ proptest! {
         };
         let precond = additive_precond();
         // LSMR converges on the least-squares system min ||y - Dx||^2 for any y.
-        let result = solve(
-            cats.view(),
-            Default::default(),
-            &y,
-            None,
-            &params,
-            &precond,
-        )
+        let design = cats.view().into_design(DesignOptions::default()).unwrap();
+        let result = solve(design, &y, &params, &precond)
         .unwrap();
         prop_assert!(
             result.converged,
@@ -97,18 +91,13 @@ proptest! {
         let precond = additive_precond();
 
         // Path A: convenience `solve()` (ingests the view internally)
-        let result_a = solve(
-            cats.view(),
-            Default::default(),
-            &y,
-            None,
-            &params,
-            &precond,
-        )
+        let design_a = cats.view().into_design(DesignOptions::default()).unwrap();
+        let result_a = solve(design_a, &y, &params, &precond)
         .unwrap();
 
         // Path B: Solver::new() — identical to solve() but without timing wrapper
-        let solver_b = Solver::new(cats.view(), None, &precond).unwrap();
+        let design_b = cats.view().into_design(DesignOptions::default()).unwrap();
+        let solver_b = Solver::new(design_b, &precond).unwrap();
         let result_b = solver_b.solve(&y, &params).unwrap();
 
         prop_assert_eq!(
@@ -134,14 +123,8 @@ proptest! {
             ..LsmrOptions::default()
         };
         let precond = additive_precond();
-        let result = solve(
-            cats.view(),
-            Default::default(),
-            &y,
-            None,
-            &params,
-            &precond,
-        )
+        let design = cats.view().into_design(DesignOptions::default()).unwrap();
+        let result = solve(design, &y, &params, &precond)
         .unwrap();
 
         if !result.converged {
@@ -187,14 +170,8 @@ proptest! {
             maxiter: n_levels + 10,
             ..LsmrOptions::default()
         };
-        let result = solve(
-            cats.view(),
-            Default::default(),
-            &y,
-            None,
-            &params,
-            None,
-        )
+        let design = cats.view().into_design(DesignOptions::default()).unwrap();
+        let result = solve(design, &y, &params, None)
         .unwrap();
 
         prop_assert!(

--- a/crates/within/tests/property_gaps.rs
+++ b/crates/within/tests/property_gaps.rs
@@ -1,6 +1,6 @@
 use ndarray::Array2;
 use proptest::prelude::*;
-use within::{solve, DesignOptions, IntoDesign, LsmrOptions, Solver};
+use within::{solve, Design, DesignOptions, LsmrOptions, Solver};
 
 #[path = "common/property_strategies.rs"]
 mod strategies;
@@ -66,7 +66,7 @@ proptest! {
         };
         let precond = additive_precond();
         // LSMR converges on the least-squares system min ||y - Dx||^2 for any y.
-        let design = cats.view().into_design(DesignOptions::default()).unwrap();
+        let design = Design::from_categories(cats.view(), DesignOptions::default()).unwrap();
         let result = solve(design, &y, &params, &precond)
         .unwrap();
         prop_assert!(
@@ -79,7 +79,7 @@ proptest! {
 
     /// `solve()` and `Solver::new().solve(, &params)` must produce bit-identical
     /// results given the same design and RHS: the wrappers differ only in
-    /// timing accounting. Both ingest the raw view into a frame design,
+    /// timing accounting. Both designs are constructed from the same raw view,
     /// so they share the same locality sort (or its absence) and run in
     /// identical internal row order on any input.
     #[test]
@@ -90,13 +90,13 @@ proptest! {
         };
         let precond = additive_precond();
 
-        // Path A: convenience `solve()` (ingests the view internally)
-        let design_a = cats.view().into_design(DesignOptions::default()).unwrap();
+        // Path A: convenience `solve()`.
+        let design_a = Design::from_categories(cats.view(), DesignOptions::default()).unwrap();
         let result_a = solve(design_a, &y, &params, &precond)
         .unwrap();
 
         // Path B: Solver::new() — identical to solve() but without timing wrapper
-        let design_b = cats.view().into_design(DesignOptions::default()).unwrap();
+        let design_b = Design::from_categories(cats.view(), DesignOptions::default()).unwrap();
         let solver_b = Solver::new(design_b, &precond).unwrap();
         let result_b = solver_b.solve(&y, &params).unwrap();
 
@@ -123,7 +123,7 @@ proptest! {
             ..LsmrOptions::default()
         };
         let precond = additive_precond();
-        let design = cats.view().into_design(DesignOptions::default()).unwrap();
+        let design = Design::from_categories(cats.view(), DesignOptions::default()).unwrap();
         let result = solve(design, &y, &params, &precond)
         .unwrap();
 
@@ -170,7 +170,7 @@ proptest! {
             maxiter: n_levels + 10,
             ..LsmrOptions::default()
         };
-        let design = cats.view().into_design(DesignOptions::default()).unwrap();
+        let design = Design::from_categories(cats.view(), DesignOptions::default()).unwrap();
         let result = solve(design, &y, &params, None)
         .unwrap();
 

--- a/crates/within/tests/slopes.rs
+++ b/crates/within/tests/slopes.rs
@@ -61,11 +61,8 @@ fn solve_with(
     config: &PreconditionerConfig,
 ) -> SolveResult {
     let effects = vec![Effect::new(levels, intercept, [z]).expect("effect")];
-    let options = match weights {
-        Some(weights) => DesignOptions::default().weights(weights),
-        None => DesignOptions::default(),
-    };
-    let design = options.from_effects(effects).expect("design");
+    let options = DesignOptions::new(false, weights.map(Into::into));
+    let design = Design::from_effects(effects, options).expect("design");
     Solver::new(design, config)
         .expect("solver")
         .solve(y, &LsmrOptions::default())
@@ -250,8 +247,11 @@ fn batch_solve_shares_unidentified_and_back_transforms_each_rhs() {
     let y1 = synthetic_y(levels.len());
     let y2: Vec<f64> = y1.iter().map(|v| v * -1.5 + 0.3).collect();
 
-    let design =
-        Design::new(vec![Effect::new(&levels, true, [&z[..]]).expect("effect")]).expect("design");
+    let design = Design::from_effects(
+        vec![Effect::new(&levels, true, [&z[..]]).expect("effect")],
+        DesignOptions::default(),
+    )
+    .expect("design");
     let solver = Solver::new(design, PreconditionerConfig::default()).expect("solver");
     let opts = LsmrOptions::default();
     let batch = solver.solve_batch(&[&y1, &y2], &opts).expect("batch");
@@ -290,9 +290,10 @@ fn three_slopes_solve_bounded_with_exact_rank_drops() {
         .collect();
     let y = synthetic_y(n);
 
-    let design = Design::new(vec![
-        Effect::new(&levels, true, [&z1[..], &z2, &z3]).expect("effect")
-    ])
+    let design = Design::from_effects(
+        vec![Effect::new(&levels, true, [&z1[..], &z2, &z3]).expect("effect")],
+        DesignOptions::default(),
+    )
     .expect("design");
     let r = Solver::new(design, PreconditionerConfig::default())
         .expect("solver")

--- a/crates/within/tests/slopes.rs
+++ b/crates/within/tests/slopes.rs
@@ -61,7 +61,10 @@ fn solve_with(
     config: &PreconditionerConfig,
 ) -> SolveResult {
     let effects = vec![Effect::new(levels, intercept, [z]).expect("effect")];
-    let options = DesignOptions::new(false, weights.map(Into::into));
+    let options = DesignOptions {
+        weights: weights.map(Into::into),
+        ..Default::default()
+    };
     let design = Design::from_effects(effects, options).expect("design");
     Solver::new(design, config)
         .expect("solver")

--- a/crates/within/tests/slopes.rs
+++ b/crates/within/tests/slopes.rs
@@ -2,7 +2,9 @@
 //! user's parametrization, fitted-value invariance under the internal
 //! reparametrization, and deterministic rank-drop reporting.
 
-use within::{Effect, LsmrOptions, PreconditionerConfig, SolveResult, Solver};
+use within::{
+    Design, DesignOptions, Effect, LsmrOptions, PreconditionerConfig, SolveResult, Solver,
+};
 
 const TOL: f64 = 1e-6;
 
@@ -58,14 +60,16 @@ fn solve_with(
     y: &[f64],
     config: &PreconditionerConfig,
 ) -> SolveResult {
-    Solver::new(
-        vec![Effect::new(levels, intercept, [z]).expect("effect")],
-        weights,
-        config,
-    )
-    .expect("solver")
-    .solve(y, &LsmrOptions::default())
-    .expect("solve")
+    let effects = vec![Effect::new(levels, intercept, [z]).expect("effect")];
+    let options = match weights {
+        Some(weights) => DesignOptions::default().weights(weights),
+        None => DesignOptions::default(),
+    };
+    let design = options.from_effects(effects).expect("design");
+    Solver::new(design, config)
+        .expect("solver")
+        .solve(y, &LsmrOptions::default())
+        .expect("solve")
 }
 
 fn solve_single(
@@ -246,12 +250,9 @@ fn batch_solve_shares_unidentified_and_back_transforms_each_rhs() {
     let y1 = synthetic_y(levels.len());
     let y2: Vec<f64> = y1.iter().map(|v| v * -1.5 + 0.3).collect();
 
-    let solver = Solver::new(
-        vec![Effect::new(&levels, true, [&z[..]]).expect("effect")],
-        None,
-        PreconditionerConfig::default(),
-    )
-    .expect("solver");
+    let design =
+        Design::new(vec![Effect::new(&levels, true, [&z[..]]).expect("effect")]).expect("design");
+    let solver = Solver::new(design, PreconditionerConfig::default()).expect("solver");
     let opts = LsmrOptions::default();
     let batch = solver.solve_batch(&[&y1, &y2], &opts).expect("batch");
 
@@ -289,14 +290,14 @@ fn three_slopes_solve_bounded_with_exact_rank_drops() {
         .collect();
     let y = synthetic_y(n);
 
-    let r = Solver::new(
-        vec![Effect::new(&levels, true, [&z1[..], &z2, &z3]).expect("effect")],
-        None,
-        PreconditionerConfig::default(),
-    )
-    .expect("solver")
-    .solve(&y, &LsmrOptions::default())
-    .expect("solve");
+    let design = Design::new(vec![
+        Effect::new(&levels, true, [&z1[..], &z2, &z3]).expect("effect")
+    ])
+    .expect("design");
+    let r = Solver::new(design, PreconditionerConfig::default())
+        .expect("solver")
+        .solve(&y, &LsmrOptions::default())
+        .expect("solve");
     assert!(r.converged);
     assert!(
         r.iterations <= 30,

--- a/crates/within/tests/slopes_routing.rs
+++ b/crates/within/tests/slopes_routing.rs
@@ -2,7 +2,9 @@
 //! factors through balanced/scaled signed subdomains, with frustrated
 //! components solving through their Gremban double cover (#62).
 
-use within::{Effect, LsmrOptions, Preconditioner, PreconditionerConfig, SchurMode, Solver};
+use within::{
+    Design, Effect, LsmrOptions, Preconditioner, PreconditionerConfig, SchurMode, Solver,
+};
 
 fn lcg(seed: &mut u64) -> u64 {
     *seed = seed
@@ -36,10 +38,13 @@ fn two_factor_slope_solves_with_bounded_iterations() {
         Effect::new(&f, true, [&z[..]]).expect("slope effect"),
         Effect::new(&g, true, []).expect("plain effect"),
     ];
-    let r = Solver::new(effects, None, PreconditionerConfig::default())
-        .expect("signed routing builds")
-        .solve(&y, &LsmrOptions::default())
-        .expect("solve");
+    let r = Solver::new(
+        Design::new(effects).expect("design"),
+        PreconditionerConfig::default(),
+    )
+    .expect("signed routing builds")
+    .solve(&y, &LsmrOptions::default())
+    .expect("solve");
 
     assert!(r.converged);
     assert!(r.iterations <= 50, "iterations = {}", r.iterations);
@@ -69,10 +74,13 @@ fn unit_trends_plus_time_effects_boundary() {
         Effect::new(&unit, true, [&t[..]]).expect("trend effect"),
         Effect::new(&time, true, []).expect("time effect"),
     ];
-    let r = Solver::new(effects, None, PreconditionerConfig::default())
-        .expect("PSD-boundary routing builds")
-        .solve(&y, &LsmrOptions::default())
-        .expect("solve");
+    let r = Solver::new(
+        Design::new(effects).expect("design"),
+        PreconditionerConfig::default(),
+    )
+    .expect("PSD-boundary routing builds")
+    .solve(&y, &LsmrOptions::default())
+    .expect("solve");
 
     assert!(r.converged);
     assert!(r.iterations <= 60, "iterations = {}", r.iterations);
@@ -90,10 +98,13 @@ fn frustrated_component_solves_via_cover() {
         Effect::new(&g, true, []).expect("plain effect"),
     ];
 
-    let r = Solver::new(effects, None, PreconditionerConfig::default())
-        .expect("frustrated component builds via its Gremban cover")
-        .solve(&y, &LsmrOptions::default())
-        .expect("solve");
+    let r = Solver::new(
+        Design::new(effects).expect("design"),
+        PreconditionerConfig::default(),
+    )
+    .expect("frustrated component builds via its Gremban cover")
+    .solve(&y, &LsmrOptions::default())
+    .expect("solve");
     assert!(r.converged);
     assert!(r.unidentified.is_empty());
 
@@ -147,10 +158,13 @@ fn frustrated_two_factor_slope_solves_with_bounded_iterations() {
         Effect::new(&f, true, [&z[..]]).expect("slope effect"),
         Effect::new(&g, true, []).expect("plain effect"),
     ];
-    let r = Solver::new(effects, None, PreconditionerConfig::default())
-        .expect("frustrated routing builds")
-        .solve(&y, &LsmrOptions::default())
-        .expect("solve");
+    let r = Solver::new(
+        Design::new(effects).expect("design"),
+        PreconditionerConfig::default(),
+    )
+    .expect("frustrated routing builds")
+    .solve(&y, &LsmrOptions::default())
+    .expect("solve");
 
     assert!(r.converged);
     assert!(r.iterations <= 80, "iterations = {}", r.iterations);
@@ -169,10 +183,13 @@ fn near_collinear_cross_term_direction_survives_routing() {
         Effect::new(&f, false, [&z1[..]]).unwrap(),
         Effect::new(&f, false, [&z2[..]]).unwrap(),
     ];
-    let r = Solver::new(effects, None, PreconditionerConfig::default())
-        .expect("near-collinear pair builds")
-        .solve(&y, &LsmrOptions::default())
-        .expect("solve");
+    let r = Solver::new(
+        Design::new(effects).expect("design"),
+        PreconditionerConfig::default(),
+    )
+    .expect("near-collinear pair builds")
+    .solve(&y, &LsmrOptions::default())
+    .expect("solve");
     assert!(r.converged);
     assert!(
         (r.x[0] - 1.0).abs() < 1e-6 && (r.x[1] + 1.0).abs() < 1e-6,
@@ -218,7 +235,7 @@ fn surplus_component_sampled_matches_exact_reduction() {
             },
             reduction: Default::default(),
         };
-        Solver::new(effects, None, config)
+        Solver::new(Design::new(effects).expect("design"), config)
             .expect("build")
             .solve(&y, &LsmrOptions::default())
             .expect("solve")
@@ -273,8 +290,11 @@ fn singleton_level_in_non_first_slope_term_solves_under_default() {
         ]
     };
 
-    let solver = Solver::new(effects(), None, PreconditionerConfig::default())
-        .expect("default preconditioner builds");
+    let solver = Solver::new(
+        Design::new(effects()).expect("design"),
+        PreconditionerConfig::default(),
+    )
+    .expect("default preconditioner builds");
 
     // The preconditioner must match the operator's column count, uncovered ones included.
     let precond = solver
@@ -297,7 +317,7 @@ fn singleton_level_in_non_first_slope_term_solves_under_default() {
 
     // The demeaned residual is gauge-invariant, so it agrees though raw coefficients need not.
     for cfg in [PreconditionerConfig::Off, PreconditionerConfig::Diagonal] {
-        let alt = Solver::new(effects(), None, cfg)
+        let alt = Solver::new(Design::new(effects()).expect("design"), cfg)
             .expect("alt preconditioner builds")
             .solve(&y, &LsmrOptions::default())
             .expect("alt solve");
@@ -313,7 +333,7 @@ fn singleton_level_in_non_first_slope_term_solves_under_default() {
     let bytes = postcard::to_stdvec(precond).expect("serialize");
     let restored: Preconditioner = postcard::from_bytes(&bytes).expect("deserialize");
     assert_eq!(restored.ncols(), solver.n_dofs());
-    let reused = Solver::new(effects(), None, restored)
+    let reused = Solver::new(Design::new(effects()).expect("design"), restored)
         .expect("reused preconditioner accepted")
         .solve(&y, &LsmrOptions::default())
         .expect("reused solve");

--- a/crates/within/tests/slopes_routing.rs
+++ b/crates/within/tests/slopes_routing.rs
@@ -3,7 +3,8 @@
 //! components solving through their Gremban double cover (#62).
 
 use within::{
-    Design, Effect, LsmrOptions, Preconditioner, PreconditionerConfig, SchurMode, Solver,
+    Design, DesignOptions, Effect, LsmrOptions, Preconditioner, PreconditionerConfig, SchurMode,
+    Solver,
 };
 
 fn lcg(seed: &mut u64) -> u64 {
@@ -39,7 +40,7 @@ fn two_factor_slope_solves_with_bounded_iterations() {
         Effect::new(&g, true, []).expect("plain effect"),
     ];
     let r = Solver::new(
-        Design::new(effects).expect("design"),
+        Design::from_effects(effects, DesignOptions::default()).expect("design"),
         PreconditionerConfig::default(),
     )
     .expect("signed routing builds")
@@ -75,7 +76,7 @@ fn unit_trends_plus_time_effects_boundary() {
         Effect::new(&time, true, []).expect("time effect"),
     ];
     let r = Solver::new(
-        Design::new(effects).expect("design"),
+        Design::from_effects(effects, DesignOptions::default()).expect("design"),
         PreconditionerConfig::default(),
     )
     .expect("PSD-boundary routing builds")
@@ -99,7 +100,7 @@ fn frustrated_component_solves_via_cover() {
     ];
 
     let r = Solver::new(
-        Design::new(effects).expect("design"),
+        Design::from_effects(effects, DesignOptions::default()).expect("design"),
         PreconditionerConfig::default(),
     )
     .expect("frustrated component builds via its Gremban cover")
@@ -159,7 +160,7 @@ fn frustrated_two_factor_slope_solves_with_bounded_iterations() {
         Effect::new(&g, true, []).expect("plain effect"),
     ];
     let r = Solver::new(
-        Design::new(effects).expect("design"),
+        Design::from_effects(effects, DesignOptions::default()).expect("design"),
         PreconditionerConfig::default(),
     )
     .expect("frustrated routing builds")
@@ -184,7 +185,7 @@ fn near_collinear_cross_term_direction_survives_routing() {
         Effect::new(&f, false, [&z2[..]]).unwrap(),
     ];
     let r = Solver::new(
-        Design::new(effects).expect("design"),
+        Design::from_effects(effects, DesignOptions::default()).expect("design"),
         PreconditionerConfig::default(),
     )
     .expect("near-collinear pair builds")
@@ -235,10 +236,13 @@ fn surplus_component_sampled_matches_exact_reduction() {
             },
             reduction: Default::default(),
         };
-        Solver::new(Design::new(effects).expect("design"), config)
-            .expect("build")
-            .solve(&y, &LsmrOptions::default())
-            .expect("solve")
+        Solver::new(
+            Design::from_effects(effects, DesignOptions::default()).expect("design"),
+            config,
+        )
+        .expect("build")
+        .solve(&y, &LsmrOptions::default())
+        .expect("solve")
     };
 
     let sampled = solve(SchurMode::Approximate(
@@ -291,7 +295,7 @@ fn singleton_level_in_non_first_slope_term_solves_under_default() {
     };
 
     let solver = Solver::new(
-        Design::new(effects()).expect("design"),
+        Design::from_effects(effects(), DesignOptions::default()).expect("design"),
         PreconditionerConfig::default(),
     )
     .expect("default preconditioner builds");
@@ -317,10 +321,13 @@ fn singleton_level_in_non_first_slope_term_solves_under_default() {
 
     // The demeaned residual is gauge-invariant, so it agrees though raw coefficients need not.
     for cfg in [PreconditionerConfig::Off, PreconditionerConfig::Diagonal] {
-        let alt = Solver::new(Design::new(effects()).expect("design"), cfg)
-            .expect("alt preconditioner builds")
-            .solve(&y, &LsmrOptions::default())
-            .expect("alt solve");
+        let alt = Solver::new(
+            Design::from_effects(effects(), DesignOptions::default()).expect("design"),
+            cfg,
+        )
+        .expect("alt preconditioner builds")
+        .solve(&y, &LsmrOptions::default())
+        .expect("alt solve");
         for (i, (&d, &a)) in r.demeaned.iter().zip(&alt.demeaned).enumerate() {
             assert!(
                 (d - a).abs() < 1e-8,
@@ -333,10 +340,13 @@ fn singleton_level_in_non_first_slope_term_solves_under_default() {
     let bytes = postcard::to_stdvec(precond).expect("serialize");
     let restored: Preconditioner = postcard::from_bytes(&bytes).expect("deserialize");
     assert_eq!(restored.ncols(), solver.n_dofs());
-    let reused = Solver::new(Design::new(effects()).expect("design"), restored)
-        .expect("reused preconditioner accepted")
-        .solve(&y, &LsmrOptions::default())
-        .expect("reused solve");
+    let reused = Solver::new(
+        Design::from_effects(effects(), DesignOptions::default()).expect("design"),
+        restored,
+    )
+    .expect("reused preconditioner accepted")
+    .solve(&y, &LsmrOptions::default())
+    .expect("reused solve");
     for (i, (&a, &b)) in r.x.iter().zip(&reused.x).enumerate() {
         assert!(
             (a - b).abs() < 1e-9,

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -1,7 +1,6 @@
 use ndarray::array;
 use within::{
-    solve, Design, DesignOptions, Effect, IntoDesign, LsmrOptions, Preconditioner,
-    PreconditionerConfig, Solver,
+    solve, Design, DesignOptions, Effect, LsmrOptions, Preconditioner, PreconditionerConfig, Solver,
 };
 
 #[path = "common/orchestrate_helpers.rs"]
@@ -22,10 +21,7 @@ fn categories_and_y() -> (ndarray::Array2<u32>, Vec<f64>) {
 }
 
 fn design(categories: &ndarray::Array2<u32>) -> Design<'_> {
-    categories
-        .view()
-        .into_design(DesignOptions::default())
-        .expect("design")
+    Design::from_categories(categories.view(), DesignOptions::default()).expect("design")
 }
 
 #[test]
@@ -164,8 +160,11 @@ fn test_solver_batch_term_design_shares_drop_report() {
     ];
     let params = default_params();
 
-    let solver = Solver::new(Design::new(effects).expect("design"), additive_precond())
-        .expect("solver build");
+    let solver = Solver::new(
+        Design::from_effects(effects, DesignOptions::default()).expect("design"),
+        additive_precond(),
+    )
+    .expect("solver build");
     let batch = solver
         .solve_batch(&[&ys[0], &ys[1]], &params)
         .expect("solve batch");
@@ -295,23 +294,16 @@ fn test_internal_locality_sort_is_transparent() {
         let frame =
             ObservationFrame::new(vec![col0.clone().into(), col1.clone().into()], Vec::new())
                 .expect("frame");
-        let options = match weights {
-            Some(weights) => DesignOptions::default().weights(weights),
-            None => DesignOptions::default(),
-        };
-        let design = options.from_frame(frame).expect("design");
+        let options = DesignOptions::new(false, weights.map(Into::into));
+        let design = Design::from_frame(frame, options).expect("design");
         Solver::new(design, &precond).expect("solver")
     };
     let make_oracle = |weights: Option<Vec<f64>>| {
         let frame =
             ObservationFrame::new(vec![col0.clone().into(), col1.clone().into()], Vec::new())
                 .expect("frame");
-        let options = match weights {
-            Some(weights) => DesignOptions::default().weights(weights),
-            None => DesignOptions::default(),
-        }
-        .with_locality_sort(false);
-        let design = options.from_frame(frame).expect("oracle design");
+        let options = DesignOptions::new(false, weights.map(Into::into));
+        let design = Design::from_frame_unsorted(frame, options).expect("oracle design");
         Solver::new(design, &precond).expect("oracle solver")
     };
 

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -1,5 +1,8 @@
 use ndarray::array;
-use within::{solve, Effect, LsmrOptions, Preconditioner, PreconditionerConfig, Solver};
+use within::{
+    solve, Design, DesignOptions, Effect, IntoDesign, LsmrOptions, Preconditioner,
+    PreconditionerConfig, Solver,
+};
 
 #[path = "common/orchestrate_helpers.rs"]
 mod common;
@@ -18,23 +21,22 @@ fn categories_and_y() -> (ndarray::Array2<u32>, Vec<f64>) {
     (categories, y)
 }
 
+fn design(categories: &ndarray::Array2<u32>) -> Design<'_> {
+    categories
+        .view()
+        .into_design(DesignOptions::default())
+        .expect("design")
+}
+
 #[test]
 fn test_solver_matches_oneshot() {
     let (categories, y) = categories_and_y();
     let params = default_params();
     let precond = additive_precond();
 
-    let oneshot = solve(
-        categories.view(),
-        Default::default(),
-        &y,
-        None,
-        &params,
-        &precond,
-    )
-    .expect("oneshot");
+    let oneshot = solve(design(&categories), &y, &params, &precond).expect("oneshot");
 
-    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver = Solver::new(design(&categories), &precond).expect("solver build");
     let result = solver.solve(&y, &params).expect("solver solve");
 
     assert!(result.converged);
@@ -50,7 +52,7 @@ fn test_solver_demeaned() {
     let params = default_params();
     let precond = additive_precond();
 
-    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver = Solver::new(design(&categories), &precond).expect("solver build");
     let result = solver.solve(&y, &params).expect("solver solve");
 
     assert_eq!(result.demeaned.len(), y.len());
@@ -67,7 +69,7 @@ fn test_solver_no_preconditioner() {
     let (categories, y) = categories_and_y();
     let params = default_params();
 
-    let solver = Solver::new(categories.view(), None, None).expect("solver build");
+    let solver = Solver::new(design(&categories), None).expect("solver build");
     let result = solver.solve(&y, &params).expect("solver solve");
 
     assert!(result.converged);
@@ -80,7 +82,7 @@ fn test_solver_diagonal_preconditioner() {
     let params = default_params();
     let precond = PreconditionerConfig::Diagonal;
 
-    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver = Solver::new(design(&categories), &precond).expect("solver build");
     assert!(
         solver.preconditioner().is_some(),
         "diagonal preconditioner should be cached"
@@ -96,7 +98,7 @@ fn test_diagonal_preconditioner_single_factor_is_cached() {
     let categories = array![[0u32], [1], [0], [2], [1]];
     let precond = PreconditionerConfig::Diagonal;
 
-    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver = Solver::new(design(&categories), &precond).expect("solver build");
 
     let cached = solver
         .preconditioner()
@@ -115,7 +117,7 @@ fn test_solver_batch() {
     let params = default_params();
     let precond = additive_precond();
 
-    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver = Solver::new(design(&categories), &precond).expect("solver build");
 
     let r1 = solver.solve(&y1, &params).expect("solve y1");
     let r2 = solver.solve(&y2, &params).expect("solve y2");
@@ -162,7 +164,8 @@ fn test_solver_batch_term_design_shares_drop_report() {
     ];
     let params = default_params();
 
-    let solver = Solver::new(effects, None, additive_precond()).expect("solver build");
+    let solver = Solver::new(Design::new(effects).expect("design"), additive_precond())
+        .expect("solver build");
     let batch = solver
         .solve_batch(&[&ys[0], &ys[1]], &params)
         .expect("solve batch");
@@ -186,7 +189,7 @@ fn test_unidentified_empty_for_plain_factors() {
     let params = default_params();
     let precond = additive_precond();
 
-    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver = Solver::new(design(&categories), &precond).expect("solver build");
 
     let single = solver.solve(&y, &params).expect("solve");
     assert!(single.unidentified.is_empty());
@@ -200,7 +203,7 @@ fn test_unidentified_empty_for_plain_factors() {
 fn test_solver_properties() {
     let (categories, _) = categories_and_y();
 
-    let solver = Solver::new(categories.view(), None, None).expect("solver build");
+    let solver = Solver::new(design(&categories), None).expect("solver build");
 
     assert_eq!(solver.n_dofs(), 5); // 3 levels + 2 levels
     assert_eq!(solver.n_obs(), 5);
@@ -212,7 +215,7 @@ fn test_serde_roundtrip() {
     let params = default_params();
     let precond = additive_precond();
 
-    let solver1 = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver1 = Solver::new(design(&categories), &precond).expect("solver build");
     let r1 = solver1.solve(&y, &params).expect("solve 1");
 
     // Serialize preconditioner
@@ -224,8 +227,7 @@ fn test_serde_roundtrip() {
 
     // Deserialize and build new solver
     let precond2: Preconditioner = postcard::from_bytes(&bytes).expect("deserialize");
-    let solver2 =
-        Solver::new(categories.view(), None, precond2).expect("solver from preconditioner");
+    let solver2 = Solver::new(design(&categories), precond2).expect("solver from preconditioner");
     let r2 = solver2.solve(&y, &params).expect("solve 2");
 
     for (a, b) in r1.x.iter().zip(r2.x.iter()) {
@@ -237,7 +239,7 @@ fn test_serde_roundtrip() {
 fn test_diagonal_serde_roundtrip() {
     let (categories, _) = categories_and_y();
     let precond = PreconditionerConfig::Diagonal;
-    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver = Solver::new(design(&categories), &precond).expect("solver build");
     let precond_ref = solver
         .preconditioner()
         .expect("should have diagonal preconditioner");
@@ -263,7 +265,7 @@ fn test_solver_accepts_prebuilt_design() {
     let params = default_params();
     let precond = additive_precond();
 
-    let solver = Solver::new(design, None, &precond).expect("prebuilt design");
+    let solver = Solver::new(design, &precond).expect("prebuilt design");
     let result = solver.solve(&y, &params).expect("solve");
     assert!(result.converged);
 }
@@ -277,7 +279,6 @@ fn test_solver_accepts_prebuilt_design() {
 #[test]
 fn test_internal_locality_sort_is_transparent() {
     use within::observation::ObservationFrame;
-    use within::Design;
 
     // Factor 0 (4 levels) is the dominant factor and is non-monotonic.
     let col0: Vec<u32> = vec![3, 0, 2, 1, 3, 0, 2, 1, 3, 0, 2, 1];
@@ -291,15 +292,27 @@ fn test_internal_locality_sort_is_transparent() {
     let precond = additive_precond();
 
     let make_solver = |weights: Option<Vec<f64>>| {
-        let design = common::make_design(vec![col0.clone(), col1.clone()]).expect("design");
-        Solver::new(design, weights, &precond).expect("solver")
+        let frame =
+            ObservationFrame::new(vec![col0.clone().into(), col1.clone().into()], Vec::new())
+                .expect("frame");
+        let options = match weights {
+            Some(weights) => DesignOptions::default().weights(weights),
+            None => DesignOptions::default(),
+        };
+        let design = options.from_frame(frame).expect("design");
+        Solver::new(design, &precond).expect("solver")
     };
     let make_oracle = |weights: Option<Vec<f64>>| {
         let frame =
             ObservationFrame::new(vec![col0.clone().into(), col1.clone().into()], Vec::new())
                 .expect("frame");
-        let design = Design::from_frame_unsorted(frame).expect("oracle design");
-        Solver::new(design, weights, &precond).expect("oracle solver")
+        let options = match weights {
+            Some(weights) => DesignOptions::default().weights(weights),
+            None => DesignOptions::default(),
+        }
+        .with_locality_sort(false);
+        let design = options.from_frame(frame).expect("oracle design");
+        Solver::new(design, &precond).expect("oracle solver")
     };
 
     // The weighted run also exercises the weights-permutation path.

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -294,7 +294,10 @@ fn test_internal_locality_sort_is_transparent() {
         let frame =
             ObservationFrame::new(vec![col0.clone().into(), col1.clone().into()], Vec::new())
                 .expect("frame");
-        let options = DesignOptions::new(false, weights.map(Into::into));
+        let options = DesignOptions {
+            weights: weights.map(Into::into),
+            ..Default::default()
+        };
         let design = Design::from_frame(frame, options).expect("design");
         Solver::new(design, &precond).expect("solver")
     };
@@ -302,7 +305,10 @@ fn test_internal_locality_sort_is_transparent() {
         let frame =
             ObservationFrame::new(vec![col0.clone().into(), col1.clone().into()], Vec::new())
                 .expect("frame");
-        let options = DesignOptions::new(false, weights.map(Into::into));
+        let options = DesignOptions {
+            weights: weights.map(Into::into),
+            ..Default::default()
+        };
         let design = Design::from_frame_unsorted(frame, options).expect("oracle design");
         Solver::new(design, &precond).expect("oracle solver")
     };

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -24,7 +24,15 @@ fn test_solver_matches_oneshot() {
     let params = default_params();
     let precond = additive_precond();
 
-    let oneshot = solve(categories.view(), &y, None, &params, &precond).expect("oneshot");
+    let oneshot = solve(
+        categories.view(),
+        Default::default(),
+        &y,
+        None,
+        &params,
+        &precond,
+    )
+    .expect("oneshot");
 
     let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
     let result = solver.solve(&y, &params).expect("solver solve");

--- a/crates/within/tests/warnings.rs
+++ b/crates/within/tests/warnings.rs
@@ -2,7 +2,7 @@
 //! [`BuildWarning`]s, not just [`Solver::warnings`] (#165).
 
 use within::{
-    solve, solve_batch, BuildWarning, Effect, LocalSolverConfig, PreconditionerConfig,
+    solve, solve_batch, BuildWarning, Design, Effect, LocalSolverConfig, PreconditionerConfig,
     ReductionStrategy, ScalingConfig, ScalingFailure, Solver,
 };
 
@@ -47,7 +47,13 @@ fn free_solve_surfaces_build_warnings() {
     let y = [1.0, 2.0, 0.5, -1.0];
     let cfg = strict_scaling();
 
-    let result = solve(warning_effects(), Default::default(), &y, None, None, &cfg).expect("solve");
+    let result = solve(
+        Design::new(warning_effects()).expect("design"),
+        &y,
+        None,
+        &cfg,
+    )
+    .expect("solve");
     assert!(
         has_scaling_warning(&result.warnings),
         "free solve dropped the preconditioner build warning: {:?}",
@@ -55,7 +61,8 @@ fn free_solve_surfaces_build_warnings() {
     );
 
     // The result field mirrors the solver accessor exactly.
-    let solver = Solver::new(warning_effects(), None, &cfg).expect("solver");
+    let solver =
+        Solver::new(Design::new(warning_effects()).expect("design"), &cfg).expect("solver");
     assert_eq!(result.warnings.as_slice(), solver.warnings());
 }
 
@@ -66,8 +73,13 @@ fn free_solve_batch_surfaces_build_warnings() {
     let ys: [&[f64]; 2] = [&y0, &y1];
     let cfg = strict_scaling();
 
-    let result = solve_batch(warning_effects(), Default::default(), &ys, None, None, &cfg)
-        .expect("solve_batch");
+    let result = solve_batch(
+        Design::new(warning_effects()).expect("design"),
+        &ys,
+        None,
+        &cfg,
+    )
+    .expect("solve_batch");
     assert!(
         has_scaling_warning(&result.warnings),
         "free solve_batch dropped the preconditioner build warning: {:?}",
@@ -75,6 +87,7 @@ fn free_solve_batch_surfaces_build_warnings() {
     );
 
     // The result field mirrors the solver accessor exactly.
-    let solver = Solver::new(warning_effects(), None, &cfg).expect("solver");
+    let solver =
+        Solver::new(Design::new(warning_effects()).expect("design"), &cfg).expect("solver");
     assert_eq!(result.warnings.as_slice(), solver.warnings());
 }

--- a/crates/within/tests/warnings.rs
+++ b/crates/within/tests/warnings.rs
@@ -1,5 +1,5 @@
-//! One-shot `solve`/`solve_batch` entry points surface preconditioner
-//! [`BuildWarning`]s, not just [`Solver::warnings`] (#165).
+//! One-shot `solve`/`solve_batch` entry points surface [`BuildWarning`]s, not
+//! just [`Solver::warnings`] (#165).
 
 use within::{
     solve, solve_batch, BuildWarning, Design, DesignOptions, Effect, LocalSolverConfig,
@@ -40,6 +40,33 @@ fn has_scaling_warning(warnings: &[BuildWarning]) -> bool {
     warnings
         .iter()
         .any(|w| matches!(w, BuildWarning::UnscalableComponent { .. }))
+}
+
+#[test]
+fn singleton_removal_surfaces_as_build_warning() {
+    let levels = [0, 0, 1];
+    let y = [1.0, 2.0, 3.0];
+    let design = Design::from_effects(
+        [Effect::new(&levels, true, []).unwrap()],
+        DesignOptions {
+            drop_singletons: true,
+            ..DesignOptions::default()
+        },
+    )
+    .expect("design");
+
+    let solver = Solver::new(design, PreconditionerConfig::Off).expect("solver");
+    assert_eq!(
+        solver.warnings(),
+        &[BuildWarning::SingletonObservationsRemoved { count: 1 }]
+    );
+    assert_eq!(
+        solver.warnings()[0].to_string(),
+        "1 singleton observation(s) removed"
+    );
+
+    let result = solver.solve(&y, None).expect("solve");
+    assert_eq!(result.warnings.as_slice(), solver.warnings());
 }
 
 #[test]

--- a/crates/within/tests/warnings.rs
+++ b/crates/within/tests/warnings.rs
@@ -2,8 +2,8 @@
 //! [`BuildWarning`]s, not just [`Solver::warnings`] (#165).
 
 use within::{
-    solve, solve_batch, BuildWarning, Design, Effect, LocalSolverConfig, PreconditionerConfig,
-    ReductionStrategy, ScalingConfig, ScalingFailure, Solver,
+    solve, solve_batch, BuildWarning, Design, DesignOptions, Effect, LocalSolverConfig,
+    PreconditionerConfig, ReductionStrategy, ScalingConfig, ScalingFailure, Solver,
 };
 
 // Two crossed slope-only factors: their signed slope cross-block is not
@@ -48,7 +48,7 @@ fn free_solve_surfaces_build_warnings() {
     let cfg = strict_scaling();
 
     let result = solve(
-        Design::new(warning_effects()).expect("design"),
+        Design::from_effects(warning_effects(), DesignOptions::default()).expect("design"),
         &y,
         None,
         &cfg,
@@ -61,8 +61,11 @@ fn free_solve_surfaces_build_warnings() {
     );
 
     // The result field mirrors the solver accessor exactly.
-    let solver =
-        Solver::new(Design::new(warning_effects()).expect("design"), &cfg).expect("solver");
+    let solver = Solver::new(
+        Design::from_effects(warning_effects(), DesignOptions::default()).expect("design"),
+        &cfg,
+    )
+    .expect("solver");
     assert_eq!(result.warnings.as_slice(), solver.warnings());
 }
 
@@ -74,7 +77,7 @@ fn free_solve_batch_surfaces_build_warnings() {
     let cfg = strict_scaling();
 
     let result = solve_batch(
-        Design::new(warning_effects()).expect("design"),
+        Design::from_effects(warning_effects(), DesignOptions::default()).expect("design"),
         &ys,
         None,
         &cfg,
@@ -87,7 +90,10 @@ fn free_solve_batch_surfaces_build_warnings() {
     );
 
     // The result field mirrors the solver accessor exactly.
-    let solver =
-        Solver::new(Design::new(warning_effects()).expect("design"), &cfg).expect("solver");
+    let solver = Solver::new(
+        Design::from_effects(warning_effects(), DesignOptions::default()).expect("design"),
+        &cfg,
+    )
+    .expect("solver");
     assert_eq!(result.warnings.as_slice(), solver.warnings());
 }

--- a/crates/within/tests/warnings.rs
+++ b/crates/within/tests/warnings.rs
@@ -47,7 +47,7 @@ fn free_solve_surfaces_build_warnings() {
     let y = [1.0, 2.0, 0.5, -1.0];
     let cfg = strict_scaling();
 
-    let result = solve(warning_effects(), &y, None, None, &cfg).expect("solve");
+    let result = solve(warning_effects(), Default::default(), &y, None, None, &cfg).expect("solve");
     assert!(
         has_scaling_warning(&result.warnings),
         "free solve dropped the preconditioner build warning: {:?}",
@@ -66,7 +66,8 @@ fn free_solve_batch_surfaces_build_warnings() {
     let ys: [&[f64]; 2] = [&y0, &y1];
     let cfg = strict_scaling();
 
-    let result = solve_batch(warning_effects(), &ys, None, None, &cfg).expect("solve_batch");
+    let result = solve_batch(warning_effects(), Default::default(), &ys, None, None, &cfg)
+        .expect("solve_batch");
     assert!(
         has_scaling_warning(&result.warnings),
         "free solve_batch dropped the preconditioner build warning: {:?}",

--- a/crates/within/tests/wire_format_fixture.rs
+++ b/crates/within/tests/wire_format_fixture.rs
@@ -3,7 +3,7 @@
 //! cross-version encoding shifts the same-build round-trip test cannot.
 //! Regenerate via the `#[ignore]`d `regenerate_wire_format_fixture` test.
 
-use within::{Effect, LsmrOptions, Preconditioner, PreconditionerConfig, Solver};
+use within::{Design, Effect, LsmrOptions, Preconditioner, PreconditionerConfig, Solver};
 
 const WIRE_FORMAT_VERSION: u32 = 12;
 const PRECOND_BYTES: &[u8] = include_bytes!("fixtures/preconditioner_v12.postcard");
@@ -33,8 +33,11 @@ fn wire_format_fixture_deserializes_and_solves() {
     let prebuilt: Preconditioner =
         postcard::from_bytes(PRECOND_BYTES).expect("deserialize fixture preconditioner");
 
-    let solver = Solver::new(fixture_effects(&f, &g, &z), None, prebuilt)
-        .expect("build solver from fixture");
+    let solver = Solver::new(
+        Design::new(fixture_effects(&f, &g, &z)).expect("design"),
+        prebuilt,
+    )
+    .expect("build solver from fixture");
     let result = solver
         .solve(&y, &LsmrOptions::default())
         .expect("solve with fixture preconditioner");
@@ -43,8 +46,7 @@ fn wire_format_fixture_deserializes_and_solves() {
 
     // Compare against a fresh build to detect any semantic regression.
     let fresh = Solver::new(
-        fixture_effects(&f, &g, &z),
-        None,
+        Design::new(fixture_effects(&f, &g, &z)).expect("design"),
         PreconditionerConfig::default(),
     )
     .expect("fresh solver");
@@ -65,8 +67,7 @@ fn wire_format_fixture_deserializes_and_solves() {
 fn signed_route_preconditioner_round_trips() {
     let (f, g, z, y) = fixture_problem();
     let solver1 = Solver::new(
-        fixture_effects(&f, &g, &z),
-        None,
+        Design::new(fixture_effects(&f, &g, &z)).expect("design"),
         PreconditionerConfig::default(),
     )
     .expect("build solver");
@@ -76,8 +77,11 @@ fn signed_route_preconditioner_round_trips() {
         .expect("serialize");
     let restored: Preconditioner = postcard::from_bytes(&bytes).expect("deserialize");
 
-    let solver2 =
-        Solver::new(fixture_effects(&f, &g, &z), None, restored).expect("solver from round-trip");
+    let solver2 = Solver::new(
+        Design::new(fixture_effects(&f, &g, &z)).expect("design"),
+        restored,
+    )
+    .expect("solver from round-trip");
     let r2 = solver2.solve(&y, &LsmrOptions::default()).expect("solve 2");
 
     for (a, b) in r1.x.iter().zip(r2.x.iter()) {
@@ -106,8 +110,7 @@ fn regenerate_wire_format_fixture() {
 
     let (f, g, z, _) = fixture_problem();
     let solver = Solver::new(
-        fixture_effects(&f, &g, &z),
-        None,
+        Design::new(fixture_effects(&f, &g, &z)).expect("design"),
         PreconditionerConfig::default(),
     )
     .expect("build solver");

--- a/crates/within/tests/wire_format_fixture.rs
+++ b/crates/within/tests/wire_format_fixture.rs
@@ -3,7 +3,9 @@
 //! cross-version encoding shifts the same-build round-trip test cannot.
 //! Regenerate via the `#[ignore]`d `regenerate_wire_format_fixture` test.
 
-use within::{Design, Effect, LsmrOptions, Preconditioner, PreconditionerConfig, Solver};
+use within::{
+    Design, DesignOptions, Effect, LsmrOptions, Preconditioner, PreconditionerConfig, Solver,
+};
 
 const WIRE_FORMAT_VERSION: u32 = 12;
 const PRECOND_BYTES: &[u8] = include_bytes!("fixtures/preconditioner_v12.postcard");
@@ -34,7 +36,8 @@ fn wire_format_fixture_deserializes_and_solves() {
         postcard::from_bytes(PRECOND_BYTES).expect("deserialize fixture preconditioner");
 
     let solver = Solver::new(
-        Design::new(fixture_effects(&f, &g, &z)).expect("design"),
+        Design::from_effects(fixture_effects(&f, &g, &z), DesignOptions::default())
+            .expect("design"),
         prebuilt,
     )
     .expect("build solver from fixture");
@@ -46,7 +49,8 @@ fn wire_format_fixture_deserializes_and_solves() {
 
     // Compare against a fresh build to detect any semantic regression.
     let fresh = Solver::new(
-        Design::new(fixture_effects(&f, &g, &z)).expect("design"),
+        Design::from_effects(fixture_effects(&f, &g, &z), DesignOptions::default())
+            .expect("design"),
         PreconditionerConfig::default(),
     )
     .expect("fresh solver");
@@ -67,7 +71,8 @@ fn wire_format_fixture_deserializes_and_solves() {
 fn signed_route_preconditioner_round_trips() {
     let (f, g, z, y) = fixture_problem();
     let solver1 = Solver::new(
-        Design::new(fixture_effects(&f, &g, &z)).expect("design"),
+        Design::from_effects(fixture_effects(&f, &g, &z), DesignOptions::default())
+            .expect("design"),
         PreconditionerConfig::default(),
     )
     .expect("build solver");
@@ -78,7 +83,8 @@ fn signed_route_preconditioner_round_trips() {
     let restored: Preconditioner = postcard::from_bytes(&bytes).expect("deserialize");
 
     let solver2 = Solver::new(
-        Design::new(fixture_effects(&f, &g, &z)).expect("design"),
+        Design::from_effects(fixture_effects(&f, &g, &z), DesignOptions::default())
+            .expect("design"),
         restored,
     )
     .expect("solver from round-trip");
@@ -110,7 +116,8 @@ fn regenerate_wire_format_fixture() {
 
     let (f, g, z, _) = fixture_problem();
     let solver = Solver::new(
-        Design::new(fixture_effects(&f, &g, &z)).expect("design"),
+        Design::from_effects(fixture_effects(&f, &g, &z), DesignOptions::default())
+            .expect("design"),
         PreconditionerConfig::default(),
     )
     .expect("build solver");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "within-py"
-version = "0.3.0"
+version = "0.4.0"
 description = "High-performance fixed-effects solver for econometric panel data"
 readme = "README.md"
 authors = [

--- a/python/within/README.md
+++ b/python/within/README.md
@@ -31,7 +31,7 @@ fe = np.asfortranarray(np.column_stack([
 y = np.random.randn(n)
 
 result = solve(fe, y)                          # Schwarz-preconditioned LSMR
-result = solve(fe, y, weights=np.ones(n))      # weighted solve
+result = solve(fe, y, design_options=DesignOptions(weights=np.ones(n)))
 result = solve(fe, y, preconditioner=PreconditionerConfig.Diagonal)
 result = solve(
     fe,
@@ -59,8 +59,8 @@ print(np.round(beta_hat, 4))  # [ 0.9982 -2.006   0.5005]
 
 | Function | Description |
 |---|---|
-| `solve(design, y, weights?, options?, preconditioner?, *, design_options?)` | Solve a single right-hand side. Returns `SolveResult`. |
-| `solve_batch(design, Y, weights?, options?, preconditioner?, *, design_options?)` | Solve multiple RHS vectors in parallel. `Y` has shape `(n_obs, k)`. Returns `BatchSolveResult`. |
+| `solve(design, y, options?, preconditioner?, *, design_options?)` | Solve a single right-hand side. Returns `SolveResult`. |
+| `solve_batch(design, Y, options?, preconditioner?, *, design_options?)` | Solve multiple RHS vectors in parallel. `Y` has shape `(n_obs, k)`. Returns `BatchSolveResult`. |
 
 `design` is a 2-D `uint32` array of category codes with shape `(n_obs, n_factors)`, or a list of `Effect` terms for varying slopes. A `UserWarning` is emitted when a C-contiguous array is passed — if the data is already sorted by the largest factor, `np.asfortranarray(design)` gives faster solves; unsorted input is copied internally either way.
 
@@ -81,7 +81,7 @@ solver2 = Solver(fe, preconditioner=precond)   # skip re-factorization
 
 | Property / Method | Description |
 |---|---|
-| `Solver(design, weights?, preconditioner?, *, design_options?)` | Build solver. Factorizes the preconditioner at construction. |
+| `Solver(design, preconditioner?, *, design_options?)` | Build solver. Factorizes the preconditioner at construction. |
 | `.solve(y, options?)` | Solve a single RHS with the given LSMR tuning. Returns `SolveResult`. |
 | `.solve_batch(Y, options?)` | Solve multiple RHS columns in parallel. Returns `BatchSolveResult`. |
 | `.preconditioner` | Return the built `Preconditioner` (picklable), or `None`. Reuse via `Solver(..., preconditioner=p)`. |

--- a/python/within/README.md
+++ b/python/within/README.md
@@ -19,7 +19,7 @@ pip install within_py
 `within`'s main user-facing function is `solve`. Provide a 2-D `uint32` array of category codes (one column per fixed-effect factor) and a response vector `y`. The solver finds x in the normal equations **D'D x = D'y**, where D is the sparse categorical design matrix.
 
 ```python
-from within import PreconditionerConfig, solve, solve_batch
+from within import DesignOptions, PreconditionerConfig, solve, solve_batch
 import numpy as np
 
 np.random.seed(1)
@@ -33,6 +33,11 @@ y = np.random.randn(n)
 result = solve(fe, y)                          # Schwarz-preconditioned LSMR
 result = solve(fe, y, weights=np.ones(n))      # weighted solve
 result = solve(fe, y, preconditioner=PreconditionerConfig.Diagonal)
+result = solve(
+    fe,
+    y,
+    design_options=DesignOptions(drop_singletons=True),
+)
 ```
 
 ### FWL regression example
@@ -54,8 +59,8 @@ print(np.round(beta_hat, 4))  # [ 0.9982 -2.006   0.5005]
 
 | Function | Description |
 |---|---|
-| `solve(design, y, weights?, options?, preconditioner?)` | Solve a single right-hand side. Returns `SolveResult`. |
-| `solve_batch(design, Y, weights?, options?, preconditioner?)` | Solve multiple RHS vectors in parallel. `Y` has shape `(n_obs, k)`. Returns `BatchSolveResult`. |
+| `solve(design, y, weights?, options?, preconditioner?, *, design_options?)` | Solve a single right-hand side. Returns `SolveResult`. |
+| `solve_batch(design, Y, weights?, options?, preconditioner?, *, design_options?)` | Solve multiple RHS vectors in parallel. `Y` has shape `(n_obs, k)`. Returns `BatchSolveResult`. |
 
 `design` is a 2-D `uint32` array of category codes with shape `(n_obs, n_factors)`, or a list of `Effect` terms for varying slopes. A `UserWarning` is emitted when a C-contiguous array is passed — if the data is already sorted by the largest factor, `np.asfortranarray(design)` gives faster solves; unsorted input is copied internally either way.
 
@@ -66,7 +71,7 @@ For repeated solves with the same design matrix, `Solver` builds the preconditio
 ```python
 from within import Solver
 
-solver = Solver(fe)
+solver = Solver(fe, design_options=DesignOptions(drop_singletons=True))
 r = solver.solve(y)                            # reuses preconditioner
 r = solver.solve_batch(np.column_stack([y, X]))
 
@@ -76,7 +81,7 @@ solver2 = Solver(fe, preconditioner=precond)   # skip re-factorization
 
 | Property / Method | Description |
 |---|---|
-| `Solver(design, weights?, preconditioner?)` | Build solver. Factorizes the preconditioner at construction. |
+| `Solver(design, weights?, preconditioner?, *, design_options?)` | Build solver. Factorizes the preconditioner at construction. |
 | `.solve(y, options?)` | Solve a single RHS with the given LSMR tuning. Returns `SolveResult`. |
 | `.solve_batch(Y, options?)` | Solve multiple RHS columns in parallel. Returns `BatchSolveResult`. |
 | `.preconditioner` | Return the built `Preconditioner` (picklable), or `None`. Reuse via `Solver(..., preconditioner=p)`. |

--- a/python/within/__init__.py
+++ b/python/within/__init__.py
@@ -46,6 +46,7 @@ For Rust-level internals, build the API docs with ``cargo doc --open``.
 from within._within import (
     BatchSolveResult,
     CoefficientLayout,
+    DesignOptions,
     Effect,
     LsmrOptions,
     Preconditioner,
@@ -61,6 +62,7 @@ from within import config  # noqa: F401 — expose submodule on `within.config`
 __all__ = [
     "BatchSolveResult",
     "CoefficientLayout",
+    "DesignOptions",
     "Effect",
     "LsmrOptions",
     "Preconditioner",

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -216,16 +216,22 @@ class DesignOptions:
     Attributes:
         drop_singletons: Iteratively remove observations belonging to a
             singleton level in any fixed-effect term.
+        weights: Observation weights in caller row order, or ``None``.
     """
 
     @property
     def drop_singletons(self) -> bool: ...
-    def __init__(self, drop_singletons: bool = False) -> None: ...
+    @property
+    def weights(self) -> list[float] | None: ...
+    def __init__(
+        self,
+        drop_singletons: bool = False,
+        weights: NDArray[np.float64] | None = None,
+    ) -> None: ...
 
 def solve(
     design: NDArray[np.uint32] | list[Effect],
     y: NDArray[np.float64],
-    weights: NDArray[np.float64] | None = None,
     options: LsmrOptions | None = None,
     preconditioner: (
         PreconditionerConfig | AdditiveSchwarz | Preconditioner | None
@@ -244,8 +250,6 @@ def solve(
             assignments (F-contiguous for best performance; a ``UserWarning``
             is emitted otherwise), or a list of :class:`Effect` terms.
         y: Response vector, shape ``(n_obs,)``, dtype ``float64``.
-        weights: Observation weights, shape ``(n_obs,)``, dtype ``float64``.
-            Default: unit weights (unweighted).
         options: LSMR solver tuning. Pass ``LsmrOptions(...)`` to override
             defaults. Default: ``LsmrOptions(tol=1e-8, maxiter=1000)``.
         preconditioner: Controls preconditioning. Five input forms are accepted:
@@ -256,8 +260,9 @@ def solve(
             settings. A previously-built ``Preconditioner`` instance reuses an
             existing factorisation.
         design_options: Processing applied while constructing the design.
-            Omitted by default; use ``DesignOptions(drop_singletons=True)`` to
-            iteratively remove singleton observations. Removed rows are
+            Omitted by default. Use ``DesignOptions(drop_singletons=True)`` to
+            iteratively remove singleton observations and
+            ``DesignOptions(weights=weights)`` for weighting. Removed rows are
             represented by ``NaN`` in ``demeaned``.
 
     Returns:
@@ -293,7 +298,6 @@ def solve(
 def solve_batch(
     design: NDArray[np.uint32] | list[Effect],
     Y: NDArray[np.float64],
-    weights: NDArray[np.float64] | None = None,
     options: LsmrOptions | None = None,
     preconditioner: (
         PreconditionerConfig | AdditiveSchwarz | Preconditioner | None
@@ -312,7 +316,6 @@ def solve_batch(
             is emitted otherwise), or a list of :class:`Effect` terms.
         Y: Response matrix, shape ``(n_obs, k)``, dtype ``float64``. Each column
             is a separate response vector.
-        weights: Observation weights. Default: unit weights.
         options: LSMR solver tuning. Default: ``LsmrOptions(tol=1e-8, maxiter=1000)``.
         preconditioner: Preconditioner configuration; see :func:`solve` for the
             accepted forms.
@@ -360,7 +363,6 @@ class Solver:
     def __init__(
         self,
         design: NDArray[np.uint32] | list[Effect],
-        weights: NDArray[np.float64] | None = None,
         preconditioner: (
             PreconditionerConfig | AdditiveSchwarz | Preconditioner | None
         ) = None,

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -210,6 +210,18 @@ class Effect:
         slopes: list[NDArray[np.float64]] | None = None,
     ) -> None: ...
 
+class DesignOptions:
+    """Processing applied while constructing a fixed-effects design.
+
+    Attributes:
+        drop_singletons: Iteratively remove observations belonging to a
+            singleton level in any fixed-effect term.
+    """
+
+    @property
+    def drop_singletons(self) -> bool: ...
+    def __init__(self, drop_singletons: bool = False) -> None: ...
+
 def solve(
     design: NDArray[np.uint32] | list[Effect],
     y: NDArray[np.float64],
@@ -218,6 +230,8 @@ def solve(
     preconditioner: (
         PreconditionerConfig | AdditiveSchwarz | Preconditioner | None
     ) = None,
+    *,
+    design_options: DesignOptions | None = None,
 ) -> SolveResult:
     """Solve fixed-effects normal equations for a single response vector.
 
@@ -241,6 +255,10 @@ def solve(
             ``AdditiveSchwarz(...)`` overrides the local-solver / reduction
             settings. A previously-built ``Preconditioner`` instance reuses an
             existing factorisation.
+        design_options: Processing applied while constructing the design.
+            Omitted by default; use ``DesignOptions(drop_singletons=True)`` to
+            iteratively remove singleton observations. Removed rows are
+            represented by ``NaN`` in ``demeaned``.
 
     Returns:
         A ``SolveResult`` with coefficients, demeaned response, convergence
@@ -280,6 +298,8 @@ def solve_batch(
     preconditioner: (
         PreconditionerConfig | AdditiveSchwarz | Preconditioner | None
     ) = None,
+    *,
+    design_options: DesignOptions | None = None,
 ) -> BatchSolveResult:
     """Solve fixed-effects normal equations for multiple response vectors.
 
@@ -296,6 +316,8 @@ def solve_batch(
         options: LSMR solver tuning. Default: ``LsmrOptions(tol=1e-8, maxiter=1000)``.
         preconditioner: Preconditioner configuration; see :func:`solve` for the
             accepted forms.
+        design_options: Processing applied while constructing the design; see
+            :func:`solve`.
 
     Returns:
         A ``BatchSolveResult`` with stacked coefficients and per-RHS metadata.
@@ -342,6 +364,8 @@ class Solver:
         preconditioner: (
             PreconditionerConfig | AdditiveSchwarz | Preconditioner | None
         ) = None,
+        *,
+        design_options: DesignOptions | None = None,
     ) -> None: ...
     def solve(
         self,

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -13,7 +13,14 @@ import warnings
 import numpy as np
 import pytest
 
-from within import LsmrOptions, PreconditionerConfig, Solver, solve, solve_batch
+from within import (
+    DesignOptions,
+    LsmrOptions,
+    PreconditionerConfig,
+    Solver,
+    solve,
+    solve_batch,
+)
 
 from conftest import as_solver_categories
 
@@ -44,7 +51,7 @@ class TestNanInfPropagation:
         y = np.array([1.0, 2.0, 3.0])
         w = np.array([1.0, np.nan, 1.0])
         with pytest.raises(ValueError, match="finite"):
-            solve(cats, y, weights=w)
+            solve(cats, y, design_options=DesignOptions(weights=w))
 
     def test_inf_in_weights_rejected(self):
         """Inf in weights should be rejected at build validation."""
@@ -52,7 +59,7 @@ class TestNanInfPropagation:
         y = np.array([1.0, 2.0, 3.0])
         w = np.array([1.0, np.inf, 1.0])
         with pytest.raises(ValueError, match="finite"):
-            solve(cats, y, weights=w)
+            solve(cats, y, design_options=DesignOptions(weights=w))
 
 
 # ---------------------------------------------------------------------------
@@ -201,8 +208,12 @@ class TestNonContiguousInputs:
         w_strided = w_full[::2]
         assert not w_strided.flags["C_CONTIGUOUS"]
 
-        result_contiguous = solve(cats, y, weights=w_direct)
-        result_strided = solve(cats, y, weights=w_strided)
+        result_contiguous = solve(
+            cats, y, design_options=DesignOptions(weights=w_direct)
+        )
+        result_strided = solve(
+            cats, y, design_options=DesignOptions(weights=w_strided)
+        )
 
         assert result_contiguous.converged and result_strided.converged
         np.testing.assert_allclose(result_contiguous.x, result_strided.x, atol=1e-12)

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from within import Effect, solve
+from within import DesignOptions, Effect, solve
 from within._within import ApproxSchurConfig
 
 from conftest import as_solver_categories
@@ -30,7 +30,7 @@ class TestErrorHandling:
         y = np.array([1.0, 2.0, 3.0])
         weights = np.array([1.0, 2.0])  # wrong length
         with pytest.raises(ValueError):
-            solve(cats, y, weights=weights)
+            solve(cats, y, design_options=DesignOptions(weights=weights))
 
     def test_wrong_dtype_categories(self):
         """float64 categories should raise a TypeError naming uint32."""
@@ -55,11 +55,9 @@ class TestErrorHandling:
 
     def test_wrong_dtype_weights(self):
         """float32 weights should raise a TypeError naming float64."""
-        cats = as_solver_categories([np.array([0, 1, 0]), np.array([0, 0, 1])])
-        y = np.array([1.0, 2.0, 3.0])
         w = np.array([1.0, 1.0, 1.0], dtype=np.float32)
         with pytest.raises(TypeError, match="float64"):
-            solve(cats, y, weights=w)
+            DesignOptions(weights=w)
 
     def test_1d_categories_raises(self):
         """1-D categories should raise TypeError."""

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -89,17 +89,15 @@ def test_coefficient_layout_locates_unidentified_and_round_trips():
         layout.address(layout.n_dofs())
 
 
-def test_free_solve_positional_order_is_weights_then_options():
-    # Pins (design, y, weights, options, ...): a weights array 3rd and
-    # LsmrOptions 4th must be accepted. A re-swap would parse the array as
-    # options (and LsmrOptions as weights) and raise.
+def test_free_solve_positional_order_uses_options_third():
+    # Pins (design, y, options, ...): LsmrOptions is the third positional
+    # argument now that weights belong to DesignOptions.
     rng = np.random.default_rng(0)
     cats = as_solver_categories(
         [rng.integers(0, 8, size=300), rng.integers(0, 6, size=300)]
     )
     y = rng.standard_normal(300)
-    w = rng.uniform(0.5, 2.0, size=300)
-    result = solve(cats, y, w, LsmrOptions(maxiter=2000))
+    result = solve(cats, y, LsmrOptions(maxiter=2000))
     assert result.converged
 
 
@@ -199,7 +197,11 @@ class TestSolveWeighted:
     def test_weighted(self, problem):
         cats, y = problem
         weights = np.random.exponential(1.0, size=len(y))
-        result = solve(as_solver_categories(cats), y, weights=weights)
+        result = solve(
+            as_solver_categories(cats),
+            y,
+            design_options=DesignOptions(weights=weights),
+        )
         assert result.converged
 
 
@@ -567,7 +569,9 @@ class TestSolveBatchFreeFunction:
         Y = np.column_stack([y, np.random.randn(len(y))])
         from within import solve_batch
 
-        result = solve_batch(categories, Y, weights=weights)
+        result = solve_batch(
+            categories, Y, design_options=DesignOptions(weights=weights)
+        )
         assert all(result.converged)
 
     def test_solve_batch_single_column(self, problem):

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -5,6 +5,7 @@ import warnings
 import numpy as np
 import pytest
 
+from conftest import as_solver_categories, generate_synthetic_data
 from within import (
     BatchSolveResult,
     CoefficientLayout,
@@ -18,8 +19,6 @@ from within import (
     solve_batch,
 )
 from within.config import AdditiveSchwarz, LocalSolverConfig, ScalingConfig
-
-from conftest import as_solver_categories, generate_synthetic_data
 
 
 def assert_normal_equations_satisfied(cats, y, result, tol, weights=None):
@@ -39,7 +38,7 @@ def assert_normal_equations_satisfied(cats, y, result, tol, weights=None):
         c = np.asarray(c)
         num_sq += np.square(np.bincount(c, weights=w * demeaned)).sum()
         den_sq += np.square(np.bincount(c, weights=w * y)).sum()
-    relative = num_sq**0.5 / max(den_sq**0.5, 1e-15)
+    relative = num_sq ** 0.5 / max(den_sq ** 0.5, 1e-15)
     assert relative < tol, (
         f"independent normal-equation residual {relative} exceeds {tol}"
     )
@@ -58,11 +57,11 @@ def test_coefficient_layout_locates_unidentified_and_round_trips():
     assert isinstance(layout, CoefficientLayout)
     assert layout.n_dofs() == len(res.x)
     assert [
-        (layout.n_levels(t), layout.n_columns(t)) for t in range(layout.n_terms())
-    ] == [
-        (3, 1),
-        (3, 2),
-    ]
+               (layout.n_levels(t), layout.n_columns(t)) for t in range(layout.n_terms())
+           ] == [
+               (3, 1),
+               (3, 2),
+           ]
 
     # The reported unidentified direction resolves to a zero coefficient slot.
     (u,) = res.unidentified
@@ -116,9 +115,13 @@ def test_design_options_drop_singletons_across_python_apis():
 
     assert design_options.drop_singletons
 
-    single = solve(categories, y, design_options=design_options)
-    batch = solve_batch(categories, Y, design_options=design_options)
-    solver = Solver(categories, design_options=design_options)
+    warning = r"3 singleton observation\(s\) removed"
+    with pytest.warns(UserWarning, match=warning):
+        single = solve(categories, y, design_options=design_options)
+    with pytest.warns(UserWarning, match=warning):
+        batch = solve_batch(categories, Y, design_options=design_options)
+    with pytest.warns(UserWarning, match=warning):
+        solver = Solver(categories, design_options=design_options)
     persistent = solver.solve(y)
 
     assert solver.n_obs == len(y)
@@ -154,10 +157,11 @@ def test_one_shot_solve_surfaces_build_warnings():
     assert persistent, "fixture should emit a build warning"
     assert user_warnings(lambda: solve(design, y, preconditioner=precond)) == persistent
     assert (
-        user_warnings(
-            lambda: solve_batch(design, np.column_stack([y, y]), preconditioner=precond)
-        )
-        == persistent
+            user_warnings(
+                lambda: solve_batch(design, np.column_stack([y, y]),
+                                    preconditioner=precond)
+            )
+            == persistent
     )
 
 
@@ -254,8 +258,8 @@ class TestDemean:
         x_hat = result.x
         offset = 0
         for n in n_levels:
-            block_hat = x_hat[offset : offset + n]
-            block_true = x_true[offset : offset + n]
+            block_hat = x_hat[offset: offset + n]
+            block_true = x_true[offset: offset + n]
             np.testing.assert_allclose(
                 block_hat - block_hat.mean(),
                 block_true - block_true.mean(),

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -8,12 +8,14 @@ import pytest
 from within import (
     BatchSolveResult,
     CoefficientLayout,
+    DesignOptions,
     Effect,
     LsmrOptions,
     Preconditioner,
     PreconditionerConfig,
     Solver,
     solve,
+    solve_batch,
 )
 from within.config import AdditiveSchwarz, LocalSolverConfig, ScalingConfig
 
@@ -99,6 +101,34 @@ def test_free_solve_positional_order_is_weights_then_options():
     w = rng.uniform(0.5, 2.0, size=300)
     result = solve(cats, y, w, LsmrOptions(maxiter=2000))
     assert result.converged
+
+
+def test_design_options_drop_singletons_across_python_apis():
+    # Rows 0..3 form a two-factor 2-core. Rows 4..6 form a path whose
+    # endpoint singleton levels trigger iterative removal of the whole path.
+    categories = as_solver_categories(
+        [
+            np.array([1, 0, 1, 0, 2, 2, 3]),
+            np.array([1, 0, 0, 1, 2, 3, 3]),
+        ]
+    )
+    y = np.array([1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0])
+    Y = np.column_stack([y, 2.0 * y])
+    design_options = DesignOptions(drop_singletons=True)
+
+    assert design_options.drop_singletons
+
+    single = solve(categories, y, design_options=design_options)
+    batch = solve_batch(categories, Y, design_options=design_options)
+    solver = Solver(categories, design_options=design_options)
+    persistent = solver.solve(y)
+
+    assert solver.n_obs == len(y)
+    assert np.all(np.isfinite(single.demeaned[:4]))
+    assert np.all(np.isnan(single.demeaned[4:]))
+    np.testing.assert_array_equal(single.demeaned, persistent.demeaned)
+    np.testing.assert_array_equal(batch.demeaned[:, 0], single.demeaned)
+    np.testing.assert_array_equal(batch.demeaned[:, 1], 2.0 * single.demeaned)
 
 
 def test_one_shot_solve_surfaces_build_warnings():


### PR DESCRIPTION
This is a first stab at #47 with the goal of keeping the API changes generic.

The main change from the API side is the introduction of `DesignOptions` for configuration of `Design::build`. It currently only holds two boolean flags `drop_singletons` (public) and `locality_sort` (crate internal) but should in principle be easy to extend.

The main functional change is that [`Design:obs_perm`](https://github.com/py-econometrics/within/blob/f34798c68629e5a75d6a626a93c136b52c8149bb/crates/within/src/domain.rs#L81) is replaced by a generic mapping [`Design::rows`](https://github.com/leostimpfle/within/blob/b78776bf361232f1f76257dcfbcf1be8c0e91e18/crates/within/src/domain.rs#L217) which maps the raw input data to the internal state (after dropping singletons and locality sorting).

@schroedk This is early stage and I will keep working on it before converting from a draft PR but any feedback you might have would be much appreciated.

