### PR TITLE
perf: concatenate per-chunk Schur edge lists in one pre-sized copy

### DIFF
--- a/crates/within/src/block_elim/schur.rs
+++ b/crates/within/src/block_elim/schur.rs
@@ -354,10 +354,9 @@ fn par_emit(matrix: &SddmMatrix, config: &ApproxSchurConfig) -> Vec<Edge> {
             },
         )
         .map(|work| work.edges)
-        .reduce(Vec::new, |mut a, mut b| {
-            a.append(&mut b);
-            a
-        });
+        // Pre-sized single copy; a `reduce` tree of `append`s recopies each edge per level.
+        .collect::<Vec<_>>()
+        .concat();
     if let Some(ground) = ground_vertex {
         edges.extend(
             matrix


### PR DESCRIPTION
`par_emit` collected sampled star edges with `reduce(Vec::new, |a, b| a.append(b))`, so rayon's reduction tree recopied every edge once per level. Collecting the chunks and calling `concat()` copies each edge exactly once into one pre-sized allocation.

Setup time on `fixest_comparison`, interleaved rounds with a rebuild between arms:

| | 500K | 2M | 5M | 20M |
|---|---|---|---|---|
| `LSMR(exact)` (null control) | +1.5% | +2.1% | +1.4% | +0.3% |
| `LSMR(approx)` | -3.2% | -4.1% | -4.1% | -5.0% |
| `LSMR(2-2)` | -9.0% | -5.6% | -6.4% | -6.2% |

Run ranges separate at 5M and 20M for `approx`, and at every size for `2-2`.

Scope: null on `slopes`, `akm_panel`, `akm_scaling` and six small-problem suites — Schur assembly is ~30% of within CPU on fixest-difficult 3FE but only 5-7% there. No regression in any suite measured.

Results are unchanged: `sort_and_dedup` imposes a total `(lo, hi, weight)` order immediately after, and iteration counts are bit-identical across every case/config pair in all runs.

Note: 5% sits inside this repo's normal noise band, so reproducing it needs the interleaved protocol — a casual before/after will not show it.