### PR TITLE
chore(deps): make faer a dev-dependency of schwarz-precond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Removed
+
+- `faer` is no longer a dependency of `schwarz-precond`; it is used only by the `custom_local_solver` example and moves to dev-dependencies.
+
 ## [0.3.0] - 2026-07-30
 
 ### Added

--- a/crates/schwarz-precond/Cargo.toml
+++ b/crates/schwarz-precond/Cargo.toml
@@ -15,10 +15,12 @@ serde = ["dep:serde"]
 
 [dependencies]
 rayon.workspace = true
-faer.workspace = true
 serde = { workspace = true, optional = true }
 thiserror.workspace = true
 thread_local = "1.1"
+
+[dev-dependencies]
+faer.workspace = true
 
 [lints]
 workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -43,20 +43,9 @@ multiple-versions = "deny"
 wildcards = "deny"
 allow-wildcard-paths = true
 skip = [
-    { crate = "equator@0.2.2", reason = "pre-existing transitive duplicate within faer's nano-gemm chain" },
-    { crate = "equator@0.4.2", reason = "pre-existing transitive duplicate within faer's nano-gemm chain" },
-    { crate = "equator-macro@0.2.1", reason = "pre-existing transitive duplicate within faer's nano-gemm chain" },
-    { crate = "equator-macro@0.4.2", reason = "pre-existing transitive duplicate within faer's nano-gemm chain" },
-    { crate = "getrandom@0.3.4", reason = "pre-existing transitive duplicate (rand 0.9 vs 0.10 chains)" },
     { crate = "rand@0.8.7", reason = "transitive duplicate; dev-dep is on rand 0.10, num-complex/faer pull the older line" },
-    { crate = "rand@0.9.5", reason = "transitive duplicate; dev-dep is on rand 0.10, faer/proptest pull the older line" },
     { crate = "rand_core@0.6.4", reason = "pre-existing transitive duplicate (criterion vs faer/approx-chol chains)" },
-    { crate = "rand_core@0.9.5", reason = "pre-existing transitive duplicate (criterion vs faer/approx-chol chains)" },
-    { crate = "syn@1.0.109", reason = "pre-existing transitive duplicate (older proc-macro crates not yet on syn 2)" },
     { crate = "syn@2.0.119", reason = "transitive duplicate; serde_derive is on syn 3, faer's enum-as-inner/sysctl chain still on syn 2" },
-    { crate = "thiserror@1.0.69", reason = "pre-existing transitive duplicate; workspace itself is on thiserror 2" },
-    { crate = "thiserror-impl@1.0.69", reason = "pre-existing transitive duplicate; workspace itself is on thiserror 2" },
-    { crate = "windows-sys@0.42.0", reason = "pre-existing transitive duplicate (older Windows-target crates)" },
 ]
 
 [sources]


### PR DESCRIPTION
`faer` is used only by the `custom_local_solver` example, which Cargo builds with
dev-dependencies, so consumers of `schwarz-precond` no longer pull it or its
nano-gemm/sysctl chain.

Taking it out of the normal dependency graph strands eleven `deny.toml` skip entries;
pruned. The three that remain are still reached — `rand@0.8.7` and `rand_core@0.6.4`
through faer's dev edge, `syn@2.0.119` through pyo3.

Neither lockfile changes: `Cargo.lock` records one flat dependency list per package
with no dev/normal distinction, and `pixi.lock` tracks conda/pypi only.

`cargo deny --locked check` goes from 11 unmatched-skip warnings to 0 and still reports
advisories/bans/licenses/sources ok. Builds pass for the lib alone (no faer),
`--examples` (faer via dev-deps), and `--workspace --all-targets --locked`;
`cargo test -p schwarz-precond` passes.
