### PR TITLE
docs: state each contract in one short line

### DIFF
--- a/crates/schwarz-precond/src/domain.rs
+++ b/crates/schwarz-precond/src/domain.rs
@@ -9,10 +9,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::error::BuildError;
 
-/// Partition-of-unity weights for a subdomain.
-///
-/// Most subdomains have uniform weights (all 1.0), so we avoid allocating
-/// a full `Vec<f64>` for them.
+/// PoU weights for a subdomain; the common uniform-1.0 case avoids allocating.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug)]
 pub enum PartitionWeights {
@@ -63,18 +60,7 @@ fn atomic_f64_add(target: &AtomicU64, val: f64) {
     }
 }
 
-/// A domain-agnostic subdomain core implementing `Rᵢ` and `D̃ᵢ` from the Schwarz formula.
-///
-/// Holds the sorted global DOF indices (defining the restriction operator `Rᵢ`)
-/// and partition-of-unity weights (defining `D̃ᵢ`). The two key operations map
-/// directly to the formula:
-///
-/// - [`restrict_weighted`](Self::restrict_weighted) computes `D̃ᵢ Rᵢ r` (gather + weight)
-/// - [`prolongate_weighted_add`](Self::prolongate_weighted_add) computes `out += Rᵢᵀ D̃ᵢ z` (weight + scatter)
-///
-/// Paired with a [`LocalSolver`](crate::local_solve::LocalSolver) (`Aᵢ⁻¹`)
-/// inside a [`SubdomainEntry`](crate::local_solve::SubdomainEntry), this
-/// yields the full per-subdomain term `Rᵢᵀ D̃ᵢ Aᵢ⁻¹ D̃ᵢ Rᵢ`.
+/// Subdomain `Rᵢ` and `D̃ᵢ`: sorted global DOF indices plus partition-of-unity weights.
 #[derive(Clone)]
 pub struct SubdomainCore {
     /// Global DOF indices belonging to this subdomain.

--- a/crates/schwarz-precond/src/error.rs
+++ b/crates/schwarz-precond/src/error.rs
@@ -17,9 +17,6 @@
 use thiserror::Error;
 
 /// Construction-time validation errors for the Schwarz building blocks.
-///
-/// Consolidates failures from subdomain core/entry construction and
-/// preconditioner-wide index checks into a single flat enum.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum BuildError {
@@ -49,12 +46,7 @@ pub enum BuildError {
     },
 }
 
-/// Runtime error emitted by a local subdomain solver during a solve call.
-///
-/// Returned by [`crate::LocalSolver::solve_local`].
-/// Backend-agnostic by design: backends report a `context` site and a
-/// free-form `message` rather than enumerating their internal error modes
-/// through this generic crate.
+/// Local-solver failure; backends report a free-form site and message, not typed modes.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum LocalSolveError {
@@ -69,9 +61,6 @@ pub enum LocalSolveError {
 }
 
 /// Runtime failure while executing a solve.
-///
-/// Covers both operator/preconditioner application failures (e.g. a local
-/// solver diverges) and iterative-solver input validation.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
 pub enum SolveError {

--- a/crates/schwarz-precond/src/lib.rs
+++ b/crates/schwarz-precond/src/lib.rs
@@ -44,25 +44,15 @@
 #![deny(missing_docs)]
 #![warn(clippy::all)]
 
-/// A linear operator A: R^ncols -> R^nrows with its adjoint A^T.
-///
-/// Preconditioners are operators too (M^{-1} is a linear map).
-/// All implementors must be Send + Sync to enable Rayon parallelism.
-///
-/// Both apply methods are fallible: implementors that cannot fail in practice
-/// (matrices, identity operators) still return `Result<(), SolveError>` so
-/// callers can use a uniform `?` propagation path. Symmetric operators
-/// should delegate `apply_adjoint` to `apply`.
+/// A linear operator with its adjoint; both applies are fallible for one uniform `?` path.
 pub trait Operator: Send + Sync {
     /// Number of rows in the operator.
     fn nrows(&self) -> usize;
     /// Number of columns in the operator.
     fn ncols(&self) -> usize;
-    /// Computes y = A * x. Returns an error if the apply fails at runtime
-    /// (e.g. a local subdomain solver diverges).
+    /// Computes `y = A x`.
     fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), error::SolveError>;
-    /// Computes y = A^T * x. For symmetric operators, this should delegate to `apply`.
-    /// Returns an error under the same conditions as `apply`.
+    /// Computes `y = Aᵀ x`; symmetric operators should delegate to `apply`.
     fn apply_adjoint(&self, x: &[f64], y: &mut [f64]) -> Result<(), error::SolveError>;
 }
 

--- a/crates/schwarz-precond/src/local_solve.rs
+++ b/crates/schwarz-precond/src/local_solve.rs
@@ -17,16 +17,7 @@ use std::sync::atomic::AtomicU64;
 use crate::domain::SubdomainCore;
 use crate::error::{BuildError, LocalSolveError};
 
-// ---------------------------------------------------------------------------
-// LocalSolver trait
-// ---------------------------------------------------------------------------
-
-/// The `Aᵢ⁻¹` operator in the Schwarz formula: a local subdomain solver.
-///
-/// Each subdomain's restricted system `Aᵢ = Rᵢ A Rᵢᵀ` is solved (exactly or
-/// approximately) by an implementor of this trait. Given a right-hand side
-/// in `rhs`, it writes the solution into `sol`. Both buffers are scratch-sized
-/// (may be larger than `n_local` for augmented systems).
+/// The `Aᵢ⁻¹` operator: solves the restricted system `Aᵢ = Rᵢ A Rᵢᵀ`, exactly or approximately.
 pub trait LocalSolver: Send + Sync {
     /// Number of DOFs in the subdomain (before augmentation).
     fn n_local(&self) -> usize;
@@ -34,15 +25,7 @@ pub trait LocalSolver: Send + Sync {
     /// Required scratch buffer size (may be > n_local for augmented systems).
     fn scratch_size(&self) -> usize;
 
-    /// Solve the local system: rhs → sol.
-    ///
-    /// Both `rhs` and `sol` have length >= `scratch_size()`.
-    /// The solver may read/write up to `scratch_size()` elements.
-    ///
-    /// `allow_inner_parallelism` is an execution-policy hint: implementations
-    /// with worthwhile inner parallel regions may consult it to decide whether
-    /// to engage nested Rayon. Implementations that have no nested-parallel
-    /// region can ignore the hint.
+    /// Solve into `sol`; buffers are `scratch_size()` long and the parallelism hint may be ignored.
     fn solve_local(
         &self,
         rhs: &mut [f64],
@@ -50,24 +33,13 @@ pub trait LocalSolver: Send + Sync {
         allow_inner_parallelism: bool,
     ) -> Result<(), LocalSolveError>;
 
-    /// Estimated amount of local work that can benefit from nested Rayon.
-    ///
-    /// Return zero when the solver has no nested-parallel region worth enabling.
+    /// Estimated local work that can benefit from nested Rayon; zero when there is no such region.
     fn inner_parallelism_work_estimate(&self) -> usize {
         0
     }
 }
 
-// ---------------------------------------------------------------------------
-// SubdomainEntry<S>
-// ---------------------------------------------------------------------------
-
-/// One term of the Schwarz sum: `Rᵢᵀ D̃ᵢ Aᵢ⁻¹ D̃ᵢ Rᵢ`.
-///
-/// Bundles a [`SubdomainCore`] (which provides `Rᵢ` and `D̃ᵢ`) with a
-/// [`LocalSolver`] (which provides `Aᵢ⁻¹`). The
-/// [`apply_weighted_into_with_scratch`](Self::apply_weighted_into_with_scratch)
-/// method computes the full contribution for this subdomain.
+/// One term of the Schwarz sum `Rᵢᵀ D̃ᵢ Aᵢ⁻¹ D̃ᵢ Rᵢ`.
 #[derive(Clone)]
 pub struct SubdomainEntry<S: LocalSolver> {
     /// Subdomain core with restriction indices and partition-of-unity weights.
@@ -130,12 +102,7 @@ impl<S: LocalSolver> SubdomainEntry<S> {
         self.solver.scratch_size()
     }
 
-    /// Accumulate the two-sided PoU weighted local solve into a global buffer.
-    ///
-    /// out += R_i^T D_i A_i^{-1} D_i R_i r
-    ///
-    /// - `r_scratch` must have length >= `self.scratch_size()`
-    /// - `z_scratch` must have length >= `self.scratch_size()`
+    /// Accumulate `out += Rᵢᵀ D̃ᵢ Aᵢ⁻¹ D̃ᵢ Rᵢ r`; both buffers must be `scratch_size()` long.
     pub fn apply_weighted_into_with_scratch(
         &self,
         r: &[f64],
@@ -148,21 +115,16 @@ impl<S: LocalSolver> SubdomainEntry<S> {
             return Ok(());
         }
 
-        // Gather with partition weights: r_scratch = D_i @ R_i @ r
         self.core.restrict_weighted(r, r_scratch);
 
-        // Local solve (strategy-specific transforms happen inside the solver)
         self.solver
             .solve_local(r_scratch, z_scratch, allow_inner_parallelism)?;
 
-        // Weighted scatter directly into output: out += R_i^T @ D_i @ z_local
         self.core.prolongate_weighted_add(z_scratch, out);
         Ok(())
     }
 
-    /// Accumulate the two-sided PoU weighted local solve into an atomic global buffer.
-    ///
-    /// out\[i\] += R_i^T D_i A_i^{-1} D_i R_i r  (via atomic f64 add)
+    /// Accumulate the weighted local solve into a global buffer via atomic f64 add.
     pub fn apply_weighted_into_atomic(
         &self,
         r: &[f64],
@@ -175,14 +137,11 @@ impl<S: LocalSolver> SubdomainEntry<S> {
             return Ok(());
         }
 
-        // Gather with partition weights: r_scratch = D_i @ R_i @ r
         self.core.restrict_weighted(r, r_scratch);
 
-        // Local solve (strategy-specific transforms happen inside the solver)
         self.solver
             .solve_local(r_scratch, z_scratch, allow_inner_parallelism)?;
 
-        // Weighted atomic scatter into output: out += R_i^T @ D_i @ z_local
         self.core.prolongate_weighted_add_atomic(z_scratch, out);
         Ok(())
     }
@@ -292,8 +251,6 @@ mod tests {
         // Prolongate: out[idx[i]] += w[i] * local[i]
         let mut out = vec![0.0; 3];
         core.prolongate_weighted_add(&local, &mut out);
-        // out[0] = 1.0 * 4.0 = 4.0,  out[1] = 0.5 * 4.0 = 2.0,  out[2] = 0.25 * 4.0 = 1.0
-        // Full round-trip effective weight = w^2: 1.0, 0.25, 0.0625
         assert!((out[0] - 4.0).abs() < 1e-14);
         assert!((out[1] - 2.0).abs() < 1e-14);
         assert!((out[2] - 1.0).abs() < 1e-14);
@@ -301,8 +258,6 @@ mod tests {
 
     #[test]
     fn test_apply_weighted_with_identity_solver() {
-        // With identity solver and uniform weights:
-        // apply_weighted = R_i^T D_i (I) D_i R_i r = R_i^T R_i r (since D_i = I)
         let core = SubdomainCore::uniform(vec![1, 2]);
         let solver = IdentityLocalSolver { n: 2 };
         let entry = SubdomainEntry::try_new(core, solver).expect("valid entry");

--- a/crates/schwarz-precond/src/lsmr/bidiag.rs
+++ b/crates/schwarz-precond/src/lsmr/bidiag.rs
@@ -11,16 +11,12 @@ use crate::{Operator, SolveError};
 use rayon::iter::{IndexedParallelIterator, ParallelIterator};
 use rayon::prelude::{ParallelSlice, ParallelSliceMut};
 
-/// Below this count the per-iteration vector kernels run sequentially —
-/// rayon wake/steal overhead would dominate otherwise.
+/// Below this count the vector kernels run sequentially; rayon wake/steal would dominate.
 pub(super) const LSMR_PAR_THRESHOLD: usize = 10_000;
-/// Per-worker chunk size for the parallel vector kernels: large enough to clear
-/// rayon dispatch overhead, small enough to stay L1-resident.
+/// Per-worker chunk size: large enough to clear rayon dispatch, small enough to stay L1-resident.
 pub(super) const LSMR_UPDATE_CHUNK: usize = 4096;
 
-/// Fused `y = x + scale * y` with `‖y_new‖²` returned. Parallel above the
-/// threshold; each chunk accumulates its own partial sum to avoid cross-thread
-/// traffic on the reduction.
+/// Fused `y = x + scale · y` returning `‖y_new‖²`; per-chunk partials avoid reduction traffic.
 #[inline]
 fn axpy_with_sq_norm(y: &mut [f64], x: &[f64], scale: f64) -> f64 {
     debug_assert_eq!(x.len(), y.len());
@@ -82,8 +78,7 @@ pub(super) fn dot(a: &[f64], b: &[f64]) -> f64 {
     a.iter().zip(b).map(|(a, b)| a * b).sum()
 }
 
-/// Parallel dot product; falls back to the sequential `dot` below
-/// the threshold.
+/// Parallel dot product, falling back to the sequential `dot` below the threshold.
 #[inline]
 fn par_dot(a: &[f64], b: &[f64]) -> f64 {
     debug_assert_eq!(a.len(), b.len());
@@ -97,9 +92,7 @@ fn par_dot(a: &[f64], b: &[f64]) -> f64 {
     }
 }
 
-/// `α = √⟨v, p̃⟩`. A near-breakdown negative `vp` (exact `‖v‖²_M ≥ 0` rounded
-/// below 0) within the relative floor `√ε·‖v‖‖p̃‖` clamps to `α = 0`; a genuinely
-/// indefinite preconditioner raises.
+/// `α = √⟨v, p̃⟩`; a `vp` negative within `√ε·‖v‖‖p̃‖` clamps to 0, an indefinite `M` raises.
 fn alpha_from_vp(v: &[f64], p_tilde: &[f64]) -> Result<f64, SolveError> {
     let vp = par_dot(v, p_tilde);
     if vp < 0.0 {
@@ -114,21 +107,9 @@ fn alpha_from_vp(v: &[f64], p_tilde: &[f64]) -> Result<f64, SolveError> {
     Ok(vp.max(0.0).sqrt())
 }
 
-/// Windowed ring of recent basis vectors for local (windowed) modified
-/// Gram-Schmidt reorthogonalization.
-///
-/// Stores up to `cap` slots, each holding `L` parallel length-`n` lanes in a
-/// flat per-lane buffer. The ring mechanics — capacity clamp, chronological
-/// (oldest-first) traversal, and wrap-around writes — live here; the inner
-/// product and MGS sweep are supplied by the `L`-specialized impls below
-/// ([`WindowRing<1>`] for Euclidean `v`, [`WindowRing<2>`] for the M-weighted
-/// `(v, p̃ = M v)` pair).
-///
-/// The disabled state is encoded as `Option<WindowRing<L>> = None` on the
-/// owning buffer; this type is only ever constructed with a positive capacity.
+/// Ring of recent basis vectors for windowed MGS; the disabled state is `None`, so `cap > 0`.
 struct WindowRing<const L: usize> {
-    /// `L` flat buffers, each `cap * n` long; lane `l`, slot `s` is the
-    /// length-`n` window `[s*n .. s*n + n]` of `lanes[l]`.
+    /// `L` flat buffers; lane `l`, slot `s` is `[s*n .. s*n + n]` of `lanes[l]`.
     lanes: [Vec<f64>; L],
     n: usize,
     next: usize,
@@ -136,10 +117,7 @@ struct WindowRing<const L: usize> {
 }
 
 impl<const L: usize> WindowRing<L> {
-    /// Returns `None` when no reorthogonalization is requested (the effective
-    /// capacity collapses to zero). The bidiagonalization can produce at most
-    /// `min(m, n)` linearly independent basis vectors before α or β hits zero,
-    /// so the ring is capped at `min(m, n)`.
+    /// `None` when no reorthogonalization is requested; capped at `min(m, n)`.
     fn new(m: usize, n: usize, local_size: usize) -> Option<Self> {
         let cap = local_size.min(m.min(n));
         if cap == 0 {
@@ -166,8 +144,7 @@ impl<const L: usize> WindowRing<L> {
         (0..count).map(move |i| (start + i) % cap)
     }
 
-    /// Reserve the next write slot, advancing the ring index and saturating the
-    /// count at capacity. Returns the slot to write into.
+    /// Reserve the next write slot, advancing the ring index and saturating the count at capacity.
     fn advance(&mut self) -> usize {
         let cap = self.capacity();
         let slot = self.next;
@@ -191,11 +168,9 @@ impl<const L: usize> WindowRing<L> {
     }
 }
 
-/// Euclidean windowed MGS over the single stored `v` lane. Used by
-/// [`GolubKahan`].
+/// Euclidean windowed MGS over the single stored `v` lane, used by [`GolubKahan`].
 impl WindowRing<1> {
-    /// Modified Gram-Schmidt sweep over stored slots in chronological order
-    /// (oldest first). Subtracts the projection of `y` onto each stored vector.
+    /// MGS sweep over stored slots oldest-first, subtracting each projection of `y`.
     fn reorthogonalize(&self, y: &mut [f64]) {
         for slot in self.chrono_slots() {
             let v_j = self.lane(0, slot);
@@ -211,15 +186,9 @@ impl WindowRing<1> {
     }
 }
 
-/// M-weighted windowed MGS over the paired `(v, p̃ = M v)` lanes. Used by
-/// [`ModifiedGolubKahan`]: `v` is M-orthogonal, not Euclidean, so the MGS
-/// coefficient is `⟨v_new, M v_j⟩ = ⟨v_new, p̃_j⟩`. Subtracting the same
-/// coefficient from both `v` and `p̃` in lockstep preserves the `p̃ = M v`
-/// invariant on the recurrence vectors.
+/// M-weighted windowed MGS: `v` is M-orthogonal, so the coefficient is `⟨v_new, p̃_j⟩`.
 impl WindowRing<2> {
-    /// M-weighted MGS over stored `(v_j, p̃_j)` pairs. The coefficient
-    /// `c = ⟨v, p̃_j⟩` is subtracted from `v` (against `v_j`) and from `p̃`
-    /// (against `p̃_j`), keeping `p̃ = M v` consistent.
+    /// Subtracts `c = ⟨v, p̃_j⟩` from both `v` and `p̃`, keeping `p̃ = M v` consistent.
     fn reorthogonalize(&self, v: &mut [f64], p_tilde: &mut [f64]) {
         for slot in self.chrono_slots() {
             let v_j = self.lane(0, slot);
@@ -230,8 +199,7 @@ impl WindowRing<2> {
         }
     }
 
-    /// Copy the normalized `v` and `p_tilde * inv_alpha` (= `M · v_norm`) into
-    /// the paired next slots, advancing the ring.
+    /// Copy normalized `v` and `p_tilde · inv_alpha` into the next slots, advancing the ring.
     fn push(&mut self, v: &[f64], p_tilde_unscaled: &[f64], inv_alpha: f64) {
         let slot = self.advance();
         self.lane_mut(0, slot).copy_from_slice(v);
@@ -245,16 +213,14 @@ impl WindowRing<2> {
     }
 }
 
-/// One step of the bidiagonal sequence: the freshly computed `(α_{k+1},
-/// β_{k+1})` scalars emitted by the bidiagonalization.
+/// One step of the bidiagonal sequence: the freshly computed `(α_{k+1}, β_{k+1})` scalars.
 #[derive(Clone, Copy)]
 pub(super) struct BidiagStep {
     pub(super) alpha: f64,
     pub(super) beta: f64,
 }
 
-/// A bidiagonalization stream feeding LSMR with `(α, β)` pairs and the
-/// matching normalized basis vector `v_k`.
+/// Stream feeding LSMR `(α, β)` pairs and the matching normalized `v_k`.
 pub(super) trait Bidiagonalization {
     /// Advance one step. After the call, `v()` is the normalized `v_{k+1}`.
     fn step(&mut self) -> Result<BidiagStep, SolveError>;
@@ -264,14 +230,11 @@ pub(super) trait Bidiagonalization {
 
 impl<A: Operator + ?Sized> Bidiagonalization for GolubKahan<'_, A> {
     fn step(&mut self) -> Result<BidiagStep, SolveError> {
-        // β_{k+1} u_{k+1} = A v_k − α_k u_k
         self.operator.apply(&self.bufs.v, &mut self.bufs.av)?;
         let beta_sq = axpy_with_sq_norm(&mut self.bufs.u, &self.bufs.av, -self.alpha);
         let beta = beta_sq.sqrt();
         if beta == 0.0 {
-            // Lucky breakdown: the Krylov space is exhausted. Zero v so the
-            // caller's `solution.update` produces no contribution this step;
-            // alpha = 0 in the rotation makes the recurrence well-defined.
+            // Lucky breakdown: zero `v` so `solution.update` contributes nothing.
             self.bufs.v.fill(0.0);
             self.alpha = 0.0;
             return Ok(BidiagStep { alpha: 0.0, beta });
@@ -279,13 +242,11 @@ impl<A: Operator + ?Sized> Bidiagonalization for GolubKahan<'_, A> {
         // beta > 0 here: the beta == 0 lucky breakdown returned above.
         scale_in_place(&mut self.bufs.u, 1.0 / beta);
 
-        // α_{k+1} v_{k+1} = Aᵀ u_{k+1} − β_{k+1} v_k
         self.operator
             .apply_adjoint(&self.bufs.u, &mut self.bufs.atu)?;
         let mut alpha_sq = axpy_with_sq_norm(&mut self.bufs.v, &self.bufs.atu, -beta);
 
-        // Windowed MGS in the standard inner product, before normalization.
-        // After the correction, α must be re-derived from the updated v.
+        // MGS runs before normalization, so α must be re-derived from the corrected `v`.
         if let Some(reorth) = &self.bufs.local_reorth {
             reorth.reorthogonalize(&mut self.bufs.v);
             alpha_sq = par_dot(&self.bufs.v, &self.bufs.v);
@@ -295,7 +256,6 @@ impl<A: Operator + ?Sized> Bidiagonalization for GolubKahan<'_, A> {
             scale_in_place(&mut self.bufs.v, 1.0 / alpha);
         }
 
-        // Push the normalized v_{k+1} into the ring.
         if let Some(reorth) = &mut self.bufs.local_reorth {
             reorth.push(&self.bufs.v);
         }
@@ -313,16 +273,12 @@ impl<A: Operator + ?Sized, M: Operator + ?Sized> Bidiagonalization
     for ModifiedGolubKahan<'_, A, M>
 {
     fn step(&mut self) -> Result<BidiagStep, SolveError> {
-        // Phase 1 — ũ_{k+1} unnormalized: scale = −α_k / β_k.
-        // Compute ũ_{k+1} = A ṽ_k − (α_k / β_k) ũ_k, then β_{k+1} = ‖ũ_{k+1}‖.
         let scale = -(self.alpha * self.beta_prev_inv);
         self.operator.apply(&self.bufs.v, &mut self.bufs.av)?;
         let beta_sq = axpy_with_sq_norm(&mut self.bufs.u, &self.bufs.av, scale);
         let beta = beta_sq.sqrt();
         if beta == 0.0 {
-            // Lucky breakdown (preconditioned): same invariant as the
-            // unpreconditioned path — zero v (and the paired p̃) so
-            // `solution.update` is a no-op this step.
+            // Lucky breakdown: zero `v` and its paired `p̃` so the update contributes nothing.
             self.bufs.v.fill(0.0);
             self.bufs.p_tilde.fill(0.0);
             self.alpha = 0.0;
@@ -332,9 +288,7 @@ impl<A: Operator + ?Sized, M: Operator + ?Sized> Bidiagonalization
         // beta > 0 here: the beta == 0 lucky breakdown returned above.
         let beta_inv = 1.0 / beta;
 
-        // Phase 2 — fold the adjoint matvec into the p̃ recurrence.
         self.update_p_tilde(beta, beta_inv)?;
-        // Phase 3 — recover v, M-weighted MGS, normalize, push to the ring.
         let alpha_new = self.reorthonormalize_v()?;
 
         self.alpha = alpha_new;
@@ -377,8 +331,7 @@ impl GolubKahanBuffers {
     }
 }
 
-/// Standard Golub-Kahan bidiagonalization. No preconditioner, no `p̃`
-/// buffer, two normalizations per step (`u` and `v`).
+/// Standard Golub-Kahan bidiagonalization: no preconditioner, two normalizations per step.
 pub(super) struct GolubKahan<'a, A: Operator + ?Sized> {
     operator: &'a A,
     bufs: GolubKahanBuffers,
@@ -387,8 +340,7 @@ pub(super) struct GolubKahan<'a, A: Operator + ?Sized> {
 }
 
 impl<'a, A: Operator + ?Sized> GolubKahan<'a, A> {
-    /// Initialize the bidiagonalization. Returns `Self` and the first step
-    /// `(α₁, β₁)`.
+    /// Initialize the bidiagonalization, returning `Self` and the first step `(α₁, β₁)`.
     pub(super) fn init(
         operator: &'a A,
         b: &[f64],
@@ -398,8 +350,7 @@ impl<'a, A: Operator + ?Sized> GolubKahan<'a, A> {
         let n = operator.ncols();
         let mut bufs = GolubKahanBuffers::new(m, n, local_size);
 
-        // β₁ = ‖b‖ via the max-scaled norm: par_dot(b, b).sqrt() overflows to ∞
-        // for large-magnitude b, zeroing u₁ into a silent x = 0 result.
+        // `par_dot(b, b).sqrt()` overflows to ∞ for large `b`, zeroing u₁ into a silent `x = 0`.
         let beta = super::vec_norm(b);
         if beta > 0.0 {
             let inv = 1.0 / beta;
@@ -408,14 +359,12 @@ impl<'a, A: Operator + ?Sized> GolubKahan<'a, A> {
             }
         }
 
-        // α₁ v₁ = Aᵀ u₁
         operator.apply_adjoint(&bufs.u, &mut bufs.v)?;
         let alpha = par_dot(&bufs.v, &bufs.v).sqrt();
         if alpha > 0.0 {
             scale_in_place(&mut bufs.v, 1.0 / alpha);
         }
 
-        // Seed the reorth buffer with v₁ so the next step's MGS sees it.
         if let Some(reorth) = &mut bufs.local_reorth {
             reorth.push(&bufs.v);
         }
@@ -433,15 +382,11 @@ impl<'a, A: Operator + ?Sized> GolubKahan<'a, A> {
 
 /// Workspaces used by [`ModifiedGolubKahan`].
 struct ModifiedGolubKahanBuffers {
-    /// `u` in observation space (length m). Left unnormalized between steps;
-    /// `‖u‖ = β_{k+1}` after the forward stage. The next step's adjoint matvec
-    /// produces `β · Aᵀ u_norm`, and the `β/α_prev` coefficient applied to
-    /// `p_tilde` cancels the unnormalization.
+    /// `u` left unnormalized between steps, so `‖u‖ = β_{k+1}`.
     u: Vec<f64>,
     /// `ṽ` in DOF space (length n). **Normalized** at the end of each step.
     v: Vec<f64>,
-    /// `p̃` recurrence vector (length n).
-    /// Invariant: `p_tilde_stored = α · M · v_normalized`.
+    /// `p̃` recurrence vector (length n); invariant `p_tilde_stored = α · M · v_normalized`.
     p_tilde: Vec<f64>,
     /// Scratch for `A · v` (length m).
     av: Vec<f64>,
@@ -464,9 +409,7 @@ impl ModifiedGolubKahanBuffers {
     }
 }
 
-/// Modified Golub-Kahan bidiagonalization with `M ≈ AᵀA`. Stores `p̃`
-/// scaled by `α` between steps so the preconditioner solve is a single
-/// `M⁻¹` application per iteration.
+/// Modified Golub-Kahan with `M ≈ AᵀA`, storing `p̃` scaled by `α` so a step costs one `M⁻¹`.
 pub(super) struct ModifiedGolubKahan<'a, A: Operator + ?Sized, M: Operator + ?Sized> {
     operator: &'a A,
     preconditioner: &'a M,
@@ -478,8 +421,7 @@ pub(super) struct ModifiedGolubKahan<'a, A: Operator + ?Sized, M: Operator + ?Si
 }
 
 impl<'a, A: Operator + ?Sized, M: Operator + ?Sized> ModifiedGolubKahan<'a, A, M> {
-    /// Initialize the bidiagonalization. Returns `Self` and the first step
-    /// `(α₁, β₁)`.
+    /// Initialize the bidiagonalization, returning `Self` and the first step `(α₁, β₁)`.
     pub(super) fn init(
         operator: &'a A,
         preconditioner: &'a M,
@@ -490,8 +432,7 @@ impl<'a, A: Operator + ?Sized, M: Operator + ?Sized> ModifiedGolubKahan<'a, A, M
         let n = operator.ncols();
         let mut bufs = ModifiedGolubKahanBuffers::new(m, n, local_size);
 
-        // β₁ = ‖b‖ via the max-scaled norm: par_dot(b, b).sqrt() overflows to ∞
-        // for large-magnitude b, zeroing u₁ into a silent x = 0 result.
+        // `par_dot(b, b).sqrt()` overflows to ∞ for large `b`, zeroing u₁ into a silent `x = 0`.
         let beta = super::vec_norm(b);
         if beta > 0.0 {
             let inv = 1.0 / beta;
@@ -500,21 +441,16 @@ impl<'a, A: Operator + ?Sized, M: Operator + ?Sized> ModifiedGolubKahan<'a, A, M
             }
         }
 
-        // p̃ = Aᵀ u₁
         operator.apply_adjoint(&bufs.u, &mut bufs.p_tilde)?;
 
-        // ṽ₁ = M⁻¹ p̃
         preconditioner.apply(&bufs.p_tilde, &mut bufs.v)?;
 
-        // α₁ = √⟨ṽ₁, p̃⟩ via the M-norm dot product trick.
         let alpha = alpha_from_vp(&bufs.v, &bufs.p_tilde)?;
 
-        // Normalize v; leave p_tilde at α₁·p̃_norm.
         if alpha > 0.0 {
             scale_in_place(&mut bufs.v, 1.0 / alpha);
         }
 
-        // Seed the reorth buffer with the (v₁, p̃₁_norm = M v₁) pair.
         if let Some(reorth) = &mut bufs.local_reorth {
             let inv_alpha = if alpha > 0.0 { 1.0 / alpha } else { 0.0 };
             reorth.push(&bufs.v, &bufs.p_tilde, inv_alpha);
@@ -532,16 +468,7 @@ impl<'a, A: Operator + ?Sized, M: Operator + ?Sized> ModifiedGolubKahan<'a, A, M
         ))
     }
 
-    /// Phase 2 of [`step`](Bidiagonalization::step): fold the adjoint matvec
-    /// into the `p̃` recurrence.
-    ///
-    /// `apply_adjoint` on the unnormalized `u` yields `β · Aᵀ u_norm`. The
-    /// `p̃ = α · M v` invariant is maintained by scaling the running `p̃` with
-    /// `β / α_k`: the `α_k` in the denominator cancels the `α_k` factor stored
-    /// in `p̃` from the previous step, so the updated `p̃` ends up as
-    /// `α_new · M v_new` (up to MGS) on completion of this iteration.
-    /// Precondition: `α_k > 0` (the outer loop guard in `lsmr_from_bidiag`
-    /// never calls `step()` once `α` has collapsed to zero).
+    /// Scaling by `β / α_k` cancels the stored `α_k`; requires `α_k > 0`.
     fn update_p_tilde(&mut self, beta: f64, beta_inv: f64) -> Result<(), SolveError> {
         self.operator
             .apply_adjoint(&self.bufs.u, &mut self.bufs.atu)?;
@@ -554,18 +481,7 @@ impl<'a, A: Operator + ?Sized, M: Operator + ?Sized> ModifiedGolubKahan<'a, A, M
         Ok(())
     }
 
-    /// Phase 3 of [`step`](Bidiagonalization::step): recover `v` from `p̃`, run
-    /// M-weighted MGS, normalize, and push the pair to the ring. Returns the
-    /// corrected `α_{k+1}`.
-    ///
-    /// First recover `v` from `p̃` via the preconditioner: `ṽ_{k+1} = M⁻¹ p̃`
-    /// (equals `α_new · v_norm` before normalization). Then run modified
-    /// Gram-Schmidt against past `(v, p̃ = M v)` pairs, mutating `v` and
-    /// `p_tilde` in lockstep so the `p̃ = M v` invariant holds on the corrected
-    /// pair. After MGS, `α_{k+1} = √⟨ṽ, p̃⟩` is the corrected norm; we normalize
-    /// `v` in place (`p_tilde` stays at `α_new · p̃_norm` for the next step),
-    /// and push the normalized `v_{k+1}` and `p̃_{k+1,norm} = p_tilde / α_new`
-    /// into the ring for the next step's MGS.
+    /// Recover `ṽ = M⁻¹ p̃`, MGS in lockstep to hold `p̃ = M v`, normalize; returns `α_{k+1}`.
     fn reorthonormalize_v(&mut self) -> Result<f64, SolveError> {
         self.preconditioner
             .apply(&self.bufs.p_tilde, &mut self.bufs.v)?;

--- a/crates/schwarz-precond/src/lsmr/recurrence.rs
+++ b/crates/schwarz-precond/src/lsmr/recurrence.rs
@@ -9,9 +9,7 @@ use super::bidiag::{BidiagStep, LSMR_PAR_THRESHOLD, LSMR_UPDATE_CHUNK};
 use rayon::iter::{IndexedParallelIterator, ParallelIterator};
 use rayon::prelude::{ParallelSlice, ParallelSliceMut};
 
-/// Givens rotation `[[c, s], [-s, c]]` constructed from a column `(a, b)`
-/// such that the rotation applied to that column yields `(r, 0)` with
-/// `r = hypot(a, b)`.
+/// Givens rotation built from `(a, b)` so applying it yields `(r, 0)`, `r = hypot(a, b)`.
 #[derive(Clone, Copy)]
 struct Givens {
     c: f64,
@@ -28,9 +26,7 @@ impl Givens {
     }
 }
 
-/// Natural outputs of one rotation step. Carries the scalars that
-/// Algorithm 2.8 produces in the "construct rotation P̂_k / P̄_k" blocks
-/// and feeds straight into the `(x, h, h̄)` recurrence.
+/// Natural outputs of one rotation step, feeding straight into the `(x, h, h̄)` recurrence.
 #[derive(Clone, Copy)]
 pub(super) struct RotationStep {
     /// `ρ_k`, output of P̂_k.
@@ -46,9 +42,7 @@ pub(super) struct RotationStep {
 }
 
 impl RotationStep {
-    /// Seed value used as `prev` on the first iteration. With
-    /// `theta_bar = 0`, the `t_hbar` ratio in the solution recurrence
-    /// vanishes, matching the `h̄₀ = 0` initial condition in Algorithm 2.8.
+    /// First-iteration seed; `theta_bar = 0` vanishes the `t_hbar` ratio, matching `h̄₀ = 0`.
     pub(super) fn initial() -> Self {
         Self {
             rho: 1.0,
@@ -60,18 +54,13 @@ impl RotationStep {
     }
 }
 
-/// LSMR scalar state. Carries the state both Givens rotation chains need
-/// between iterations: `α̅` and `φ̄` for P̂_k (LSQR-side), and `c̅, s̅,
-/// ζ̄` for P̄_k (LSMR-side).
+/// LSMR scalar state: `α̅`/`φ̄` for the LSQR-side chain, `c̅, s̅, ζ̄` for the LSMR-side one.
 pub(super) struct LsmrRecurrenceState {
-    // P̂ chain
     alpha_bar: f64,
     phi_bar: f64,
-    // P̄ chain
     c_bar: f64,
     s_bar: f64,
     zeta_bar: f64,
-    // |ζ̄₀| snapshot (clamped), relativizes the reported normal-eq residual.
     zeta0: f64,
 }
 
@@ -90,38 +79,18 @@ impl LsmrRecurrenceState {
 
     /// Construct and apply both rotations for the current step.
     pub(super) fn step(&mut self, s: BidiagStep) -> RotationStep {
-        // Construct rotation P̂_k (Algorithm 2.8, LSQR side): eliminates
-        // β_{k+1} against α̅_k. Outputs:
-        //   * `p_hat.r` is the diagonal entry `ρ_k` of the upper-bidiagonal
-        //     factor (returned below as `RotationStep::rho`).
-        //   * `theta_new = ŝ_k · α_{k+1}` is the superdiagonal `θ_{k+1}`
-        //     carried forward into P̄_k and the next iteration's P̂.
-        //   * `alpha_bar_new = −ĉ_k · α_{k+1}` becomes `α̅_{k+1}`, the
-        //     diagonal seed consumed by the next P̂.
-        //   * `phi_bar_new = ŝ_k · φ̄_k` advances the LSQR transformed-RHS
-        //     scalar used by the residual estimate `|φ̄|`.
         let p_hat = Givens::new(self.alpha_bar, s.beta);
         let theta_new = p_hat.s * s.alpha;
         let alpha_bar_new = -p_hat.c * s.alpha;
         let phi_bar_new = p_hat.s * self.phi_bar;
 
-        // Construct rotation P̄_k (Algorithm 2.8, LSMR side): eliminates
-        // θ_{k+1} against c̅_{k-1}·ρ_k. The off-diagonal feeding this
-        // rotation is `θ̄_k = s̄_{k-1} · ρ_k`, which reads `self.s_bar` —
-        // the *previous* iteration's `s̄`. The read MUST happen before we
-        // commit `p_bar.s` into `self.s_bar` further down; otherwise we
-        // would mix s̄_k into θ̄_k and break the recurrence.
+        // `theta_bar` MUST be read before `p_bar.s` is committed, or s̄_k mixes into θ̄_k.
         let theta_bar = self.s_bar * p_hat.r;
         let p_bar = Givens::new(self.c_bar * p_hat.r, theta_new);
-        // `p_bar.r` is `ρ̄_k`. `zeta = c̄_k · ζ̄_k` is the committed
-        // transformed-RHS scalar `ζ_k`.
         let zeta = p_bar.c * self.zeta_bar;
-        // Sign comes from applying P̄_k to the transformed RHS: the
-        // off-diagonal entry of `[[c̄, s̄], [−s̄, c̄]]` acting on `(ζ̄, 0)`
-        // yields `−s̄_k · ζ̄_k` as the new ζ̄.
+        // The minus comes from `[[c̄, s̄], [−s̄, c̄]]` acting on `(ζ̄, 0)`.
         let zeta_bar_new = -p_bar.s * self.zeta_bar;
 
-        // Commit chain state.
         self.alpha_bar = alpha_bar_new;
         self.phi_bar = phi_bar_new;
         self.c_bar = p_bar.c;
@@ -137,8 +106,7 @@ impl LsmrRecurrenceState {
         }
     }
 
-    /// `|φ̄|` — conservative estimate of `‖r_k‖`. The LSMR residual is
-    /// bounded by the LSQR residual, which equals `|φ̄|`.
+    /// `|φ̄|` — conservative `‖r_k‖` estimate; LSMR's residual is bounded by LSQR's.
     pub(super) fn residual_estimate(&self) -> f64 {
         self.phi_bar.abs()
     }
@@ -148,17 +116,13 @@ impl LsmrRecurrenceState {
         self.zeta_bar.abs()
     }
 
-    /// `|ζ̄ₖ| / |ζ̄₀|` — normal-equation residual relative to its initial value
-    /// `‖Aᵀb‖` (Fong & Saunders); the clamp on `ζ̄₀` guards the ratio.
+    /// `|ζ̄ₖ| / |ζ̄₀|` — normal-equation residual relative to `‖Aᵀb‖`; the `ζ̄₀` clamp guards it.
     pub(super) fn relative_normal_eq_residual(&self) -> f64 {
         self.normal_eq_residual_estimate() / self.zeta0
     }
 }
 
-/// Vectors carried by the LSMR solution recurrence.
-///
-/// `(h, h̄)` are the auxiliary recurrence vectors that let us assemble `x`
-/// without storing the full `V_k` basis.
+/// Vectors carried by the recurrence; `(h, h̄)` let `x` be built without the full `V_k` basis.
 pub(super) struct SolutionState {
     x: Vec<f64>,
     h: Vec<f64>,
@@ -166,8 +130,7 @@ pub(super) struct SolutionState {
 }
 
 impl SolutionState {
-    /// Initialize from the first normalized basis vector: `h₁ = v₁`,
-    /// `x = 0`, `h̄₀ = 0`.
+    /// Initialize from the first normalized basis vector: `h₁ = v₁`, `x = 0`, `h̄₀ = 0`.
     pub(super) fn init(v1: &[f64]) -> Self {
         Self {
             x: vec![0.0; v1.len()],
@@ -176,14 +139,9 @@ impl SolutionState {
         }
     }
 
-    /// Apply one step of the `(x, h, h̄)` recurrence. `v` must be the
-    /// normalized `v_{k+1}` from the bidiagonalization. `prev` carries
-    /// `(ρ_{k-1}, ρ̄_{k-1})` from the previous rotation step (seeded with
-    /// [`RotationStep::initial`] on the first iteration).
+    /// One `(x, h, h̄)` step; `v` must be normalized `v_{k+1}` and `prev` carries `(ρ, ρ̄)_{k-1}`.
     pub(super) fn update(&mut self, v: &[f64], curr: RotationStep, prev: RotationStep) {
-        // Ratios consumed by the recurrence (Algorithm 2.8, "Update h̄, x, h").
-        // Denominators are O(1) Givens-rotation diagonals, so an absolute
-        // f64::EPSILON guard catches genuine loss of significance.
+        // Denominators are O(1) Givens diagonals, so an absolute `f64::EPSILON` guard suffices.
         let t_x_denom = curr.rho * curr.rho_bar;
         let t_x = if t_x_denom.abs() > f64::EPSILON {
             curr.zeta / t_x_denom
@@ -247,8 +205,7 @@ pub(super) enum Stop {
     NormalEquationTolerance,
 }
 
-/// Fong & Saunders' two stop criteria for LSMR plus the running `‖A‖_F²`
-/// accumulator that the second criterion needs.
+/// Fong & Saunders' two LSMR stop criteria plus the running `‖A‖_F²` accumulator the second needs.
 pub(super) struct ConvergenceState {
     /// `tol · ‖b‖`.
     abs_tol: f64,

--- a/crates/schwarz-precond/src/schwarz/buffers.rs
+++ b/crates/schwarz-precond/src/schwarz/buffers.rs
@@ -14,10 +14,6 @@ use crate::error::SolveError;
 
 use super::planning::ResolvedReductionStrategy;
 
-// ============================================================================
-// Buffer pooling
-// ============================================================================
-
 pub(super) struct BufferPool {
     n_dofs: usize,
     max_scratch_size: usize,
@@ -60,20 +56,13 @@ impl BufferPool {
         ))
     }
 
-    /// Return a buffer to the pool. Infallible by design: pool bookkeeping
-    /// must never mask the caller's real `apply_result`. On the error path the
-    /// buffer is dropped (see below); on a poisoned pool lock the buffer is
-    /// likewise dropped rather than surfaced as a `Synchronization` error.
+    /// Infallible: pool bookkeeping must never mask the caller's real `apply_result`.
     pub(super) fn put(&self, bufs: SchwarzBuffers, apply_result: &Result<(), SolveError>) {
-        // On error, the atomic backend's swap-zero readout pass is skipped,
-        // leaving stale partial-write values in the AtomicU64 vec. Drop the
-        // buffer rather than pooling it for the next caller to inherit dirty
-        // state.
+        // The swap-zero readout is skipped on error, so drop rather than pool dirty state.
         if apply_result.is_err() {
             return;
         }
-        // A poisoned lock means a worker panicked; just drop the buffer (the
-        // pool lazily re-allocates on the next `take`) instead of erroring.
+        // A poisoned lock means a worker panicked; drop it and let the next `take` re-allocate.
         if let Ok(mut pool) = self.inner.lock() {
             if pool.len() < Self::MAX_POOL_SIZE {
                 pool.push(bufs);
@@ -154,14 +143,7 @@ impl SchwarzBuffers {
     }
 }
 
-/// Thread-local stack of reusable per-worker buffers backed by a shared pool.
-///
-/// Each Rayon worker reuses its own buffers across sequential outer tasks via a
-/// `ThreadLocal` stack, with no cross-thread synchronization in the hot loop.
-/// Nested re-entry on the same worker allocates an extra buffer only when
-/// needed, so the number of retained buffers tracks re-entry depth rather than
-/// Rayon task splitting. At round end [`into_pool`](Self::into_pool) gathers the
-/// shared pool and every worker stack back into one vec for the next round.
+/// Thread-local buffer stack over a shared pool; retained buffers track re-entry depth.
 pub(super) struct WorkerBufferStack<T: Send> {
     shared_pool: Mutex<Vec<T>>,
     worker_stacks: ThreadLocal<RefCell<Vec<T>>>,
@@ -203,9 +185,7 @@ impl<T: Send> WorkerBufferStack<T> {
             .unwrap_or_else(|| (self.alloc)())
     }
 
-    /// Gather the shared pool and all worker stacks back into one vec so it can
-    /// be returned to its [`SchwarzBuffers`] home for the next round. `ctx`
-    /// labels the synchronization error if the pool lock was poisoned.
+    /// Gather pool and worker stacks for the next round; `ctx` labels a poisoned lock.
     pub(super) fn into_pool(mut self, ctx: &'static str) -> Result<Vec<T>, SolveError> {
         let mut pool = self
             .shared_pool
@@ -218,8 +198,7 @@ impl<T: Send> WorkerBufferStack<T> {
     }
 }
 
-/// Worker-local buffers for the parallel-reduction path: a [`WorkerBufferStack`]
-/// of per-worker accumulators plus the reduce-into-`z` step that sums them.
+/// Worker-local buffers for the parallel-reduction path, plus the reduce-into-`z` step.
 pub(super) struct WorkerReductionBuffers {
     pub(super) stack: WorkerBufferStack<AdditiveSweepBuffers>,
 }
@@ -242,21 +221,15 @@ impl WorkerReductionBuffers {
         z: &mut [f64],
         apply_result: &Result<(), SolveError>,
     ) -> Result<Vec<AdditiveSweepBuffers>, SolveError> {
-        // Always leave `z` fully written so a failed apply never exposes a
-        // partial accumulation. On the apply-error path zero `z` up front —
-        // there is nothing to reduce, and this also covers the case where the
-        // subsequent pool recovery fails.
+        // Leave `z` fully written so a failed apply never exposes a partial accumulation.
         if apply_result.is_err() {
             z.fill(0.0);
         }
         let mut buffers = self.stack.into_pool("additive.reduction.pool.into_inner")?;
-        // On success, `reduce_into` zeroes-then-sums into `z`.
         if apply_result.is_ok() {
             Self::reduce_into(z, &buffers);
         }
-        // Re-zero each worker's accumulator for the next round. This is a
-        // `P × n_dofs` pass run on every apply, so spread it across workers
-        // (rayon already owns the thread pool) rather than zeroing serially.
+        // A `P × n_dofs` pass on every apply, so spread it across workers.
         buffers
             .par_iter_mut()
             .for_each(|b| b.global_accum.fill(0.0));

--- a/crates/schwarz-precond/src/schwarz/executor.rs
+++ b/crates/schwarz-precond/src/schwarz/executor.rs
@@ -22,10 +22,6 @@ use super::buffers::{
 };
 use super::planning::ReductionPlan;
 
-// ============================================================================
-// Additive executor
-// ============================================================================
-
 pub(super) struct AdditiveExecutor<S: LocalSolver> {
     subdomains: Arc<Vec<SubdomainEntry<S>>>,
     buf_pool: BufferPool,
@@ -55,8 +51,7 @@ impl<S: LocalSolver> AdditiveExecutor<S> {
         self.subdomains.len()
     }
 
-    /// Dispatch entry point: take a buffer from the pool, run the backend,
-    /// return the buffer.
+    /// Dispatch entry point: take a buffer from the pool, run the backend, return the buffer.
     pub(super) fn apply(
         &self,
         plan: ReductionPlan,
@@ -108,17 +103,13 @@ impl<S: LocalSolver> AdditiveExecutor<S> {
                     })
                 });
 
-        // Recover the scratch pool for the next round before propagating any
-        // apply error. A pool-recovery failure must not mask a real
-        // `LocalSolveFailed`, so prefer the original error when it is one.
+        // A pool-recovery failure must not mask a real `LocalSolveFailed`.
         match worker_scratch.into_pool("additive.atomic.scratch.into_inner") {
             Ok(recovered) => *scratch_pool = recovered,
             Err(into_err) => return apply_result.and(Err(into_err)),
         }
 
-        // On apply error the swap-zero readout is skipped, leaving `accum`
-        // dirty; `BufferPool::put` then drops the whole buffer (matching the
-        // pre-pooling behaviour), so the next caller starts from a clean accum.
+        // On apply error the swap-zero readout is skipped, so `put` drops the buffer.
         apply_result?;
 
         const READOUT_CHUNK: usize = 4096;
@@ -164,9 +155,7 @@ impl<S: LocalSolver> AdditiveExecutor<S> {
                     })
                 });
 
-        // `finish_round` writes `z` (zeroed on the apply-error path) and
-        // recovers the pool. A pool-recovery failure must not mask a real
-        // `LocalSolveFailed`, so prefer the original error when it is one.
+        // A pool-recovery failure must not mask a real `LocalSolveFailed`.
         match worker_buffers.finish_round(z, &apply_result) {
             Ok(recovered) => *pool = recovered,
             Err(finish_err) => return apply_result.and(Err(finish_err)),

--- a/crates/schwarz-precond/src/schwarz/planning.rs
+++ b/crates/schwarz-precond/src/schwarz/planning.rs
@@ -17,12 +17,9 @@ pub enum ReductionStrategy {
     /// Choose a backend from build-time metrics and the current Rayon width.
     #[default]
     Auto,
-    /// Each subdomain atomically scatters into a shared accumulator.
-    /// Memory: O(n_dofs) shared + O(P * max_scratch) thread-local.
+    /// Atomic scatter into a shared accumulator; O(n_dofs) shared plus O(P · max_scratch) local.
     AtomicScatter,
-    /// Each task accumulates into a private buffer, then a parallel
-    /// chunk-based reduction combines them.
-    /// Memory: O(P * n_dofs) for task buffers.
+    /// Private per-task buffers combined by a parallel chunk reduction; O(P · n_dofs).
     ParallelReduction,
 }
 
@@ -47,12 +44,7 @@ pub(super) struct ReductionPlan {
     pub(super) allow_inner_parallelism: bool,
 }
 
-/// Build-time scheduling metrics + `Auto` resolution logic.
-///
-/// Holds only the metrics that require walking the subdomain entries
-/// (work distribution, scatter overlap). Sizes already known to the
-/// preconditioner (`n_subdomains`, `n_dofs`) are passed at call time
-/// rather than duplicated here.
+/// Build-time scheduling metrics and `Auto` resolution.
 #[derive(Debug, Clone, Copy)]
 pub(super) struct AdditiveScheduler {
     pub(super) total_inner_parallel_work: usize,

--- a/crates/schwarz-precond/src/schwarz/preconditioner.rs
+++ b/crates/schwarz-precond/src/schwarz/preconditioner.rs
@@ -16,15 +16,7 @@ use crate::Operator;
 use super::executor::AdditiveExecutor;
 use super::planning::{AdditiveScheduler, ReductionPlan, ReductionStrategy};
 
-// ---------------------------------------------------------------------------
-// Serde
-// ---------------------------------------------------------------------------
-
-/// Persists the subdomain entries and the global DOF count `n_dofs` — the
-/// latter is not recoverable from the entries alone when some operator columns
-/// are covered by no subdomain. `max_scratch_size` and the scheduling metrics
-/// are re-derived on deserialize; the reduction strategy resets to `Auto`;
-/// buffers are re-allocated fresh.
+/// Persists `n_dofs`, which entries alone cannot recover when some columns are uncovered.
 #[cfg(feature = "serde")]
 impl<S> serde::Serialize for SchwarzPreconditioner<S>
 where
@@ -34,9 +26,6 @@ where
         use serde::ser::SerializeStruct;
         let mut state = serializer.serialize_struct("SchwarzPreconditioner", 2)?;
         state.serialize_field("subdomains", self.executor.subdomains())?;
-        // Persist the global DOF count: it is not recoverable from the
-        // subdomains alone when the operator has structural-null tail DOFs
-        // that no subdomain covers.
         state.serialize_field("n_dofs", &self.executor.n_dofs())?;
         state.end()
     }
@@ -58,12 +47,7 @@ where
         }
 
         let h: Helper<S> = Helper::deserialize(deserializer)?;
-        // The bytes may be untrusted (a cache, another machine, a tampered
-        // file). `n_dofs` below the covered subdomain index span is a caller
-        // bug for the infallible constructors — only debug-asserted there — but
-        // from arbitrary input it would let a subdomain scatter out of bounds
-        // at apply time, so reject it here as a typed error rather than build
-        // an unsound preconditioner.
+        // An `n_dofs` below the covered span would let a subdomain scatter out of bounds.
         let covered_span = h
             .subdomains
             .iter()
@@ -84,12 +68,7 @@ where
     }
 }
 
-/// One-level additive Schwarz preconditioner, generic over the local solver.
-///
-/// Subdomains (factored matrices) are stored behind `Arc` so that cloning
-/// shares the heavy subdomain data. A pool of per-thread buffer sets enables
-/// safe concurrent `apply()` calls on the same instance — each caller grabs
-/// an independent buffer set from the pool for the duration of the call.
+/// One-level additive Schwarz preconditioner; pooled per-thread buffers make `apply()` safe.
 pub struct SchwarzPreconditioner<S: LocalSolver> {
     reduction_strategy: ReductionStrategy,
     scheduler: AdditiveScheduler,
@@ -97,22 +76,12 @@ pub struct SchwarzPreconditioner<S: LocalSolver> {
 }
 
 impl<S: LocalSolver> SchwarzPreconditioner<S> {
-    /// Construct from pre-built subdomain entries, inferring the global DOF
-    /// count from the maximum global index across entries (or 0 if empty).
-    ///
-    /// Suitable only when every DOF is covered by a subdomain. An operator
-    /// with columns no subdomain touches (e.g. an unidentified direction kept
-    /// for shape) must state its true width via [`Self::with_n_dofs`], or the
-    /// inferred count falls short and the mismatch surfaces at apply time.
+    /// Infers `n_dofs` from the maximum global index; only valid when every DOF is covered.
     pub fn new(entries: Vec<SubdomainEntry<S>>, strategy: ReductionStrategy) -> Self {
         Self::build(entries, None, strategy)
     }
 
-    /// Construct with an explicit global DOF count: the operator's column
-    /// count, which may exceed the span of the subdomains' global indices. A
-    /// column no subdomain covers stays in the null space, so its apply output
-    /// is `0`. A count below the covered span is a caller bug (a subdomain
-    /// would scatter out of bounds), caught in debug builds.
+    /// Explicit global DOF count; an uncovered column stays in the null space and applies to `0`.
     pub fn with_n_dofs(
         entries: Vec<SubdomainEntry<S>>,
         n_dofs: usize,
@@ -121,9 +90,7 @@ impl<S: LocalSolver> SchwarzPreconditioner<S> {
         Self::build(entries, Some(n_dofs), strategy)
     }
 
-    /// Shared constructor: one pass over `entries` derives `max_scratch_size`,
-    /// the scheduling metrics, and the covered index span. `n_dofs` is taken
-    /// as given, or inferred from that span when `None`.
+    /// One pass over `entries` derives `max_scratch_size`, the metrics, and the covered span.
     fn build(
         entries: Vec<SubdomainEntry<S>>,
         n_dofs: Option<usize>,
@@ -207,8 +174,7 @@ impl<S: LocalSolver> SchwarzPreconditioner<S> {
 }
 
 impl<S: LocalSolver> Clone for SchwarzPreconditioner<S> {
-    /// Clone shares both the subdomain data and the buffer pool via `Arc`.
-    /// This is O(1) and the clone is fully interchangeable with the original.
+    /// Clone shares subdomain data and the buffer pool via `Arc`: O(1) and fully interchangeable.
     fn clone(&self) -> Self {
         Self {
             reduction_strategy: self.reduction_strategy,

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -21,8 +21,7 @@ use crate::results::{
     PyBatchSolveResult, PySolveResult,
 };
 
-/// Build a one-shot solver, run the solve (mirroring [`within::solve`]'s
-/// timing), and hand back the build warnings so the caller can re-emit them.
+/// Build a one-shot solver and hand back build warnings for the caller to re-emit.
 fn build_and_solve<'a>(
     design: impl IntoDesign<'a>,
     y: &[f64],
@@ -56,10 +55,6 @@ fn build_and_solve_batch<'a>(
     Ok((result, solver.warnings().to_vec()))
 }
 
-// ---------------------------------------------------------------------------
-// Public solve functions
-// ---------------------------------------------------------------------------
-
 #[pyfunction]
 #[pyo3(signature = (design, y, weights=None, options=None, preconditioner=None))]
 pub fn solve<'py>(
@@ -75,9 +70,7 @@ pub fn solve<'py>(
     let y = readonly_f64_1d("y", y)?;
     let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
 
-    // Borrow the array views while the GIL is held (`PyReadonlyArray` needs the
-    // token), but defer slice coercion -- and any copy of strided input -- into
-    // the GIL-released closures below, so the F-contiguous path copies nothing.
+    // Defer slice coercion into the released closures, so the F-contiguous path copies nothing.
     let y_arr = y.as_array();
     let w_view = weights.as_ref().map(|w| w.as_array());
 
@@ -143,8 +136,7 @@ pub fn solve_batch<'py>(
     }
 }
 
-/// Validate `Y`'s row count up front: an empty batch (`Y.shape[1] == 0`) would
-/// otherwise silently skip the per-column length check inside `Solver::solve`.
+/// An empty batch would otherwise silently skip the per-column length check in `solve`.
 fn validate_batch_rows(y_rows: usize, n_obs: usize) -> PyResult<()> {
     if y_rows != n_obs {
         return Err(value_err(format!(
@@ -154,14 +146,7 @@ fn validate_batch_rows(y_rows: usize, n_obs: usize) -> PyResult<()> {
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Effect-term design
-// ---------------------------------------------------------------------------
-
-/// One factor's effect: level codes, an optional intercept, and slope covariates.
-///
-/// Holds its columns natively (copied out of numpy) so the borrowed [`Effect`]
-/// it lowers to can be rebuilt off-GIL, where `Py` handles can't reach.
+/// Holds its columns natively so the borrowed [`Effect`] can be rebuilt off-GIL.
 #[pyclass(frozen, skip_from_py_object, module = "within._within")]
 #[pyo3(name = "Effect")]
 #[derive(Clone)]
@@ -197,8 +182,7 @@ impl PyEffect {
 }
 
 impl PyEffect {
-    /// Rebuild the borrowed native [`Effect`]. Infallible: `PyEffect::new`
-    /// already validated these exact columns through `Effect::new`.
+    /// Infallible: `PyEffect::new` already validated these exact columns.
     fn as_effect(&self) -> Effect<'_> {
         Effect::new(
             &self.levels,
@@ -217,8 +201,7 @@ enum DesignSource<'py> {
     Effects(Vec<PyEffect>),
 }
 
-/// Interpret the Python `design` argument: a 2-D `uint32` categories matrix
-/// (borrowed) or a list of [`Effect`] terms (cloned out of Python).
+/// A 2-D `uint32` categories matrix (borrowed) or a list of [`Effect`] terms (cloned).
 fn extract_design<'py>(py: Python<'_>, design: &Bound<'py, PyAny>) -> PyResult<DesignSource<'py>> {
     if design.cast::<PyUntypedArray>().is_ok() {
         let categories = readonly_u32_2d("design", design)?;
@@ -236,15 +219,7 @@ fn extract_design<'py>(py: Python<'_>, design: &Bound<'py, PyAny>) -> PyResult<D
     ))
 }
 
-// ---------------------------------------------------------------------------
-// Persistent Solver
-// ---------------------------------------------------------------------------
-
-/// Persistent solver that reuses preconditioners across multiple solves.
-///
-/// Build once with `Solver(categories, ...)`, then call `solve()` or
-/// `solve_batch()` repeatedly. The expensive preconditioner factorization
-/// happens only at construction time.
+/// Persistent solver reusing preconditioners; the factorization happens once at construction.
 #[pyclass(frozen, module = "within._within")]
 #[pyo3(name = "Solver")]
 pub struct PySolver {
@@ -265,9 +240,7 @@ impl PySolver {
         let weights_vec: Option<Vec<f64>> = weights.as_ref().map(|w| w.as_array().to_vec());
         let precond = resolve_precond_input(py, preconditioner)?;
 
-        // Release the GIL for the design copy/build and preconditioner
-        // factorisation; `BuildError` carries no Python types, so it is mapped
-        // to a Python exception only once the GIL is reacquired.
+        // `BuildError` carries no Python types, so it maps to an exception once the GIL is back.
         let solver = match extract_design(py, design)? {
             DesignSource::Categories(categories) => {
                 let cats = categories.as_array();
@@ -278,8 +251,7 @@ impl PySolver {
             DesignSource::Effects(terms) => {
                 py.detach(move || -> Result<Solver<'static>, BuildError> {
                     let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
-                    // The design borrows the terms' buffers; the solver outlives
-                    // them, so lower to owned columns first.
+                    // The solver outlives the terms' buffers, so lower to owned columns first.
                     let design = Design::new(effects)?.into_owned();
                     Solver::new(design, weights_vec, precond)
                 })
@@ -307,10 +279,7 @@ impl PySolver {
         run_solve(py, || self.solver.solve(&y_cow, &params))
     }
 
-    /// Solve for multiple response vectors in parallel.
-    ///
-    /// `Y` is a 2-D array of shape `(n_obs, k)` where each column is a
-    /// separate response vector.
+    /// `Y` is `(n_obs, k)` with one response per column.
     #[pyo3(name = "solve_batch", signature = (Y, options=None))]
     fn solve_batch_py<'py>(
         &self,
@@ -338,10 +307,7 @@ impl PySolver {
         run_batch(py, || self.solver.solve_batch(&col_refs, &params))
     }
 
-    /// Return the built preconditioner, or ``None`` if unconfigured.
-    ///
-    /// The returned object is picklable and can be passed to a new
-    /// ``Solver(…, preconditioner=p)`` to skip the expensive build step.
+    /// The built preconditioner, or ``None`` if unconfigured; picklable and reusable.
     #[getter]
     #[pyo3(name = "preconditioner")]
     fn preconditioner_py(&self) -> PyResult<Option<PyPreconditioner>> {

--- a/crates/within-py/src/convert.rs
+++ b/crates/within-py/src/convert.rs
@@ -7,10 +7,6 @@ use numpy::{PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
 use within::{SolveError, WithinError};
 
-// ---------------------------------------------------------------------------
-// Shared conversion helpers
-// ---------------------------------------------------------------------------
-
 /// Convert a numpy array view to a contiguous slice, copying only if non-contiguous.
 pub(crate) fn coerce_to_slice<'a>(arr: &'a numpy::ndarray::ArrayView1<'_, f64>) -> Cow<'a, [f64]> {
     match arr.as_slice() {
@@ -24,10 +20,7 @@ pub(crate) fn value_err(e: impl std::fmt::Display) -> PyErr {
     PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string())
 }
 
-/// Maps a native solver error to the Python exception class matching its kind:
-/// caller input-validation failures become `ValueError`; runtime/environment
-/// failures (a poisoned lock, a diverged subdomain solve) become `RuntimeError`,
-/// so Python callers can branch on the distinction.
+/// Input-validation failures become `ValueError`, runtime failures `RuntimeError`.
 pub(crate) trait IntoPyErr {
     fn into_py_err(self) -> PyErr;
 }
@@ -50,9 +43,7 @@ impl IntoPyErr for WithinError {
     }
 }
 
-/// A `TypeError` naming the dtype an input array must have (and the dtype it
-/// actually had, when the object exposes one) — the opaque PyO3 extraction
-/// failure names neither.
+/// The opaque PyO3 extraction failure names neither the expected dtype nor the actual one.
 fn dtype_err(name: &str, expected: &str, obj: &Bound<'_, PyAny>) -> PyErr {
     let got = obj
         .getattr("dtype")
@@ -97,15 +88,7 @@ pub(crate) fn column_refs<'a>(columns: &'a [Cow<'_, [f64]>]) -> Vec<&'a [f64]> {
     columns.iter().map(|c| &**c).collect()
 }
 
-// ---------------------------------------------------------------------------
-// Misc helpers
-// ---------------------------------------------------------------------------
-
-/// Extract the columns of a 2-D array as borrowed-or-owned slices.
-///
-/// A column of an F-contiguous (column-major) array is contiguous in memory and
-/// is borrowed directly (`Cow::Borrowed`); a strided column (e.g. from C-order
-/// input) is copied (`Cow::Owned`). Borrows are tied to the view's data lifetime.
+/// An F-contiguous column is contiguous so it is borrowed; a strided one is copied.
 pub(crate) fn extract_columns<'a>(
     arr: &numpy::ndarray::ArrayView2<'a, f64>,
 ) -> Vec<Cow<'a, [f64]>> {
@@ -124,15 +107,7 @@ pub(crate) fn warn_c_contiguous(
     py: Python<'_>,
     cats: &numpy::ndarray::ArrayView2<'_, u32>,
 ) -> PyResult<()> {
-    // Warn only when the per-factor columns are NOT readable as contiguous
-    // slices -- i.e. exactly when ingest must copy them: row stride != 1.
-    // The column stride is irrelevant: even reversed (negative), each column
-    // stays a contiguous slice and is borrowed zero-copy in logical order. A
-    // single row or empty input is trivially contiguous regardless of strides.
-    // Sortedness is unknown here (the locality sort happens later, inside
-    // Design construction), so the advice is hedged: when the dominant factor
-    // is unsorted, the sort copies the columns into contiguous owned storage
-    // anyway and asfortranarray would only add a redundant copy.
+    // Warn only when row stride != 1, i.e. exactly when ingest must copy.
     let strides = cats.strides();
     if cats.nrows() > 1 && strides[0] != 1 {
         PyErr::warn(

--- a/crates/within-py/src/lib.rs
+++ b/crates/within-py/src/lib.rs
@@ -1,4 +1,4 @@
-// __reduce__ methods return noisy PyO3 tuple types; allow the lint crate-wide.
+// `__reduce__` methods return noisy PyO3 tuple types; allow the lint crate-wide.
 #![allow(clippy::type_complexity)]
 
 //! Thin PyO3 bridge exposing the [`within`] crate to Python as `within._within`.
@@ -19,10 +19,6 @@ use config::{
     PyPreconditioner, PyPreconditionerConfig, PyReductionStrategy, PyScalingConfig, PySchur,
 };
 use results::{PyBatchSolveResult, PyCoefficientLayout, PySolveResult, PyUnidentifiedDirection};
-
-// ---------------------------------------------------------------------------
-// Module
-// ---------------------------------------------------------------------------
 
 #[pymodule]
 fn _within(m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/crates/within/src/block_elim/csr_matrix.rs
+++ b/crates/within/src/block_elim/csr_matrix.rs
@@ -7,19 +7,7 @@
 //! carries the rectangular cross-factor coupling block produced in `domain` and
 //! consumed here.
 
-/// Square sparse matrix in Compressed Sparse Row (CSR) format.
-///
-/// # CSR Invariants
-///
-/// A well-formed `CsrMatrix` satisfies:
-/// - `indptr.len() == n + 1`
-/// - `indptr[0] == 0` and `indptr` is non-decreasing
-/// - `indices.len() == data.len() == indptr[n] as usize` (the number of non-zeros)
-/// - All column indices in `indices` are in `0..n`
-/// - Within each row, column indices are sorted ascending with no duplicates
-///
-/// Block elimination produces these by construction, so [`CsrMatrix::new`] is
-/// infallible and the invariants are guarded only in debug builds.
+/// Block elimination produces the CSR invariants, so [`CsrMatrix::new`] only debug-checks them.
 #[derive(Clone)]
 pub(crate) struct CsrMatrix {
     indptr: Vec<u32>,
@@ -29,12 +17,7 @@ pub(crate) struct CsrMatrix {
 }
 
 impl CsrMatrix {
-    /// Create a `CsrMatrix` from raw CSR components.
-    ///
-    /// The components must satisfy the CSR invariants documented on
-    /// [`CsrMatrix`]. Block elimination produces them by construction, so this
-    /// constructor is infallible; in debug builds the invariants are checked
-    /// with `assert!`, and in release builds they are trusted.
+    /// Trusted in release, `assert!`-checked in debug.
     pub(crate) fn new(indptr: Vec<u32>, indices: Vec<u32>, data: Vec<f64>, n: usize) -> Self {
         #[cfg(debug_assertions)]
         {

--- a/crates/within/src/csr_block.rs
+++ b/crates/within/src/csr_block.rs
@@ -5,18 +5,13 @@ pub(crate) const PAR_SPMV_THRESHOLD: usize = 10_000;
 /// Target number of non-zeros per parallel chunk.
 const TARGET_NNZ_PER_CHUNK: usize = 32_768;
 
-/// Checked `usize -> u32` for CSR index / compact-level values: a silent
-/// `as u32` truncation above `u32::MAX` would corrupt the structure with no
-/// diagnostic, and these are build-path invariants, so panic loudly instead.
+/// Checked `usize -> u32`: a silent `as` truncation would corrupt the structure undiagnosed.
 #[inline]
 pub(crate) fn to_u32(x: usize) -> u32 {
     u32::try_from(x).expect("CSR index exceeds u32::MAX")
 }
 
-/// Rectangular CSR matrix used as the off-diagonal block in bipartite Gramians.
-///
-/// Stores C (n_q × n_r) or C^T (n_r × n_q). All column indices within each
-/// row are sorted in ascending order.
+/// Rectangular CSR block storing `C` or `Cᵀ`, column indices ascending within each row.
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) struct CsrBlock {
     pub(crate) indptr: Vec<u32>,
@@ -32,14 +27,7 @@ impl CsrBlock {
         self.data.len()
     }
 
-    /// Whether the CSR arrays are self-consistent: `indptr` holds `nrows + 1`
-    /// entries starting at `0` and non-decreasing, its last entry equals
-    /// `indices.len() == data.len()`, and every column index is `< ncols`.
-    ///
-    /// `nrows`/`ncols` are stored beside the arrays, so untrusted bytes can set
-    /// them to disagree; [`crate::block_elim`] deserialization screens a block
-    /// with this before indexing it, since a block that passes cannot drive an
-    /// out-of-bounds gather, scatter, or transpose.
+    /// `nrows`/`ncols` sit beside the arrays, so untrusted bytes can make them disagree.
     pub(crate) fn is_structurally_valid(&self) -> bool {
         if self.nrows.checked_add(1) != Some(self.indptr.len()) {
             return false;
@@ -67,10 +55,7 @@ impl CsrBlock {
             .map(|(&j, &w)| (j as usize, w))
     }
 
-    /// Transpose this CSR block: (nrows × ncols) → (ncols × nrows).
-    ///
-    /// O(nnz). Rows of the output are automatically sorted because we process
-    /// source rows in ascending order.
+    /// Transpose in O(nnz); output rows come out sorted because source rows go ascending.
     pub(crate) fn transpose(&self) -> CsrBlock {
         let nnz = self.nnz();
         let mut row_counts = vec![0u32; self.ncols];
@@ -104,9 +89,7 @@ impl CsrBlock {
         }
     }
 
-    /// Build a CSR block from a row-major dense table, skipping zeros.
-    ///
-    /// `table` has layout `table[i * ncols + j]` for row i, column j.
+    /// Build a CSR block from a row-major dense table (`table[i * ncols + j]`), skipping zeros.
     pub(crate) fn from_dense_table(table: &[f64], nrows: usize, ncols: usize) -> Self {
         debug_assert_eq!(table.len(), nrows * ncols);
         let mut indptr = vec![0u32; nrows + 1];
@@ -142,10 +125,7 @@ impl CsrBlock {
         }
     }
 
-    /// y = base + A * x (sparse matrix-vector multiply with explicit base).
-    ///
-    /// This fuses a `copy_from_slice(base)` with sparse accumulation to avoid an
-    /// extra pass over the output buffer in block-elimination solves.
+    /// `y = base + A x`, fusing the base copy with accumulation to avoid an extra pass.
     pub(crate) fn spmv_assign_add(
         &self,
         x: &[f64],
@@ -212,10 +192,6 @@ mod tests {
     use super::*;
 
     fn make_3x4_block() -> CsrBlock {
-        // 3x4 matrix:
-        // [1.0  0.0  2.0  0.0]
-        // [0.0  3.0  0.0  4.0]
-        // [5.0  0.0  6.0  0.0]
         CsrBlock::from_dense_table(
             &[1.0, 0.0, 2.0, 0.0, 0.0, 3.0, 0.0, 4.0, 5.0, 0.0, 6.0, 0.0],
             3,
@@ -271,10 +247,7 @@ mod tests {
         assert_eq!(bt.ncols, 3);
         assert_eq!(bt.nnz(), 6);
 
-        // Verify A^T[j, i] == A[i, j] by checking specific values
-        // Original row 0: (0,0)=1, (0,2)=2
-        // Transposed: row 0 should have (0,0)=1, (0,2)=5
-        // row 2 should have (2,0)=2, (2,2)=6
+        // A^T[j, i] == A[i, j] on the values, not just the structure.
 
         // Row 0 of transpose: columns 0 and 2 (from original rows 0 and 2 having col 0)
         let r0_start = bt.indptr[0] as usize;
@@ -355,21 +328,14 @@ mod tests {
         assert_eq!(bt.nnz(), 0);
     }
 
-    // Above PAR_SPMV_THRESHOLD the parallel path must reproduce the sequential
-    // result exactly: each chunk reconstructs its global rows as
-    // `chunk_idx * chunk + local_i`, so a wrong reconstruction (or a no-op body)
-    // yields wrong output. Chunk *sizing* is a perf knob that cannot change the
-    // result — it is used consistently for both the split and the row offset —
-    // so it is deliberately not asserted.
+    // Chunk *sizing* cannot change the result, so it is deliberately not asserted.
     #[test]
     fn par_spmv_matches_seq_above_threshold() {
         let nrows = PAR_SPMV_THRESHOLD + 2_000;
         let ncols = 64;
         let half = ncols / 2;
 
-        // Two nonzeros per row, columns kept distinct and ascending so the block
-        // is structurally valid; values vary with the row so a misindexed row is
-        // observable.
+        // Values vary with the row, so a misindexed row is observable.
         let mut indptr = vec![0u32; nrows + 1];
         let mut indices = Vec::with_capacity(2 * nrows);
         let mut data = Vec::with_capacity(2 * nrows);

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -16,50 +16,19 @@ use scatter::scatter_apply;
 /// Minimum number of rows before scatter/gather loops are parallelized.
 const PAR_THRESHOLD: usize = 10_000;
 
-// ===========================================================================
-// DesignOperator — D, optionally rescaled by W^{1/2}
-// ===========================================================================
-
-/// Rectangular design operator: `D` (unweighted) or `W^{1/2} D` (weighted).
-///
-/// `apply` = `D x` / `W^{1/2} D x` (gather), `apply_adjoint` = `D^T x` /
-/// `D^T W^{1/2} x` (scatter). For the weighted variant, the normal equations
-/// `A^T A = D^T W D = G` recover the Gramian, so the same Schwarz
-/// preconditioner approximating `G^{-1}` applies. Pass `None` to
-/// [`DesignOperator::new`] for `D`, or `Some(&sqrt_w)` for `W^{1/2} D`. The branch
-/// on weights is hoisted outside the per-row loop — the weighted gather applies
-/// `W^{1/2}` in a trailing per-chunk sweep, and the adjoint multiplies inline
-/// through a closure, so there is no per-row scratch buffer.
+/// Design operator `D` or `W^{1/2} D`, whose normal equations `AᵀA = DᵀWD` recover the Gramian.
 pub(crate) struct DesignOperator<'a> {
     design: &'a Design<'a>,
     sqrt_weights: Option<&'a [f64]>,
-    /// Reusable atomic-scatter scratch, sized once to the largest term's
-    /// coefficient block and reused across terms and `apply_adjoint` calls so
-    /// it is allocated once per operator rather than once per LSMR iteration.
-    /// `apply_adjoint` takes `&self`, but `AtomicF64`'s load/store/fetch_add are
-    /// `&self` operations, so a plain `Vec<AtomicF64>` (already `Sync`) needs no
-    /// lock: each call re-seeds the buffer via `store` instead of resizing it.
+    /// Sized once to the largest term's block, so it allocates per operator, not per iteration.
     scatter_scratch: Vec<AtomicF64>,
-    /// Debug-only reentry sentinel: a concurrent `apply_adjoint` would race the
-    /// `scatter_scratch` writes it makes through `&self`.
+    /// Debug-only reentry sentinel: a concurrent `apply_adjoint` would race the scratch writes.
     #[cfg(debug_assertions)]
     adjoint_active: AtomicBool,
 }
 
 impl<'a> DesignOperator<'a> {
-    /// Wrap a design matrix as a linear operator.
-    ///
-    /// Pass `None` for `D`, `Some(&sqrt_w)` for `W^{1/2} D` — the weights must
-    /// already be square-rooted (the `Solver` computes `sqrt(W)` once and
-    /// borrows it across every per-RHS operator), and `sqrt_w.len()` must equal
-    /// `design.n_obs`.
-    ///
-    /// # Panics
-    ///
-    /// Panics when `sqrt_weights.is_some()` and its length does not equal
-    /// `design.n_obs`. The `Solver` entry points perform fallible validation
-    /// against `BuildError::WeightCountMismatch` before construction, so callers
-    /// that go through `Solver::new` or `solve()` never trigger this panic.
+    /// `sqrt_weights` must be pre-square-rooted and `design.n_obs` long.
     pub(crate) fn new(design: &'a Design<'a>, sqrt_weights: Option<&'a [f64]>) -> Self {
         if let Some(sw) = sqrt_weights {
             assert_eq!(
@@ -80,10 +49,7 @@ impl<'a> DesignOperator<'a> {
         }
     }
 
-    /// Compute the observation-space RHS `b = W^{1/2} y`.
-    ///
-    /// For unweighted designs, borrows `y` (no allocation); the weighted
-    /// variant returns an owned scaled copy.
+    /// Observation-space RHS `b = W^{1/2} y`; borrows unweighted, owns weighted.
     pub(crate) fn weighted_rhs<'y>(&self, y: &'y [f64]) -> Cow<'y, [f64]> {
         match self.sqrt_weights {
             None => Cow::Borrowed(y),
@@ -92,8 +58,7 @@ impl<'a> DesignOperator<'a> {
     }
 }
 
-/// RAII reentry guard: `acquire` asserts no call is in flight; `Drop` clears
-/// the flag on every exit path, panics included.
+/// RAII reentry guard; `Drop` clears the flag on every exit path including panics.
 #[cfg(debug_assertions)]
 struct ReentryGuard<'a>(&'a AtomicBool);
 
@@ -139,10 +104,7 @@ impl Operator for DesignOperator<'_> {
         debug_assert_eq!(x.len(), self.design.n_obs);
         debug_assert_eq!(y.len(), self.design.n_dofs);
         y.fill(0.0);
-        // Reuse the per-operator atomic-scatter scratch across iterations. No
-        // lock needed: `AtomicF64` mutates through `&self`, and a single
-        // operator's `apply_adjoint` calls are sequential (`solve_batch` builds
-        // a distinct operator per RHS), so the shared buffer is never raced.
+        // No lock needed: `solve_batch` builds one operator per RHS, so calls are sequential.
         match self.sqrt_weights {
             Some(sw) => scatter_apply(self.design, &self.scatter_scratch, y, &|i| sw[i] * x[i]),
             None => scatter_apply(self.design, &self.scatter_scratch, y, &|i| x[i]),
@@ -151,8 +113,7 @@ impl Operator for DesignOperator<'_> {
     }
 }
 
-// The guard's flag is a private, debug-gated field, so this test lives beside
-// it rather than in the crate's shared `operator/tests.rs`.
+// The guard's flag is private and debug-gated, so this test lives beside it.
 #[cfg(all(test, debug_assertions))]
 mod reentry_guard_tests {
     use std::sync::atomic::Ordering;
@@ -177,7 +138,7 @@ mod reentry_guard_tests {
     fn apply_adjoint_detects_in_flight_reentry() {
         let design = one_factor_design();
         let op = DesignOperator::new(&design, None);
-        // Simulate a sibling apply_adjoint already in flight on this operator.
+        // Simulate a sibling `apply_adjoint` already in flight on this operator.
         op.adjoint_active.store(true, Ordering::Release);
         op.apply_adjoint(
             &vec![0.0; op.design.n_obs],

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -8,9 +8,7 @@ use within::{
     WithinError,
 };
 
-// Behavior: a malformed input produces the right typed error. The Display /
-// source() / From plumbing is covered by a single wiring check per enum below,
-// not by pinning every message string.
+// The Display/source()/From plumbing has one wiring check per enum, not per message.
 
 #[test]
 fn test_empty_observations_error() {
@@ -75,8 +73,7 @@ fn test_empty_categories_via_solve() {
 
 #[test]
 fn test_preconditioner_dimension_mismatch_error() {
-    // Build a preconditioner against a larger design, then try to reuse it
-    // with a smaller design — the dim check in Solver::new should fire.
+    // Reusing a larger design's preconditioner must trip the dim check in Solver::new.
     let big = Array2::from_shape_vec((4, 2), vec![0u32, 0, 1, 1, 2, 0, 3, 1]).expect("big array");
     let small = Array2::from_shape_vec((3, 2), vec![0u32, 0, 1, 1, 0, 0]).expect("small array");
 
@@ -118,8 +115,7 @@ fn test_non_finite_response_rejected() {
         other => panic!("Expected Solve(InvalidInput) via solve(), got: {other:?}"),
     }
 
-    // The persistent Solver API funnels through the same Solver::solve guard, so
-    // the check cannot be bypassed by constructing a Solver and solving in place.
+    // The persistent Solver API funnels through the same guard, so it cannot be bypassed.
     let solver = Solver::new(cats.view(), None, &precond).expect("solver");
     match solver.solve(&y, &params).unwrap_err() {
         SolveError::InvalidInput { message, .. } => {
@@ -131,8 +127,7 @@ fn test_non_finite_response_rejected() {
         other => panic!("Expected InvalidInput via Solver::solve(), got: {other:?}"),
     }
 
-    // solve_batch funnels every column through Solver::solve; the bad value is
-    // in the 2nd RHS.
+    // solve_batch funnels every column through Solver::solve; the bad value is in the 2nd RHS.
     let good = [1.0, 2.0, 3.0];
     let bad = [1.0, 2.0, f64::INFINITY];
     match solve_batch(cats.view(), &[&good[..], &bad[..]], None, &params, &precond).unwrap_err() {
@@ -148,9 +143,7 @@ fn test_non_finite_response_rejected() {
 
 #[test]
 fn test_collinear_finite_slope_is_unidentified_not_rejected() {
-    // A duplicated (collinear) but FINITE slope is genuine rank deficiency, not
-    // malformed input: it must resolve to an UnidentifiedDirection, never an
-    // InvalidLoading. Guards against conflating the two (#122).
+    // A duplicated but FINITE slope is rank deficiency, not malformed input (#122).
     let levels = [0u32, 0, 1, 1];
     let z = [1.0, 3.0, 2.0, 5.0];
     let y = [1.0, 2.0, 3.0, 4.0];
@@ -178,10 +171,7 @@ fn test_solver_accepts_slope_bearing_design_alongside_other_terms() {
     Solver::new(design, None, None).expect("signed routing builds");
 }
 
-// ---------------------------------------------------------------------------
-// Error-type plumbing: one wiring check per enum (From conversions and the
-// transparent source() forward), not per-message pinning.
-// ---------------------------------------------------------------------------
+// One wiring check per enum: From conversions and the transparent source() forward.
 
 #[test]
 fn test_within_error_from_build_error() {
@@ -205,7 +195,7 @@ fn test_within_error_from_solve_error() {
 
 #[test]
 fn test_within_error_source_chains_through_transparent_wrapper() {
-    // Transparent: WithinError -> (BuildError::Preconditioner via #[source]) -> schwarz_precond::BuildError
+    // Transparent: WithinError -> BuildError::Preconditioner -> schwarz_precond::BuildError
     let inner = schwarz_precond::BuildError::ScratchSizeTooSmall {
         scratch_size: 1,
         required_min: 2,


### PR DESCRIPTION
Comment-only pass over 17 files: multi-paragraph doc blocks and narrating
inline comments collapse to a single line carrying the load-bearing why,
and section-divider banners go entirely.

No behavior change — the diff contains no non-comment lines.

- `schwarz-precond`: all 10 changed files
- `within-py`: `api.rs`, `convert.rs`, `lib.rs`
- `within`: `csr_block.rs`, `block_elim/csr_matrix.rs`, `operator/design.rs`, `tests/error_paths.rs`

Split out of #223, which keeps the code changes.
