### PR TITLE
fix: install numpy from the nightly index for 3.15/3.15t interpreters

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -301,6 +301,11 @@ jobs:
       - name: Install wheel and smoke-solve
         run: |
           python -m pip install --upgrade pip
+          if [[ "${{ matrix.python-version }}" == "3.15-dev" ]]; then
+            python -m pip install --pre \
+              --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+              numpy
+          fi
           pip install dist/*.whl
           python .github/workflows/smoke_solve.py
 
@@ -395,6 +400,11 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
+          if [[ "${{ matrix.python-version }}" == "3.15t-dev" ]]; then
+            python -m pip install --pre \
+              --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+              numpy
+          fi
           pip install dist/${{ matrix.wheel-glob }}.whl
           python .github/workflows/smoke_solve.py
       - name: Free-threaded correctness test


### PR DESCRIPTION
Diagnosed from the "17 min is not acceptable" Wheels run on main (31016034333): the `3.15t-dev`/`3.15-dev` import-test jobs were 4-9x slower than their `3.14t` siblings because PyPI has no prebuilt numpy wheel for cp315/cp315t yet — pip fell back to building numpy from source. On Windows that's an experimental MINGW-W64 build numpy itself flags as "CRASHES ARE TO BE EXPECTED", and took ~8 minutes alone, stretching the whole run from ~9 to 17 minutes.

Installs numpy from the `scientific-python-nightly-wheels` index before installing the `within` wheel, for the 3.15 variants only — the same workaround PR #212 already had for this exact case, which I dropped when re-deriving the matrix onto the post-#243 file structure. Verified the index actually carries prebuilt `cp315`/`cp315t` wheels for every platform this workflow targets (macOS x86_64/arm64, manylinux/musllinux aarch64/x86_64, win_amd64) before writing this, so it's not just swapping one silent fallback for another.