### PR TITLE
docs(changelog): release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.3.0] - 2026-07-30
 
 ### Added
 


### PR DESCRIPTION
Marks the accumulated `[Unreleased]` section as `0.3.0`, dated today. No content changes to the entries.