### PR TITLE
docs: compile the schwarz-precond README example in CI

### DIFF
--- a/crates/schwarz-precond/README.md
+++ b/crates/schwarz-precond/README.md
@@ -15,7 +15,7 @@ schwarz-precond = "0.1"
 
 Or with Cargo:
 
-```
+```console
 cargo add schwarz-precond
 ```
 

--- a/crates/schwarz-precond/src/lib.rs
+++ b/crates/schwarz-precond/src/lib.rs
@@ -56,6 +56,11 @@ pub trait Operator: Send + Sync {
     fn apply_adjoint(&self, x: &[f64], y: &mut [f64]) -> Result<(), error::SolveError>;
 }
 
+// Compiles the README usage example as a doctest so it cannot drift from the public API.
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+pub struct ReadmeDoctests;
+
 /// Domain decomposition primitives: subdomain cores and partition weights.
 pub mod domain;
 /// Typed errors for build and runtime failures.


### PR DESCRIPTION
Pulls `crates/schwarz-precond/README.md` into the crate as a doctest via `include_str!`, gated with `#[cfg(doctest)]` so it compiles under `cargo test` (all-platform CI) with zero footprint on the public API, rustdoc, or clippy.

The guard immediately caught the untagged `cargo add` fence — rustdoc compiles bare fences as Rust — now tagged `console`. The `rust` example itself was already correct against the current API.

Closes #257