### PR TITLE
fix: raise the documented TypeError for wrong-type design and local_solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - A design carrying varying slopes on two distinct factors could fail preconditioner construction with `matrix is not symmetric`, when rounding left the two triangles of the exact Schur complement unequal (#229).
+- A `design` that is neither a 2-D `uint32` array nor a list of `Effect` raised `ValueError` where the documented type is `TypeError`, and `AdditiveSchwarz` accepted a wrong-type `local_solver` at construction, deferring the `TypeError` to solve time (#248).
 
 ### Removed
 

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -222,9 +222,11 @@ fn extract_design<'py>(py: Python<'_>, design: &Bound<'py, PyAny>) -> PyResult<D
         warn_c_contiguous(py, &categories.as_array())?;
         return Ok(DesignSource::Categories(categories));
     }
-    let effects: Vec<Py<PyEffect>> = design
-        .extract()
-        .map_err(|_| value_err("design must be a 2-D uint32 array or a list of Effect"))?;
+    let effects: Vec<Py<PyEffect>> = design.extract().map_err(|_| {
+        PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "design must be a 2-D uint32 array or a list of Effect",
+        )
+    })?;
     Ok(DesignSource::Effects(
         effects
             .iter()

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -269,7 +269,7 @@ impl PyLocalSolverConfig {
 #[pyo3(name = "AdditiveSchwarz")]
 pub struct PyAdditiveSchwarz {
     #[pyo3(get)]
-    pub local_solver: Option<Py<PyAny>>,
+    pub local_solver: Option<Py<PyLocalSolverConfig>>,
     #[pyo3(get)]
     pub reduction: PyReductionStrategy,
 }
@@ -278,7 +278,7 @@ pub struct PyAdditiveSchwarz {
 impl PyAdditiveSchwarz {
     #[new]
     #[pyo3(signature = (local_solver=None, reduction=PyReductionStrategy::Auto))]
-    fn new(local_solver: Option<Py<PyAny>>, reduction: PyReductionStrategy) -> Self {
+    fn new(local_solver: Option<Py<PyLocalSolverConfig>>, reduction: PyReductionStrategy) -> Self {
         Self {
             local_solver,
             reduction,
@@ -420,18 +420,11 @@ fn extract_preconditioner_config(
 
     if let Ok(schwarz) = obj.cast::<PyAdditiveSchwarz>() {
         let s = schwarz.get();
-        let local = match &s.local_solver {
-            None => LocalSolverConfig::default(),
-            Some(obj) => {
-                let obj = obj.bind(py);
-                let Ok(sc) = obj.cast::<PyLocalSolverConfig>() else {
-                    return Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                        "local_solver must be LocalSolverConfig or None",
-                    ));
-                };
-                sc.get().to_native(py)
-            }
-        };
+        let local = s
+            .local_solver
+            .as_ref()
+            .map(|c| c.bind(py).get().to_native(py))
+            .unwrap_or_default();
         let reduction = s.reduction.to_native();
         return Ok(Some(PreconditionerConfig::Additive {
             local_solver: local,

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from within import Effect, solve
+from within import Effect, Solver, solve, solve_batch
 from within._within import ApproxSchurConfig
+from within.config import AdditiveSchwarz
 
 from conftest import as_solver_categories
 
@@ -82,6 +83,25 @@ class TestErrorHandling:
         with pytest.raises(TypeError) as exc:
             solve(cats, y, preconditioner="invalid")
         assert "PreconditionerConfig.Diagonal" in str(exc.value)
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda design: solve(design, np.array([1.0, 2.0, 3.0])),
+            lambda design: solve_batch(design, np.ones((3, 2))),
+            lambda design: Solver(design),
+        ],
+        ids=["solve", "solve_batch", "Solver"],
+    )
+    def test_invalid_design_type_raises(self, call):
+        """A design that is neither array nor list of Effect should raise TypeError."""
+        with pytest.raises(TypeError, match="2-D uint32 array or a list of Effect"):
+            call("invalid")
+
+    def test_additive_schwarz_rejects_local_solver_type(self):
+        """A wrong-type local_solver should raise at construction, not at solve."""
+        with pytest.raises(TypeError):
+            AdditiveSchwarz(local_solver="invalid")
 
     def test_approx_schur_config_split_zero_raises(self):
         """ApproxSchurConfig(split=0) should raise ValueError."""


### PR DESCRIPTION
Closes #248.

`solve` / `solve_batch` / `Solver` raised `ValueError` for a `design` that is neither a 2-D `uint32` array nor a list of `Effect`, and `AdditiveSchwarz` accepted any object as `local_solver`, deferring the `TypeError` to solve time. Both now raise the `TypeError` the stub already documents, and `local_solver` is validated at construction.

Typing the field `Option<Py<PyLocalSolverConfig>>` moves the check into PyO3's generated argument extraction, which retires the manual downcast in `extract_preconditioner_config`. `_within.pyi` needed no change — it was already correct on both counts.

`LocalSolverConfig` is not subclassable, so the accepted set is unchanged: no input that previously succeeded now fails. The four new tests were verified to fail against the pre-fix binary (`ValueError` for `design`, `DID NOT RAISE` for the constructor).