### PR TITLE
perf: build one star sampler per task instead of one per star

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 [[package]]
 name = "approx-chol"
 version = "0.3.1"
-source = "git+https://github.com/aai-institute/approx-chol.git?rev=3198606#319860604b1202a794e8f154941571aafcc4c13b"
+source = "git+https://github.com/aai-institute/approx-chol.git?rev=dbec7c4#dbec7c479e717f8ce92f85cbdd5fcb36f63d635e"
 dependencies = [
  "num-traits",
  "rand 0.10.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ postcard = { version = "1", features = ["use-std"] }
 thiserror = "2"
 
 [patch.crates-io]
-approx-chol = { git = "https://github.com/aai-institute/approx-chol.git", rev = "3198606" }
+approx-chol = { git = "https://github.com/aai-institute/approx-chol.git", rev = "dbec7c4" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/within/src/block_elim/schur.rs
+++ b/crates/within/src/block_elim/schur.rs
@@ -6,7 +6,7 @@
 
 use super::compensated_sum;
 use super::csr_matrix::CsrMatrix;
-use approx_chol::low_level::clique_tree_sample;
+use approx_chol::low_level::CliqueTreeSampler;
 use rayon::prelude::*;
 
 use crate::config::ApproxSchurConfig;
@@ -239,28 +239,40 @@ impl Star<'_> {
     }
 }
 
-/// Sample clique-tree fill edges for one eliminated star; ground surplus is one more incident edge, so the sampled star's capacity is exactly its eliminated diagonal.
-fn sample_star(
-    star: &Star,
-    ground: Option<(u32, f64)>,
-    config: &ApproxSchurConfig,
-    edges: &mut Vec<Edge>,
-    scratch: &mut Vec<(u32, f64)>,
-) {
-    scratch.clear();
-    for (&col, &w) in star.col_indices.iter().zip(star.weights) {
-        scratch.push((col, w));
-    }
-    if let Some((ground, surplus)) = ground {
-        if surplus > 0.0 {
-            scratch.push((ground, surplus));
+/// One rayon task's sampling state. The sampler carries scratch of its own, so it is
+/// built per task alongside the buffers rather than per star.
+struct StarWorkspace {
+    edges: Vec<Edge>,
+    entries: Vec<(u32, f64)>,
+    sampler: CliqueTreeSampler,
+}
+
+impl StarWorkspace {
+    fn new(config: &ApproxSchurConfig) -> Self {
+        Self {
+            edges: Vec::new(),
+            entries: Vec::new(),
+            sampler: CliqueTreeSampler::new(config.seed, Some(config.split)),
         }
     }
-    if scratch.len() <= 1 {
-        return;
+
+    /// Sample clique-tree fill edges for one eliminated star; ground surplus is one more incident edge, so the sampled star's capacity is exactly its eliminated diagonal.
+    fn sample_star(&mut self, star: &Star, ground: Option<(u32, f64)>) {
+        self.entries.clear();
+        for (&col, &w) in star.col_indices.iter().zip(star.weights) {
+            self.entries.push((col, w));
+        }
+        if let Some((ground, surplus)) = ground {
+            if surplus > 0.0 {
+                self.entries.push((ground, surplus));
+            }
+        }
+        if self.entries.len() <= 1 {
+            return;
+        }
+        self.sampler
+            .sample(star.index as u64, &self.entries, &mut self.edges);
     }
-    let seed = config.seed.wrapping_add(star.index as u64);
-    clique_tree_sample(scratch, Some(config.split), seed, edges);
 }
 
 /// Create a zero-copy [`Star`] view for eliminated vertex `k`.
@@ -284,17 +296,17 @@ fn par_emit(matrix: &SddmMatrix, config: &ApproxSchurConfig) -> Vec<Edge> {
     let mut edges = (0..matrix.n_eliminated())
         .into_par_iter()
         .fold(
-            || (Vec::new(), Vec::<(u32, f64)>::new()),
-            |(mut edges, mut scratch), k| {
+            || StarWorkspace::new(config),
+            |mut work, k| {
                 let star = star(matrix, k);
                 if star.degree() > 0 {
                     let ground = ground_vertex.map(|g| (g, surplus_eliminated[k]));
-                    sample_star(&star, ground, config, &mut edges, &mut scratch);
+                    work.sample_star(&star, ground);
                 }
-                (edges, scratch)
+                work
             },
         )
-        .map(|(edges, _)| edges)
+        .map(|work| work.edges)
         .reduce(Vec::new, |mut a, mut b| {
             a.append(&mut b);
             a


### PR DESCRIPTION
## Outcome

`clique_tree_sample` allocated its own scratch per call, so the ~100k stars a 1M-row 3FE
build eliminates paid six allocations each. approx-chol's `CliqueTreeSampler` owns that
scratch; `par_emit` already folds per-task state, so the sampler joins the buffers in a
named `StarWorkspace` and lives for the task rather than the star.

1M-row simple 3FE, `Solver::new`, 25 interleaved rounds per arm:

| | build | |
|---|---|---|
| base | 44.70 ms | — |
| this PR | **39.09 ms** | **−12.6%**, p<1e-10, 25/25 rounds |

Solve time is flat (−0.4%) and iterations stay at 10. The delta also carries
approx-chol's `ab2505c` surplus rule, which the base predates.

The sampled Schur complement is **not** bit-for-bit identical to the base: #88's review
made the star sort a total order on `(weight, neighbor)` rather than weight alone, so
equal-weight neighbors — common here, since the weights are cross-tab counts — now break
ties by content instead of by CSR arrival order. On a tie-free star the fill edges hash
identically to the base. 244 tests pass.

## Depends on

aai-institute/approx-chol#88, merged as `dbec7c4`; pinned to `main`. #220 touches the same
pin line, so whichever of the two merges second takes a one-line conflict there.


## CI

Tests (macOS, Windows) and MSRV pass. `cargo deny` and `cargo-semver-checks` stay red for
as long as approx-chol is consumed as a git dependency: `deny.toml` allows only the
registry, and semver-checks builds `crates/within` outside the workspace root, so the root
`[patch.crates-io]` does not apply and `approx-chol` resolves to published 0.3.1. Both
clear when approx-chol is released and the pin goes back to a registry dep; neither is
worth working around, since the only fix for the latter is a git dep inside
`crates/within/Cargo.toml`, which would not be publishable.
