### PR TITLE
Derive the reduced complement from the factorization attempt (#218)

### DIFF
--- a/crates/within/src/block_elim/solver.rs
+++ b/crates/within/src/block_elim/solver.rs
@@ -10,6 +10,7 @@ use crate::domain::{CoordinateMap, CrossTab, Grounding, LocalComponent, MatrixFo
 use crate::BuildError;
 
 use super::compensated_sum;
+use super::csr_matrix::CsrMatrix;
 use super::factor::{factor_sparse, local_solver_build, ReducedFactor};
 use super::schur;
 
@@ -187,27 +188,32 @@ impl Eliminated {
         Self::new(assemble_bipartite_cover(&self.matrix))
     }
 
-    /// At or below `dense_threshold` fill-in does not matter, so the exact complement is used.
+    /// A dense Cholesky spends nothing on sparsity, so it entails the exact complement.
     fn factor_reduced(&self, config: &LocalSolverConfig) -> Result<Factor, BuildError> {
         let exact_below = config.dense_threshold;
-        if exact_below > 0 && self.matrix.n_kept() <= exact_below {
-            let exact = schur::exact_for_factor(&self.matrix, &self.inv_diagonal);
-            let ac = config
-                .approx_chol
-                .to_approx_chol(exact_below, ExactFailure::Error);
-            match factor_sparse(&exact, ac) {
+        let factor = |complement: &CsrMatrix, on_failure| {
+            factor_sparse(
+                complement,
+                config.approx_chol.to_approx_chol(exact_below, on_failure),
+            )
+        };
+
+        let exact = (exact_below > 0 && self.matrix.n_kept() <= exact_below)
+            .then(|| schur::exact_for_factor(&self.matrix, &self.inv_diagonal));
+        if let Some(exact) = &exact {
+            match factor(exact, ExactFailure::Error) {
                 Err(approx_chol::Error::DenseFactorizationFailed { .. }) => {}
                 result => return result.map_err(local_solver_build),
             }
         }
-        let schur_csr = match &config.schur {
+
+        let complement = match &config.schur {
             SchurMode::Approximate(cfg) => schur::sampled(&self.matrix, cfg),
-            SchurMode::Exact => schur::exact_for_factor(&self.matrix, &self.inv_diagonal),
+            SchurMode::Exact => {
+                exact.unwrap_or_else(|| schur::exact_for_factor(&self.matrix, &self.inv_diagonal))
+            }
         };
-        let ac = config
-            .approx_chol
-            .to_approx_chol(exact_below, ExactFailure::FallBackToApproximate);
-        factor_sparse(&schur_csr, ac).map_err(local_solver_build)
+        factor(&complement, ExactFailure::FallBackToApproximate).map_err(local_solver_build)
     }
 }
 

--- a/crates/within/src/block_elim/solver/tests.rs
+++ b/crates/within/src/block_elim/solver/tests.rs
@@ -73,6 +73,53 @@ fn fold_rejects_a_zero_eliminated_diagonal() {
     }
 }
 
+/// The exact attempt only fails when weight spread costs the complement its definiteness.
+fn ill_scaled_laplacian() -> SddmMatrix {
+    let c = CsrBlock::from_dense_table(&[0.0, 1e-16, 1e2, 1e0, 1e5, 0.0, 0.0, 1e14, 0.0], 3, 3);
+    let ct = c.transpose();
+    let cross_tab = CrossTab { c, ct };
+    let diagonal: Vec<f64> = (0..cross_tab.n_local())
+        .map(|i| cross_tab.neighbors(i).map(|(_, v)| v).sum::<f64>())
+        .collect();
+    SddmMatrix {
+        ground_edges: vec![0.0; diagonal.len()],
+        cross_tab,
+        diagonal,
+        grounding: Grounding::Floating,
+    }
+}
+
+#[test]
+fn an_unusable_dense_pivot_is_retried_rather_than_fatal() {
+    let eliminated =
+        Eliminated::new(ill_scaled_laplacian()).expect("a positive diagonal must fold");
+    let exact = schur::exact_for_factor(&eliminated.matrix, &eliminated.inv_diagonal);
+    let exact_only = ApproxCholConfig::default()
+        .to_approx_chol(DEFAULT_DENSE_SCHUR_THRESHOLD, ExactFailure::Error);
+    assert!(
+        matches!(
+            factor_sparse(&exact, exact_only),
+            Err(approx_chol::Error::DenseFactorizationFailed { .. })
+        ),
+        "the fixture no longer reaches the fall-through"
+    );
+
+    for schur in [SchurMode::Exact, SchurMode::Approximate(Default::default())] {
+        let config = LocalSolverConfig {
+            approx_chol: ApproxCholConfig::default(),
+            schur,
+            dense_threshold: DEFAULT_DENSE_SCHUR_THRESHOLD,
+            scaling: Default::default(),
+        };
+
+        assert!(
+            eliminated.factor_reduced(&config).is_ok(),
+            "{:?}: an unusable pivot must not be fatal",
+            config.schur
+        );
+    }
+}
+
 /// Build an eliminated-major CrossTab (`n_rows > n_cols`, as orientation
 /// guarantees) whose two cross entries leave three isolated rows, plus its
 /// build-time diagonal.


### PR DESCRIPTION
Closes #218.

`factor_reduced` now derives the reduced complement from the factorization
attempt rather than alongside it. Under `SchurMode::Exact` the retry after an
unusable dense pivot re-attempts the complement already in hand instead of
forming a bitwise-identical one.

Pure refactor — no behavior change.

Adds the first test for the fall-through, which had none: an ill-scaled
Laplacian whose weight spread costs its complement numerical definiteness. The
test asserts the precondition (the exact-only attempt does fail) before
asserting both modes complete, so it cannot pass vacuously if the fixture
drifts.
