### PR TITLE
perf: stop splitting a narrow kept block's Schur rows across threads

### DIFF
--- a/crates/within/src/block_elim/schur.rs
+++ b/crates/within/src/block_elim/schur.rs
@@ -13,22 +13,48 @@ use crate::config::ApproxSchurConfig;
 use crate::csr_block::to_u32;
 use crate::domain::{Grounding, SddmMatrix};
 
-/// Exact Schur complement `S = D_keep − keep_to_elim · diag(inv_diag_elim) · elim_to_keep`, accumulated per keep-row through a dense workspace without materializing intermediate edges.
-pub(crate) fn exact(matrix: &SddmMatrix, inv_diagonal_eliminated: &[f64]) -> CsrMatrix {
-    let n_keep = matrix.n_kept();
+/// Whether the kept rows are split across threads. Each row costs a pass over the
+/// eliminated block, so splitting them pays on a wide kept block and not on a narrow
+/// one: the subdomain loop reaching here is already parallel, and a handful of rows
+/// spawned inside it only adds tasks to steal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RowSplit {
+    Sequential,
+    Parallel,
+}
 
-    let rows: Vec<(Vec<u32>, Vec<f64>)> = (0..n_keep)
-        .into_par_iter()
-        .map_init(
-            || (vec![0.0f64; n_keep], Vec::new()),
-            |(work, touched), i| {
-                compute_schur_row_dense(matrix, inv_diagonal_eliminated, i, work, touched);
-                let result = extract_sparse_row(i, work, touched);
-                touched.clear();
-                result
-            },
-        )
-        .collect();
+/// Exact Schur complement `S = D_keep − keep_to_elim · diag(inv_diag_elim) · elim_to_keep`, accumulated per keep-row through a dense workspace without materializing intermediate edges.
+pub(crate) fn exact(
+    matrix: &SddmMatrix,
+    inv_diagonal_eliminated: &[f64],
+    split: RowSplit,
+) -> CsrMatrix {
+    let n_keep = matrix.n_kept();
+    // Reset per row by `extract_sparse_row` zeroing what it read, so one workspace
+    // serves a whole sequential run and both arms return the same rows.
+    let row = |i: usize, work: &mut Vec<f64>, touched: &mut Vec<usize>| {
+        compute_schur_row_dense(matrix, inv_diagonal_eliminated, i, work, touched);
+        let result = extract_sparse_row(i, work, touched);
+        touched.clear();
+        result
+    };
+
+    let rows: Vec<(Vec<u32>, Vec<f64>)> = match split {
+        RowSplit::Parallel => (0..n_keep)
+            .into_par_iter()
+            .map_init(
+                || (vec![0.0f64; n_keep], Vec::new()),
+                |(work, touched), i| row(i, work, touched),
+            )
+            .collect(),
+        RowSplit::Sequential => {
+            let mut work = vec![0.0f64; n_keep];
+            let mut touched = Vec::new();
+            (0..n_keep)
+                .map(|i| row(i, &mut work, &mut touched))
+                .collect()
+        }
+    };
 
     assemble_schur_csr(rows, n_keep)
 }
@@ -40,8 +66,12 @@ pub(crate) fn sampled(matrix: &SddmMatrix, config: &ApproxSchurConfig) -> CsrMat
     build_laplacian_csr(&edges, n)
 }
 
-pub(crate) fn exact_for_factor(matrix: &SddmMatrix, inv_diagonal_eliminated: &[f64]) -> CsrMatrix {
-    let principal = exact(matrix, inv_diagonal_eliminated);
+pub(crate) fn exact_for_factor(
+    matrix: &SddmMatrix,
+    inv_diagonal_eliminated: &[f64],
+    split: RowSplit,
+) -> CsrMatrix {
+    let principal = exact(matrix, inv_diagonal_eliminated, split);
     let surplus = reduced_surplus(matrix, inv_diagonal_eliminated);
     build_explicit_laplacian(&principal, &surplus, matrix.grounding)
 }

--- a/crates/within/src/block_elim/schur/tests.rs
+++ b/crates/within/src/block_elim/schur/tests.rs
@@ -121,10 +121,45 @@ fn exact_schur_matches_dense_reference_when_eliminating_rows() {
     );
     let inv_diagonal: Vec<f64> = row_diag.iter().map(|d| 1.0 / d).collect();
 
-    let matrix = exact(&matrix, &inv_diagonal);
+    let matrix = exact(&matrix, &inv_diagonal, RowSplit::Parallel);
     let expected = dense_exact_schur(&c_dense, 3, 2, &row_diag, &col_diag, true);
     let got = sparse_to_dense(&matrix);
     assert_dense_close(&got, &expected, 1e-12);
+}
+
+/// The sequential arm reuses one scatter workspace across rows, so a row that failed to
+/// reset it would read the previous row's entries.
+#[test]
+fn both_row_splits_produce_the_same_complement() {
+    let c_dense = vec![1.0, 2.0, 3.0, 0.0, 0.0, 4.0];
+    let row_diag = vec![5.0, 6.0, 8.0];
+    let col_diag = vec![7.0, 9.0];
+    let inv_diagonal: Vec<f64> = row_diag.iter().map(|d| 1.0 / d).collect();
+
+    for grounding in [Grounding::Grounded, Grounding::Floating] {
+        let operator = make_operator(
+            &c_dense,
+            3,
+            2,
+            row_diag.clone(),
+            col_diag.clone(),
+            grounding,
+        );
+        let parallel = exact_for_factor(&operator, &inv_diagonal, RowSplit::Parallel);
+        let sequential = exact_for_factor(&operator, &inv_diagonal, RowSplit::Sequential);
+
+        assert_eq!(
+            sequential.indptr(),
+            parallel.indptr(),
+            "{grounding:?} indptr"
+        );
+        assert_eq!(
+            sequential.indices(),
+            parallel.indices(),
+            "{grounding:?} indices"
+        );
+        assert_eq!(sequential.data(), parallel.data(), "{grounding:?} data");
+    }
 }
 
 #[test]

--- a/crates/within/src/block_elim/solver.rs
+++ b/crates/within/src/block_elim/solver.rs
@@ -191,7 +191,11 @@ impl Eliminated {
     fn factor_reduced(&self, config: &LocalSolverConfig) -> Result<Factor, BuildError> {
         let exact_below = config.dense_threshold;
         if exact_below > 0 && self.matrix.n_kept() <= exact_below {
-            let exact = schur::exact_for_factor(&self.matrix, &self.inv_diagonal);
+            let exact = schur::exact_for_factor(
+                &self.matrix,
+                &self.inv_diagonal,
+                schur::RowSplit::Sequential,
+            );
             let ac = config
                 .approx_chol
                 .to_approx_chol(exact_below, ExactFailure::Error);
@@ -202,7 +206,9 @@ impl Eliminated {
         }
         let schur_csr = match &config.schur {
             SchurMode::Approximate(cfg) => schur::sampled(&self.matrix, cfg),
-            SchurMode::Exact => schur::exact_for_factor(&self.matrix, &self.inv_diagonal),
+            SchurMode::Exact => {
+                schur::exact_for_factor(&self.matrix, &self.inv_diagonal, schur::RowSplit::Parallel)
+            }
         };
         let ac = config
             .approx_chol


### PR DESCRIPTION
## Outcome

`exact` split its kept rows with `into_par_iter`, but the subdomain loop reaching it is
already parallel and the block taking this path is narrow by construction — the caller
gated on `dense_threshold`, so it hands over 5 to 24 rows. Nesting a handful of tasks
inside an already-saturated pool costs more than the split saves.

1M-row simple 3FE, `Solver::new`, n=50 interleaved per arm:

| | build |
|---|---|
| base | 44.91 ms |
| this PR | **44.37 ms** |

−1.21%, p=0.0035, faster in 21 of 25 paired rounds. Against a build of `main`'s own
`within` the result is now statistically indistinguishable (p=0.60) — the branch no
longer carries a construction cost of its own. Iteration count and solve time unchanged;
195 tests pass.

## How it was found

Bisecting all 30 branch commits against a fixed approx-chol put the whole residual in
`dcf9e4c` (+2.57%, p=0.00014) with the other 29 null (p=0.53). Timing that commit's
small-block path in halves showed approx-chol contributing 0.11 ms against
`exact_for_factor`'s 69.6 ms, and splitting `exact_for_factor` into its three passes put
77.5 of 77.6 ms in `exact` — `reduced_surplus` short-circuits, since these subdomains
are all `Floating`. Making that one loop sequential recovered it.

Two things this rules out: the exact-dense backend is not the cost (disabling it makes
the build 51 ms against 43.6, 17% *worse*), and neither is `reduced_surplus`.

## Note

The base now carries the pin this branch compiles against, so there is no dependency
diff here and nothing to resolve at merge. **Merge after #219**, which is what advances
approx-chol past `3198606` — this branch still calls `clique_tree_sample`, removed by
aai-institute/approx-chol#88.

## CI

Tests (macOS, Windows) and MSRV pass. `cargo deny` and `cargo-semver-checks` stay red for
as long as approx-chol is consumed as a git dependency: `deny.toml` allows only the
registry, and semver-checks builds `crates/within` outside the workspace root, so the root
`[patch.crates-io]` does not apply and `approx-chol` resolves to published 0.3.1. Both
clear when approx-chol is released and the pin goes back to a registry dep; neither is
worth working around, since the only fix for the latter is a git dep inside
`crates/within/Cargo.toml`, which would not be publishable.
