### PR TITLE
refactor: share the dense-table CrossTab test fixture

### DIFF
--- a/crates/within/src/block_elim/solver/tests.rs
+++ b/crates/within/src/block_elim/solver/tests.rs
@@ -2,7 +2,6 @@ use super::*;
 
 use crate::block_elim::csr_matrix::CsrMatrix;
 use crate::config::{ApproxCholConfig, SchurMode, DEFAULT_DENSE_SCHUR_THRESHOLD};
-use crate::csr_block::CsrBlock;
 
 #[test]
 fn test_subtract_mean_empty() {
@@ -115,10 +114,8 @@ fn make_cross_tab() -> (CrossTab, Vec<f64>) {
         0.0, 0.0, // row 3
         0.0, 0.0, // row 4
     ];
-    let c = CsrBlock::from_dense_table(&c_dense, 5, 2);
-    let ct = c.transpose();
     let diagonal = vec![2.0, 3.0, 1.0, 1.0, 1.0, 2.0, 3.0];
-    (CrossTab { c, ct }, diagonal)
+    (CrossTab::from_dense_for_test(&c_dense, 5, 2), diagonal)
 }
 
 #[test]
@@ -218,10 +215,9 @@ fn trivial_singleton_component_solves_r_over_d() {
         scaling: Default::default(),
     };
     for (n_rows, n_cols) in [(1usize, 0usize), (0, 1)] {
-        let c = CsrBlock::from_dense_table(&[], n_rows, n_cols);
-        let ct = c.transpose();
+        let cross_tab = CrossTab::from_dense_for_test(&[], n_rows, n_cols);
         let diagonal = vec![4.0; n_rows + n_cols];
-        let component = LocalComponent::general_for_test(CrossTab { c, ct }, diagonal);
+        let component = LocalComponent::general_for_test(cross_tab, diagonal);
         let solver = BlockElimSolver::build(component, &config).expect("trivial 1×1 build");
         assert_eq!(solver.n_local(), 1);
 
@@ -241,9 +237,8 @@ fn trivial_singleton_component_solves_r_over_d() {
 #[test]
 fn sampled_sparse_preserves_barely_pd_direction() {
     let surplus = 5e-10;
-    let c = CsrBlock::from_dense_table(&[1.0], 1, 1);
-    let ct = c.transpose();
-    let component = LocalComponent::general_for_test(CrossTab { c, ct }, vec![1.0 + surplus, 1.0]);
+    let cross_tab = CrossTab::from_dense_for_test(&[1.0], 1, 1);
+    let component = LocalComponent::general_for_test(cross_tab, vec![1.0 + surplus, 1.0]);
     let config = LocalSolverConfig {
         approx_chol: ApproxCholConfig::default(),
         schur: SchurMode::Approximate(crate::config::ApproxSchurConfig::default()),
@@ -289,11 +284,7 @@ fn grounded_backend_auxiliary_is_initialized_on_every_solve() {
     // approx-chol declines to ground a surplus below its resolvable pivot scale.
     assert_eq!(factor.solve_dimension(), 3);
 
-    let c = CsrBlock::from_dense_table(&[0.0; 6], 3, 2);
-    let cross_tab = CrossTab {
-        ct: c.transpose(),
-        c,
-    };
+    let cross_tab = CrossTab::from_dense_for_test(&[0.0; 6], 3, 2);
     let solver = BlockElimSolver::new(cross_tab, vec![1.0; 3], factor, CoordinateMap::default());
 
     let solve_with_dirty_auxiliary = |dirty: f64| {
@@ -334,8 +325,7 @@ fn signed_component_realizes_congruence_transformed_solve() {
             SchurMode::Approximate(crate::config::ApproxSchurConfig::default()),
         ),
     ] {
-        let c = CsrBlock::from_dense_table(&c_raw, n_rows, n_cols);
-        let ct = c.transpose();
+        let cross_tab = CrossTab::from_dense_for_test(&c_raw, n_rows, n_cols);
         let diagonals: Vec<f64> = (0..n_rows + n_cols)
             .map(|k| diag_hat[k] / (d[k] * d[k]))
             .collect();
@@ -351,8 +341,7 @@ fn signed_component_realizes_congruence_transformed_solve() {
             .enumerate()
             .map(|(i, &v)| if i < n_rows { v } else { -v })
             .collect();
-        let component =
-            LocalComponent::with_factors_for_test(CrossTab { c, ct }, diagonals, &factors);
+        let component = LocalComponent::with_factors_for_test(cross_tab, diagonals, &factors);
         let solver =
             BlockElimSolver::build(component, &config).expect("signed block-elim build failed");
 
@@ -400,10 +389,8 @@ fn frustrated_component_solves_exactly_through_cover() {
         [1.5, -1.0, 0.0, 2.9],
     ];
 
-    let c = CsrBlock::from_dense_table(&c_raw, n_rows, n_cols);
-    let ct = c.transpose();
     let component = LocalComponent::general_for_test(
-        CrossTab { c, ct },
+        CrossTab::from_dense_for_test(&c_raw, n_rows, n_cols),
         vec![a[0][0], a[1][1], a[2][2], a[3][3]],
     );
     let config = LocalSolverConfig {

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -5,9 +5,18 @@ use super::accumulate::{
 };
 use super::{build_compact_mapping, CrossTab};
 use crate::channel::{Channel, ChannelPair};
+use crate::csr_block::CsrBlock;
 use crate::domain::find_all_active_levels;
 use crate::domain::{Design, Effect};
 use crate::observation::ObservationFrame;
+
+impl CrossTab {
+    pub(crate) fn from_dense_for_test(table: &[f64], n_rows: usize, n_cols: usize) -> Self {
+        let c = CsrBlock::from_dense_table(table, n_rows, n_cols);
+        let ct = c.transpose();
+        Self { c, ct }
+    }
+}
 
 /// Terms 0 and 1 paired on their intercept channels (plain cross-tab).
 const INTERCEPT_PAIR: ChannelPair = ChannelPair {

--- a/crates/within/src/domain/factor_pairs/sddm/tests.rs
+++ b/crates/within/src/domain/factor_pairs/sddm/tests.rs
@@ -54,7 +54,7 @@ impl SddmMatrix {
         diagonal: Vec<f64>,
         grounding: Grounding,
     ) -> Self {
-        let cross_tab = cross_tab(table, n_rows, n_cols);
+        let cross_tab = CrossTab::from_dense_for_test(table, n_rows, n_cols);
         debug_assert_eq!(diagonal.len(), cross_tab.n_local());
         let ground_edges = adjacency_sums(&cross_tab)
             .iter()
@@ -70,15 +70,9 @@ impl SddmMatrix {
     }
 
     pub(crate) fn laplacian_for_test(table: &[f64], n_rows: usize, n_cols: usize) -> Self {
-        let diagonal = adjacency_sums(&cross_tab(table, n_rows, n_cols));
+        let diagonal = adjacency_sums(&CrossTab::from_dense_for_test(table, n_rows, n_cols));
         Self::from_dense_for_test(table, n_rows, n_cols, diagonal, Grounding::Floating)
     }
-}
-
-fn cross_tab(table: &[f64], n_rows: usize, n_cols: usize) -> CrossTab {
-    let c = CsrBlock::from_dense_table(table, n_rows, n_cols);
-    let ct = c.transpose();
-    CrossTab { c, ct }
 }
 
 fn assert_sddm(component: &LocalComponent) {
@@ -105,7 +99,7 @@ fn assert_sddm(component: &LocalComponent) {
 #[test]
 fn known_laplacian_has_canonical_coordinates_and_no_ground() {
     let (component, uncertified) = convert(
-        cross_tab(&[2.0, 1.0, 0.0, 3.0], 2, 2),
+        CrossTab::from_dense_for_test(&[2.0, 1.0, 0.0, 3.0], 2, 2),
         vec![3.0, 3.0, 2.0, 4.0],
         ComponentClass::KnownLaplacian,
         &ScalingConfig::default(),
@@ -122,7 +116,7 @@ fn known_laplacian_has_canonical_coordinates_and_no_ground() {
 fn known_laplacian_claim_is_checked() {
     // Structural surplus contradicts the Laplacian claim, so it must fail loudly.
     let result = convert(
-        cross_tab(&[2.0, 1.0, 0.0, 3.0], 2, 2),
+        CrossTab::from_dense_for_test(&[2.0, 1.0, 0.0, 3.0], 2, 2),
         vec![4.0, 3.0, 2.0, 4.0],
         ComponentClass::KnownLaplacian,
         &ScalingConfig::default(),
@@ -133,7 +127,7 @@ fn known_laplacian_claim_is_checked() {
 #[test]
 fn frustrated_component_stores_single_signed_operator() {
     let (component, uncertified) = convert(
-        cross_tab(&[1.0, 1.0, 1.0, -1.0], 2, 2),
+        CrossTab::from_dense_for_test(&[1.0, 1.0, 1.0, -1.0], 2, 2),
         vec![2.0, 2.0, 2.0, 2.0],
         ComponentClass::General,
         &ScalingConfig::default(),
@@ -169,7 +163,7 @@ fn scalable_signed_component_produces_valid_grounded_sddm() {
         }
     }
     let (component, uncertified) = convert(
-        cross_tab(&raw, 2, 3),
+        CrossTab::from_dense_for_test(&raw, 2, 3),
         (0..5).map(|i| diag_hat[i] / (d[i] * d[i])).collect(),
         ComponentClass::General,
         &ScalingConfig::default(),
@@ -184,7 +178,7 @@ fn scalable_signed_component_produces_valid_grounded_sddm() {
 #[test]
 fn singular_signed_boundary_remains_floating() {
     let (component, _) = convert(
-        cross_tab(&[0.5, -1.0], 2, 1),
+        CrossTab::from_dense_for_test(&[0.5, -1.0], 2, 1),
         vec![0.25, 1.0, 2.0],
         ComponentClass::General,
         &ScalingConfig::default(),
@@ -243,7 +237,7 @@ fn large_rescaled_singular_boundary_remains_floating() {
 #[test]
 fn non_scalable_component_errors_under_error_mode() {
     let result = convert(
-        cross_tab(&[1.0, -1.0, 2.0, -2.0], 2, 2),
+        CrossTab::from_dense_for_test(&[1.0, -1.0, 2.0, -2.0], 2, 2),
         vec![1.0, 2.0, 1.0, 2.0],
         ComponentClass::General,
         &ScalingConfig {
@@ -262,7 +256,7 @@ fn non_scalable_component_warns_and_clamps_under_warn_mode() {
     };
     assert_eq!(config.on_failure, ScalingFailure::Warn);
     let (component, uncertified) = convert(
-        cross_tab(&[1.0, -1.0, 2.0, -2.0], 2, 2),
+        CrossTab::from_dense_for_test(&[1.0, -1.0, 2.0, -2.0], 2, 2),
         vec![1.0, 2.0, 1.0, 2.0],
         ComponentClass::General,
         &config,
@@ -279,7 +273,7 @@ fn non_scalable_component_warns_and_clamps_under_warn_mode() {
 fn barely_pd_surplus_is_structural() {
     let surplus = 5e-10;
     let (component, _) = convert(
-        cross_tab(&[1.0], 1, 1),
+        CrossTab::from_dense_for_test(&[1.0], 1, 1),
         vec![1.0 + surplus, 1.0],
         ComponentClass::General,
         &ScalingConfig::default(),


### PR DESCRIPTION
Closes #235.

A test that needs a `CrossTab` from a dense table now calls
`CrossTab::from_dense_for_test(table, n_rows, n_cols)`. The three-step
`from_dense_table` / `transpose` / `CrossTab { c, ct }` assembly is gone from
15 fixtures across `block_elim/solver/tests.rs` and `factor_pairs/sddm/tests.rs`,
along with the module-private `fn cross_tab` the latter kept for itself.

The three sites that deliberately deviate — the inconsistent-`ncols` tab and the
two field-by-field `CsrBlock` builds — keep their hand-rolled assembly.

Behavior-preserving: 98 passed / 0 failed before and after, same test list.