### PR TITLE
ci: authenticate cargo publish via crates.io trusted publishing

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish-schwarz-precond:
@@ -16,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Publish schwarz-precond
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "schwarz-precond") | .version')
@@ -26,7 +29,7 @@ jobs:
             cargo publish -p schwarz-precond
           fi
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   publish-within:
     name: Publish within
@@ -35,6 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Publish within
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "within") | .version')
@@ -45,4 +50,4 @@ jobs:
             cargo publish -p within
           fi
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
`cargo-publish.yml` fed `CARGO_REGISTRY_TOKEN` from the `CRATES_IO_TOKEN` secret and never requested an OIDC token, so both jobs failed `403 authentication failed` on the v0.3.0 tag.

Both jobs now mint a short-lived token via `rust-lang/crates-io-auth-action@v1` (revoked in its post step), and the workflow requests `id-token: write`.

The `CRATES_IO_TOKEN` secret is now unused.