### PR TITLE
fix: document the numpy input-mutation contract instead of copying

### DIFF
--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -25,12 +25,12 @@ use crate::results::{
 fn build_and_solve<'a>(
     design: impl IntoDesign<'a>,
     y: &[f64],
-    weights: Option<&[f64]>,
+    weights: Option<Vec<f64>>,
     lsmr: &LsmrOptions,
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(SolveResult, Vec<BuildWarning>), WithinError> {
     let t_start = Instant::now();
-    let solver = Solver::new(design, weights.map(|w| w.to_vec()), precond)?;
+    let solver = Solver::new(design, weights, precond)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve(y, lsmr)?;
     result.time_setup += time_setup;
@@ -42,12 +42,12 @@ fn build_and_solve<'a>(
 fn build_and_solve_batch<'a>(
     design: impl IntoDesign<'a>,
     ys: &[&[f64]],
-    weights: Option<&[f64]>,
+    weights: Option<Vec<f64>>,
     lsmr: &LsmrOptions,
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(BatchSolveResult, Vec<BuildWarning>), WithinError> {
     let t_start = Instant::now();
-    let solver = Solver::new(design, weights.map(|w| w.to_vec()), precond)?;
+    let solver = Solver::new(design, weights, precond)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve_batch(ys, lsmr)?;
     result.time_setup += time_setup;
@@ -79,15 +79,19 @@ pub fn solve<'py>(
             let cats = categories.as_array();
             run_solve_with_warnings(py, move || {
                 let y_cow = coerce_to_slice(&y_arr);
-                let w_cow = w_view.as_ref().map(coerce_to_slice);
-                build_and_solve(cats, &y_cow, w_cow.as_deref(), &params, precond)
+                build_and_solve(cats, &y_cow, w_view.map(|w| w.to_vec()), &params, precond)
             })
         }
         DesignSource::Effects(terms) => run_solve_with_warnings(py, move || {
             let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
             let y_cow = coerce_to_slice(&y_arr);
-            let w_cow = w_view.as_ref().map(coerce_to_slice);
-            build_and_solve(effects, &y_cow, w_cow.as_deref(), &params, precond)
+            build_and_solve(
+                effects,
+                &y_cow,
+                w_view.map(|w| w.to_vec()),
+                &params,
+                precond,
+            )
         }),
     }
 }
@@ -117,8 +121,13 @@ pub fn solve_batch<'py>(
             run_batch_with_warnings(py, move || {
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
-                let w_cow = w_view.as_ref().map(coerce_to_slice);
-                build_and_solve_batch(cats, &col_refs, w_cow.as_deref(), &params, precond)
+                build_and_solve_batch(
+                    cats,
+                    &col_refs,
+                    w_view.map(|w| w.to_vec()),
+                    &params,
+                    precond,
+                )
             })
         }
         DesignSource::Effects(terms) => {
@@ -129,8 +138,13 @@ pub fn solve_batch<'py>(
                 let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
-                let w_cow = w_view.as_ref().map(coerce_to_slice);
-                build_and_solve_batch(effects, &col_refs, w_cow.as_deref(), &params, precond)
+                build_and_solve_batch(
+                    effects,
+                    &col_refs,
+                    w_view.map(|w| w.to_vec()),
+                    &params,
+                    precond,
+                )
             })
         }
     }

--- a/crates/within-py/src/lib.rs
+++ b/crates/within-py/src/lib.rs
@@ -3,10 +3,11 @@
 
 //! Thin PyO3 bridge exposing the [`within`] crate to Python as `within._within`.
 //! Converts Python/numpy types to the native API and delegates all computation
-//! to [`within`]; every heavy call releases the GIL via [`Python::detach`].
+//! to [`within`]; every heavy call detaches from the interpreter via [`Python::detach`].
 //! Usage docs live in `python/within/` and the `within._within.pyi` stub.
 //!
-//! `gil_used = false`: audited safe (no `&mut self`, no global state, borrowed NumPy inputs only).
+//! `gil_used = false`: no `&mut self`, no global state; numpy inputs are read in place.
+//! Callers must not mutate an array from another thread while a call reads it.
 
 use pyo3::prelude::*;
 

--- a/python/within/__init__.py
+++ b/python/within/__init__.py
@@ -40,6 +40,10 @@ Two-tier public API:
   (``AdditiveSchwarz``, ``LocalSolverConfig``, ``ApproxCholConfig``,
   ``ApproxSchurConfig``, ``ReductionStrategy``).
 
+Thread safety: the heavy work runs with the interpreter detached and reads the
+caller's arrays in place. As with NumPy itself, an input array must not be
+mutated from another thread while a ``within`` call is reading it.
+
 For Rust-level internals, build the API docs with ``cargo doc --open``.
 """
 


### PR DESCRIPTION
#247 proposed copying every numpy input before `py.detach`, so a concurrent mutation from another Python thread could not be observed mid-solve. Reverted after checking the contract: rust-numpy documents that borrows "are not bound to the GIL and will stay active after the GIL is released, for example by calling `detach`", and treats concurrent modification from Python as the caller's responsibility. NumPy says the same about its own arrays. Copying also does not make the race correct — it turns a torn read into a stale snapshot.

Measured cost of copying: **+267MB peak RSS** on a 5M×8 `solve_batch` (a full duplicate of `Y`), against a ~126MB noise floor. Free on `solve`, where the solver materializes owned columns either way.

Inputs stay borrowed. What changes:

- the caller obligation is stated in the package docstring
- the `gil_used = false` audit note no longer cites "borrowed NumPy inputs only" as its justification (that was the property #247 questioned, not an argument for it) and no longer claims the GIL is held, which is false on the 3.14t wheels
- `build_and_solve` takes `Option<Vec<f64>>`, dropping a double copy of strided weights

Closes #247.