### PR TITLE
fix: keep the exact Schur complement bitwise symmetric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- A design carrying varying slopes on two distinct factors could fail preconditioner construction with `matrix is not symmetric`, when rounding left the two triangles of the exact Schur complement unequal (#229).
+
 ### Removed
 
 - `faer` is no longer a dependency of `schwarz-precond`; it is used only by the `custom_local_solver` example and moves to dev-dependencies.

--- a/crates/within/src/block_elim/schur.rs
+++ b/crates/within/src/block_elim/schur.rs
@@ -104,12 +104,13 @@ fn compute_schur_row_dense(
     touched.push(i);
 
     for (k, w) in matrix.cross_tab.ct.row(i) {
-        let scale = w * inv_diagonal_eliminated[k];
+        let inv = inv_diagonal_eliminated[k];
         for (j, v) in matrix.cross_tab.c.row(k) {
             if work[j] == 0.0 && j != i {
                 touched.push(j);
             }
-            work[j] -= scale * v;
+            // Pairing the loadings before the reciprocal makes (i, j) and (j, i) bitwise equal.
+            work[j] -= (w * v) * inv;
         }
     }
 }

--- a/crates/within/src/block_elim/schur/tests.rs
+++ b/crates/within/src/block_elim/schur/tests.rs
@@ -233,3 +233,34 @@ fn sampled_schur_carries_surplus_exactly_on_low_degree_stars() {
         assert!(row_sum.abs() < 1e-12, "row {i} sum is {row_sum}");
     }
 }
+
+/// Signed loadings cancel past approx-chol's 8-ulp ingest tolerance, so this must be bitwise.
+#[test]
+fn exact_schur_triangles_agree_bitwise_on_signed_loadings() {
+    let c_dense = vec![
+        0.3, -1.7, 0.0, //
+        2.9, 0.7, 1.3, //
+        -0.11, 3.3, 5.1, //
+        1.9, 0.0, -2.3, //
+    ];
+    let row_diag = vec![3.0, 7.0, 0.9, 11.0];
+    let col_diag = vec![13.7, 2.3, 19.1];
+    let inv_diagonal: Vec<f64> = row_diag.iter().map(|d| 1.0 / d).collect();
+
+    for grounding in [Grounding::Grounded, Grounding::Floating] {
+        let operator = make_operator(
+            &c_dense,
+            4,
+            3,
+            row_diag.clone(),
+            col_diag.clone(),
+            grounding,
+        );
+        let dense = sparse_to_dense(&exact_for_factor(&operator, &inv_diagonal));
+        for (i, row) in dense.iter().enumerate() {
+            for (j, &value) in row.iter().enumerate() {
+                assert_eq!(value, dense[j][i], "{grounding:?} asymmetric at ({i}, {j})");
+            }
+        }
+    }
+}

--- a/crates/within/tests/slopes_routing.rs
+++ b/crates/within/tests/slopes_routing.rs
@@ -324,3 +324,67 @@ fn singleton_level_in_non_first_slope_term_solves_under_default() {
         );
     }
 }
+
+/// One slope column per sloped factor, as a function of the year code.
+struct Loadings {
+    what: &'static str,
+    worker: fn(f64) -> f64,
+    firm: fn(f64) -> f64,
+}
+
+/// Dual-factor slopes reduce through the exact dense Schur; the trigger is the loading values.
+#[test]
+fn dual_factor_slopes_build_across_loading_shapes() {
+    const N_YEARS: usize = 10;
+    let n_obs = 50_000;
+    let n_indiv = n_obs / N_YEARS;
+    let n_firm = n_indiv / 23;
+
+    let worker: Vec<u32> = (0..n_obs).map(|i| (i / N_YEARS) as u32).collect();
+    let year: Vec<u32> = (0..n_obs).map(|i| (i % N_YEARS) as u32).collect();
+    let firm: Vec<u32> = (0..n_obs).map(|i| (i % n_firm) as u32).collect();
+    let t: Vec<f64> = year.iter().map(|&y| y as f64).collect();
+
+    for shape in [
+        Loadings {
+            what: "t / t^2",
+            worker: |t| t,
+            firm: |t| t * t,
+        },
+        Loadings {
+            what: "t^2 / t",
+            worker: |t| t * t,
+            firm: |t| t,
+        },
+        Loadings {
+            what: "exp / t^2",
+            worker: |t| (0.3 * t).exp(),
+            firm: |t| t * t,
+        },
+        Loadings {
+            what: "t / log",
+            worker: |t| t,
+            firm: |t| (1.0 + t).ln(),
+        },
+    ] {
+        let what = shape.what;
+        let z0: Vec<f64> = t.iter().map(|&t| (shape.worker)(t)).collect();
+        let z2: Vec<f64> = t.iter().map(|&t| (shape.firm)(t)).collect();
+        let y: Vec<f64> = (0..n_obs)
+            .map(|i| {
+                (worker[i] as f64 * 0.017).sin() + 0.4 * z0[i] - 0.2 * z2[i]
+                    + (i as f64 * 0.31).cos() * 0.1
+            })
+            .collect();
+        let effects = vec![
+            Effect::new(&worker, true, [&z0[..]]).expect("worker slope"),
+            Effect::new(&year, true, []).expect("year effect"),
+            Effect::new(&firm, true, [&z2[..]]).expect("firm slope"),
+        ];
+        let r = Solver::new(effects, None, PreconditionerConfig::default())
+            .unwrap_or_else(|e| panic!("{what}: build failed: {e}"))
+            .solve(&y, &LsmrOptions::default())
+            .unwrap_or_else(|e| panic!("{what}: solve failed: {e}"));
+        assert!(r.converged, "{what}: did not converge");
+    }
+}

--- a/crates/within/tests/slopes_routing.rs
+++ b/crates/within/tests/slopes_routing.rs
@@ -328,8 +328,8 @@ fn singleton_level_in_non_first_slope_term_solves_under_default() {
 /// One slope column per sloped factor, as a function of the year code.
 struct Loadings {
     what: &'static str,
-    worker: fn(f64) -> f64,
-    firm: fn(f64) -> f64,
+    worker_loading: fn(f64) -> f64,
+    firm_loading: fn(f64) -> f64,
 }
 
 /// Dual-factor slopes reduce through the exact dense Schur; the trigger is the loading values.
@@ -345,41 +345,44 @@ fn dual_factor_slopes_build_across_loading_shapes() {
     let firm: Vec<u32> = (0..n_obs).map(|i| (i % n_firm) as u32).collect();
     let t: Vec<f64> = year.iter().map(|&y| y as f64).collect();
 
-    for shape in [
+    for Loadings {
+        what,
+        worker_loading,
+        firm_loading,
+    } in [
         Loadings {
             what: "t / t^2",
-            worker: |t| t,
-            firm: |t| t * t,
+            worker_loading: |t| t,
+            firm_loading: |t| t * t,
         },
         Loadings {
             what: "t^2 / t",
-            worker: |t| t * t,
-            firm: |t| t,
+            worker_loading: |t| t * t,
+            firm_loading: |t| t,
         },
         Loadings {
             what: "exp / t^2",
-            worker: |t| (0.3 * t).exp(),
-            firm: |t| t * t,
+            worker_loading: |t| (0.3 * t).exp(),
+            firm_loading: |t| t * t,
         },
         Loadings {
             what: "t / log",
-            worker: |t| t,
-            firm: |t| (1.0 + t).ln(),
+            worker_loading: |t| t,
+            firm_loading: |t| (1.0 + t).ln(),
         },
     ] {
-        let what = shape.what;
-        let z0: Vec<f64> = t.iter().map(|&t| (shape.worker)(t)).collect();
-        let z2: Vec<f64> = t.iter().map(|&t| (shape.firm)(t)).collect();
+        let z_worker: Vec<f64> = t.iter().map(|&t| worker_loading(t)).collect();
+        let z_firm: Vec<f64> = t.iter().map(|&t| firm_loading(t)).collect();
         let y: Vec<f64> = (0..n_obs)
             .map(|i| {
-                (worker[i] as f64 * 0.017).sin() + 0.4 * z0[i] - 0.2 * z2[i]
+                (worker[i] as f64 * 0.017).sin() + 0.4 * z_worker[i] - 0.2 * z_firm[i]
                     + (i as f64 * 0.31).cos() * 0.1
             })
             .collect();
         let effects = vec![
-            Effect::new(&worker, true, [&z0[..]]).expect("worker slope"),
+            Effect::new(&worker, true, [&z_worker[..]]).expect("worker slope"),
             Effect::new(&year, true, []).expect("year effect"),
-            Effect::new(&firm, true, [&z2[..]]).expect("firm slope"),
+            Effect::new(&firm, true, [&z_firm[..]]).expect("firm slope"),
         ];
         let r = Solver::new(effects, None, PreconditionerConfig::default())
             .unwrap_or_else(|e| panic!("{what}: build failed: {e}"))


### PR DESCRIPTION
Closes #229.

The exact Schur row scatter folded the eliminated diagonal's reciprocal into the outer
loading, so entry `(i, j)` was computed as `(c_ki · d_k⁻¹) · c_kj` and `(j, i)` as
`(c_kj · d_k⁻¹) · c_ki`. The intermediates round differently, leaving the triangles up to
an ulp apart per term; signed slope loadings on two distinct factors cancel enough to
amplify that past approx-chol's 8-ulp ingest tolerance.

Pairing the loadings before the reciprocal makes the terms bitwise equal. Measured on the
issue's repro: worst relative asymmetry 2.66e-15 (12 ulps) before, exactly 0 after.

Only the exact path was affected — the sampled complement writes each edge into both
triangles from one value. `dense_threshold = 0` escaped because it gates the small-block
exact route in `Eliminated::factor_reduced`, which is also why both Schur modes failed
alike.

Coverage: a bitwise-symmetry unit test on a signed cross-tab, and a dual-factor slopes
build sweeping four loading shapes. Both verified red without the fix. A 6-shape × 5-size
sweep of the issue's DGP went from 6 failures to 0.

Neutral on exact-Schur setup at 2M rows (0.0695s → 0.0707s median, against 0.0950s →
0.0961s drift on the untouched approximate arm).