### PR TITLE
revert: drop Python 3.15 wheel support until 3.15 actually ships

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -160,7 +160,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter python3.14t python3.15t pypy3.11
+          args: --release --out dist --interpreter python3.14t pypy3.11
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
       - name: Upload wheels
@@ -181,7 +181,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: x86_64
-          args: --release --out dist --interpreter python3.14t python3.15t
+          args: --release --out dist --interpreter python3.14t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -199,14 +199,13 @@ jobs:
         with:
           python-version: |
             3.14t
-            3.15t-dev
             pypy3.11
           architecture: x64
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: x64
-          args: --release --out dist --interpreter python3.14t python3.15t pypy3.11
+          args: --release --out dist --interpreter python3.14t pypy3.11
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v7
@@ -230,13 +229,12 @@ jobs:
         with:
           python-version: |
             3.14t
-            3.15t-dev
             pypy3.11
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --interpreter python3.14t python3.15t pypy3.11
+          args: --release --out dist --interpreter python3.14t pypy3.11
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v7
@@ -288,7 +286,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15-dev"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -319,11 +317,6 @@ jobs:
             free-threaded: true
           - runner: ubuntu-latest
             wheel-suffix: linux-nonabi3-x86_64
-            python-version: "3.15t-dev"
-            wheel-glob: "*cp315-cp315t*"
-            free-threaded: true
-          - runner: ubuntu-latest
-            wheel-suffix: linux-nonabi3-x86_64
             python-version: "pypy3.11"
             wheel-glob: "*pp311*"
           - runner: ubuntu-24.04-arm
@@ -333,22 +326,12 @@ jobs:
             free-threaded: true
           - runner: ubuntu-24.04-arm
             wheel-suffix: linux-nonabi3-aarch64
-            python-version: "3.15t-dev"
-            wheel-glob: "*cp315-cp315t*"
-            free-threaded: true
-          - runner: ubuntu-24.04-arm
-            wheel-suffix: linux-nonabi3-aarch64
             python-version: "pypy3.11"
             wheel-glob: "*pp311*"
           - runner: macos-15-intel
             wheel-suffix: macos-nonabi3-x86_64
             python-version: "3.14t"
             wheel-glob: "*cp314-cp314t*"
-            free-threaded: true
-          - runner: macos-15-intel
-            wheel-suffix: macos-nonabi3-x86_64
-            python-version: "3.15t-dev"
-            wheel-glob: "*cp315-cp315t*"
             free-threaded: true
           - runner: macos-15-intel
             wheel-suffix: macos-nonabi3-x86_64
@@ -358,11 +341,6 @@ jobs:
             wheel-suffix: macos-nonabi3-aarch64
             python-version: "3.14t"
             wheel-glob: "*cp314-cp314t*"
-            free-threaded: true
-          - runner: macos-latest
-            wheel-suffix: macos-nonabi3-aarch64
-            python-version: "3.15t-dev"
-            wheel-glob: "*cp315-cp315t*"
             free-threaded: true
           - runner: macos-latest
             wheel-suffix: macos-nonabi3-aarch64
@@ -372,11 +350,6 @@ jobs:
             wheel-suffix: windows-nonabi3-x64
             python-version: "3.14t"
             wheel-glob: "*cp314-cp314t*"
-            free-threaded: true
-          - runner: windows-latest
-            wheel-suffix: windows-nonabi3-x64
-            python-version: "3.15t-dev"
-            wheel-glob: "*cp315-cp315t*"
             free-threaded: true
           - runner: windows-latest
             wheel-suffix: windows-nonabi3-x64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Free Threading :: 2 - Beta",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Rust",


### PR DESCRIPTION
Supersedes #244 (closed).

Python 3.15 hasn't released yet, and neither has a numpy wheel for cp315/cp315t on PyPI. Everything #242 added for 3.15 (`-dev` interpreter builds, `3.15-dev`/`3.15t-dev` test-matrix entries) was testing against a moving nightly target with no real user benefit today, and the fragility showed up immediately: a 17-minute CI run on main, driven by an experimental MINGW-W64 numpy source build on Windows that numpy itself warns will crash.

Drops the 3.15/3.15t-dev interpreter builds, matrix entries, and the `Python :: 3.15` classifier. Keeps everything targeting 3.14 (released, stable numpy support): 3.14t/pypy3.11 wheels, the `3.14t` import-test-nonabi3 entries, and `tests/test_free_threaded.py`.

Re-add 3.15 support once 3.15 actually ships — at that point it should just be a normal stable-wheel version bump, no nightly-index workaround needed.