### PR TITLE
Remove AdditiveSchwarz from Python API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **BREAKING:** Python preconditioner selection is unified under the immutable `PreconditionerConfig` value class: the existing `.Additive`, `.Off`, and `.Diagonal` values remain, while `.additive(...)` replaces the separate `AdditiveSchwarz` class for tuned configurations.
 - **BREAKING:** The serialized `Preconditioner` wire format changed (v13 → v14) to retain its complete construction config and configured reduction strategy; older additive payloads no longer decode.
 - **BREAKING:** The serialized `Preconditioner` wire format changed (v14 → v15) to retain its original build duration; older payloads no longer decode.
 - Rust `Preconditioner` objects expose their normalized construction configuration through `Preconditioner::config()`.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ The `preconditioner` argument accepts any of:
 | `PreconditionerConfig.Additive` | Additive Schwarz shortcut, equivalent to `None`. |
 | `PreconditionerConfig.Diagonal` | Diagonal/Jacobi preconditioner using `diag(D^T W D)^{-1}`. |
 | `PreconditionerConfig.additive(local_solver?, reduction?)` | Tuned additive Schwarz configuration. Advanced argument types are available from `within.config`. |
-| `AdditiveSchwarz(local_solver?, reduction?)` | Existing tuned Schwarz configuration API — import from `within.config`. |
 | `Preconditioner` instance | Reuse a previously-built preconditioner across solvers. |
 
 `PreconditionerConfig` instances compare by value. A built preconditioner exposes

--- a/benchmarks/_framework.py
+++ b/benchmarks/_framework.py
@@ -21,9 +21,8 @@ from typing import Any, Callable, Literal, TypeVar
 import numpy as np
 from numpy.typing import NDArray
 
-from within import LsmrOptions, solve
+from within import LsmrOptions, PreconditionerConfig, solve
 from within._within import (
-    AdditiveSchwarz,
     ApproxCholConfig,
     ApproxSchurConfig,
     Schur,
@@ -187,9 +186,11 @@ def benchmark_lsmr(
     )
 
 
-def make_additive_schwarz(local_solver: Any) -> AdditiveSchwarz:
+def make_additive_schwarz(local_solver: Any) -> PreconditionerConfig:
     """Construct additive Schwarz using the default Auto reduction mode."""
-    return AdditiveSchwarz(local_solver=local_solver, reduction=ReductionStrategy.Auto)
+    return PreconditionerConfig.additive(
+        local_solver=local_solver, reduction=ReductionStrategy.Auto
+    )
 
 
 def standard_solver_configs(

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -66,7 +66,7 @@ pub fn solve<'py>(
     preconditioner: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<PySolveResult> {
     let params = resolve_lsmr_config(options)?;
-    let precond = resolve_precond_input(py, preconditioner)?;
+    let precond = resolve_precond_input(preconditioner)?;
     let y = readonly_f64_1d("y", y)?;
     let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
 
@@ -107,7 +107,7 @@ pub fn solve_batch<'py>(
     preconditioner: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<PyBatchSolveResult> {
     let params = resolve_lsmr_config(options)?;
-    let precond = resolve_precond_input(py, preconditioner)?;
+    let precond = resolve_precond_input(preconditioner)?;
     let y = readonly_f64_2d("Y", Y)?;
     let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
 
@@ -254,7 +254,7 @@ impl PySolver {
     ) -> PyResult<Self> {
         let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
         let weights_vec: Option<Vec<f64>> = weights.as_ref().map(|w| w.as_array().to_vec());
-        let precond = resolve_precond_input(py, preconditioner)?;
+        let precond = resolve_precond_input(preconditioner)?;
 
         // `BuildError` carries no Python types, so it maps to an exception once the GIL is back.
         let solver = match extract_design(py, design)? {

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -316,27 +316,6 @@ impl PyLocalSolverConfig {
 }
 
 #[pyclass(frozen, module = "within._within")]
-#[pyo3(name = "AdditiveSchwarz")]
-pub struct PyAdditiveSchwarz {
-    #[pyo3(get)]
-    pub local_solver: Option<Py<PyLocalSolverConfig>>,
-    #[pyo3(get)]
-    pub reduction: PyReductionStrategy,
-}
-
-#[pymethods]
-impl PyAdditiveSchwarz {
-    #[new]
-    #[pyo3(signature = (local_solver=None, reduction=PyReductionStrategy::Auto))]
-    fn new(local_solver: Option<Py<PyLocalSolverConfig>>, reduction: PyReductionStrategy) -> Self {
-        Self {
-            local_solver,
-            reduction,
-        }
-    }
-}
-
-#[pyclass(frozen, module = "within._within")]
 #[pyo3(name = "LsmrOptions")]
 pub struct PyLsmrOptions {
     #[pyo3(get)]
@@ -454,7 +433,6 @@ impl PyPreconditioner {
 
 /// Must run under the GIL; the result is all-native, so it can move into a released closure.
 pub(crate) fn resolve_precond_input(
-    py: Python<'_>,
     preconditioner: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<PreconditionerInput> {
     if let Some(obj) = preconditioner {
@@ -462,12 +440,11 @@ pub(crate) fn resolve_precond_input(
             return Ok(PreconditionerInput::Prebuilt(built.get().inner.clone()));
         }
     }
-    Ok(extract_preconditioner_config(py, preconditioner)?
+    Ok(extract_preconditioner_config(preconditioner)?
         .map_or(PreconditionerInput::Default, PreconditionerInput::Config))
 }
 
 fn extract_preconditioner_config(
-    py: Python<'_>,
     preconditioner: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<Option<PreconditionerConfig>> {
     let Some(obj) = preconditioner else {
@@ -478,23 +455,8 @@ fn extract_preconditioner_config(
         return Ok(Some(config.get().to_native()));
     }
 
-    if let Ok(schwarz) = obj.cast::<PyAdditiveSchwarz>() {
-        let s = schwarz.get();
-        let local = s
-            .local_solver
-            .as_ref()
-            .map(|c| c.bind(py).get().to_native(py))
-            .unwrap_or_default();
-        let reduction = s.reduction.to_native();
-        return Ok(Some(PreconditionerConfig::Additive {
-            local_solver: local,
-            reduction,
-        }));
-    }
-
     Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-        "preconditioner must be PreconditionerConfig.Additive, PreconditionerConfig.Off, \
-         PreconditionerConfig.Diagonal, AdditiveSchwarz(...), a pre-built Preconditioner, or None",
+        "preconditioner must be a PreconditionerConfig, a pre-built Preconditioner, or None",
     ))
 }
 

--- a/crates/within-py/src/lib.rs
+++ b/crates/within-py/src/lib.rs
@@ -18,8 +18,8 @@ mod results;
 
 use api::{solve, solve_batch, PyEffect, PySolver};
 use config::{
-    PyAdditiveSchwarz, PyApproxCholConfig, PyApproxSchurConfig, PyLocalSolverConfig, PyLsmrOptions,
-    PyPreconditioner, PyPreconditionerConfig, PyReductionStrategy, PyScalingConfig, PySchur,
+    PyApproxCholConfig, PyApproxSchurConfig, PyLocalSolverConfig, PyLsmrOptions, PyPreconditioner,
+    PyPreconditionerConfig, PyReductionStrategy, PyScalingConfig, PySchur,
 };
 use results::{PyBatchSolveResult, PyCoefficientLayout, PySolveResult, PyUnidentifiedDirection};
 
@@ -30,7 +30,6 @@ fn _within(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyUnidentifiedDirection>()?;
     m.add_class::<PyCoefficientLayout>()?;
     m.add_class::<PyLsmrOptions>()?;
-    m.add_class::<PyAdditiveSchwarz>()?;
     m.add_class::<PyReductionStrategy>()?;
     m.add_class::<PyPreconditionerConfig>()?;
     m.add_class::<PyApproxCholConfig>()?;

--- a/python/within/README.md
+++ b/python/within/README.md
@@ -96,7 +96,6 @@ solver2 = Solver(fe, preconditioner=precond)   # skip re-factorization
 | `PreconditionerConfig.Additive` | Additive Schwarz shortcut (equivalent to `None`). |
 | `PreconditionerConfig.additive(local_solver?, reduction?)` | Tuned additive Schwarz configuration. Advanced argument types are available from `within.config`. |
 | `PreconditionerConfig.Diagonal` | Diagonal/Jacobi preconditioner using `diag(D^T W D)^{-1}`. |
-| `AdditiveSchwarz(local_solver?, reduction?)` | Existing tuned Schwarz configuration API — import from `within.config`. |
 | `Preconditioner` (built) | Reuse a previously-built preconditioner across solvers. |
 
 Pass `None` (the default) to use additive Schwarz with the default local solver.

--- a/python/within/__init__.py
+++ b/python/within/__init__.py
@@ -37,8 +37,8 @@ Two-tier public API:
   (``solve``, ``Solver``, ``LsmrOptions``, ``PreconditionerConfig``,
   ``Preconditioner``).
 - :mod:`within.config` re-exports the advanced configuration objects
-  (``AdditiveSchwarz``, ``LocalSolverConfig``, ``ApproxCholConfig``,
-  ``ApproxSchurConfig``, ``ReductionStrategy``).
+  (``LocalSolverConfig``, ``ApproxCholConfig``, ``ApproxSchurConfig``,
+  ``ReductionStrategy``).
 
 Thread safety: the heavy work runs with the interpreter detached and reads the
 caller's arrays in place. As with NumPy itself, an input array must not be

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -220,9 +220,7 @@ def solve(
     y: NDArray[np.float64],
     weights: NDArray[np.float64] | None = None,
     options: LsmrOptions | None = None,
-    preconditioner: (
-        PreconditionerConfig | AdditiveSchwarz | Preconditioner | None
-    ) = None,
+    preconditioner: (PreconditionerConfig | Preconditioner | None) = None,
 ) -> SolveResult:
     """Solve fixed-effects normal equations for a single response vector.
 
@@ -239,13 +237,13 @@ def solve(
             Default: unit weights (unweighted).
         options: LSMR solver tuning. Pass ``LsmrOptions(...)`` to override
             defaults. Default: ``LsmrOptions(tol=1e-8, maxiter=1000)``.
-        preconditioner: Controls preconditioning. Five input forms are accepted:
+        preconditioner: Controls preconditioning. Three input types are accepted:
             ``None`` (default) builds the additive Schwarz preconditioner with
-            default settings. ``PreconditionerConfig.Off`` disables it.
-            ``PreconditionerConfig.Diagonal`` uses diagonal/Jacobi scaling.
-            ``AdditiveSchwarz(...)`` overrides the local-solver / reduction
-            settings. A previously-built ``Preconditioner`` instance reuses an
-            existing factorisation.
+            default settings. ``PreconditionerConfig.Off`` disables it;
+            ``PreconditionerConfig.Diagonal`` uses diagonal/Jacobi scaling;
+            ``PreconditionerConfig.additive(...)`` tunes the local solver and
+            reduction settings. A previously-built ``Preconditioner`` instance
+            reuses an existing factorisation.
 
     Returns:
         A ``SolveResult`` with coefficients, demeaned response, convergence
@@ -282,9 +280,7 @@ def solve_batch(
     Y: NDArray[np.float64],
     weights: NDArray[np.float64] | None = None,
     options: LsmrOptions | None = None,
-    preconditioner: (
-        PreconditionerConfig | AdditiveSchwarz | Preconditioner | None
-    ) = None,
+    preconditioner: (PreconditionerConfig | Preconditioner | None) = None,
 ) -> BatchSolveResult:
     """Solve fixed-effects normal equations for multiple response vectors.
 
@@ -348,9 +344,7 @@ class Solver:
         self,
         design: NDArray[np.uint32] | list[Effect],
         weights: NDArray[np.float64] | None = None,
-        preconditioner: (
-            PreconditionerConfig | AdditiveSchwarz | Preconditioner | None
-        ) = None,
+        preconditioner: (PreconditionerConfig | Preconditioner | None) = None,
     ) -> None: ...
     def solve(
         self,
@@ -450,17 +444,4 @@ class LocalSolverConfig:
         schur: Schur | None = None,
         dense_threshold: int | None = None,
         scaling: ScalingConfig | None = None,
-    ) -> None: ...
-
-class AdditiveSchwarz:
-    """Additive Schwarz preconditioner with configurable local solver."""
-
-    @property
-    def local_solver(self) -> LocalSolverConfig | None: ...
-    @property
-    def reduction(self) -> ReductionStrategy: ...
-    def __init__(
-        self,
-        local_solver: LocalSolverConfig | None = None,
-        reduction: ReductionStrategy = ReductionStrategy.Auto,
     ) -> None: ...

--- a/python/within/config.py
+++ b/python/within/config.py
@@ -7,9 +7,8 @@ preconditioner live in this submodule.
 
 Typical usage::
 
-    from within import solve, LsmrOptions
+    from within import LsmrOptions, PreconditionerConfig, solve
     from within.config import (
-        AdditiveSchwarz,
         ApproxCholConfig,
         ApproxSchurConfig,
         LocalSolverConfig,
@@ -17,7 +16,7 @@ Typical usage::
         Schur,
     )
 
-    schwarz = AdditiveSchwarz(
+    schwarz = PreconditionerConfig.additive(
         local_solver=LocalSolverConfig(
             approx_chol=ApproxCholConfig(split_merge=2),
             schur=Schur.approximate(ApproxSchurConfig(split=2)),
@@ -31,7 +30,6 @@ Schur); pass ``Schur.exact()`` for the exact complement.
 """
 
 from within._within import (
-    AdditiveSchwarz,
     ApproxCholConfig,
     ApproxSchurConfig,
     LocalSolverConfig,
@@ -41,7 +39,6 @@ from within._within import (
 )
 
 __all__ = [
-    "AdditiveSchwarz",
     "ApproxCholConfig",
     "ApproxSchurConfig",
     "LocalSolverConfig",

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from within import Effect, Solver, solve, solve_batch
+from within import Effect, PreconditionerConfig, Solver, solve, solve_batch
 from within._within import ApproxSchurConfig
-from within.config import AdditiveSchwarz
 
 from conftest import as_solver_categories
 
@@ -82,7 +81,7 @@ class TestErrorHandling:
         y = np.array([1.0, 2.0, 3.0])
         with pytest.raises(TypeError) as exc:
             solve(cats, y, preconditioner="invalid")
-        assert "PreconditionerConfig.Diagonal" in str(exc.value)
+        assert "PreconditionerConfig" in str(exc.value)
 
     @pytest.mark.parametrize(
         "call",
@@ -98,10 +97,10 @@ class TestErrorHandling:
         with pytest.raises(TypeError, match="2-D uint32 array or a list of Effect"):
             call("invalid")
 
-    def test_additive_schwarz_rejects_local_solver_type(self):
+    def test_additive_config_rejects_local_solver_type(self):
         """A wrong-type local_solver should raise at construction, not at solve."""
         with pytest.raises(TypeError):
-            AdditiveSchwarz(local_solver="invalid")
+            PreconditionerConfig.additive(local_solver="invalid")
 
     def test_approx_schur_config_split_zero_raises(self):
         """ApproxSchurConfig(split=0) should raise ValueError."""

--- a/tests/test_preconditioner.py
+++ b/tests/test_preconditioner.py
@@ -7,7 +7,6 @@ import pytest
 
 from within import LsmrOptions, Preconditioner, PreconditionerConfig, Solver, solve
 from within._within import (
-    AdditiveSchwarz,
     ApproxCholConfig,
     ApproxSchurConfig,
     LocalSolverConfig,
@@ -88,7 +87,7 @@ class TestAdvancedConfigs:
                 cats,
                 y,
                 options=LsmrOptions(maxiter=2000),
-                preconditioner=AdditiveSchwarz(local_solver=local),
+                preconditioner=PreconditionerConfig.additive(local_solver=local),
             )
             assert result.converged
 
@@ -98,7 +97,9 @@ class TestAdvancedConfigs:
             as_solver_categories(cats),
             y,
             options=LsmrOptions(),
-            preconditioner=AdditiveSchwarz(local_solver=LocalSolverConfig()),
+            preconditioner=PreconditionerConfig.additive(
+                local_solver=LocalSolverConfig()
+            ),
         )
         assert result.converged
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -6,8 +6,8 @@ import numpy as np
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-from within import Solver, solve
-from within.config import AdditiveSchwarz, ReductionStrategy
+from within import PreconditionerConfig, Solver, solve
+from within.config import ReductionStrategy
 
 
 @st.composite
@@ -67,22 +67,10 @@ class TestProperties:
 
 
 class TestAdvancedPreconditioners:
-    """Tests for AdditiveSchwarz preconditioner configs."""
-
-    def test_additive_schwarz_object_converges(self):
-        """AdditiveSchwarz() as preconditioner object should converge."""
-        rng = np.random.default_rng(42)
-        categories = np.asfortranarray(
-            np.column_stack(
-                [rng.integers(0, 20, size=500), rng.integers(0, 20, size=500)]
-            ).astype(np.uint32)
-        )
-        y = rng.standard_normal(500)
-        result = solve(categories, y, preconditioner=AdditiveSchwarz())
-        assert result.converged
+    """Tests for additive preconditioner configs."""
 
     def test_reduction_strategy_atomic_scatter_converges(self):
-        """AdditiveSchwarz with AtomicScatter reduction should converge."""
+        """Additive config with AtomicScatter reduction should converge."""
         rng = np.random.default_rng(10)
         categories = np.asfortranarray(
             np.column_stack(
@@ -93,12 +81,14 @@ class TestAdvancedPreconditioners:
         result = solve(
             categories,
             y,
-            preconditioner=AdditiveSchwarz(reduction=ReductionStrategy.AtomicScatter),
+            preconditioner=PreconditionerConfig.additive(
+                reduction=ReductionStrategy.AtomicScatter
+            ),
         )
         assert result.converged
 
     def test_reduction_strategy_parallel_reduction_converges(self):
-        """AdditiveSchwarz with ParallelReduction strategy should converge."""
+        """Additive config with ParallelReduction strategy should converge."""
         rng = np.random.default_rng(11)
         categories = np.asfortranarray(
             np.column_stack(
@@ -109,7 +99,7 @@ class TestAdvancedPreconditioners:
         result = solve(
             categories,
             y,
-            preconditioner=AdditiveSchwarz(
+            preconditioner=PreconditionerConfig.additive(
                 reduction=ReductionStrategy.ParallelReduction
             ),
         )
@@ -127,12 +117,14 @@ class TestAdvancedPreconditioners:
         r_atomic = solve(
             categories,
             y,
-            preconditioner=AdditiveSchwarz(reduction=ReductionStrategy.AtomicScatter),
+            preconditioner=PreconditionerConfig.additive(
+                reduction=ReductionStrategy.AtomicScatter
+            ),
         )
         r_parallel = solve(
             categories,
             y,
-            preconditioner=AdditiveSchwarz(
+            preconditioner=PreconditionerConfig.additive(
                 reduction=ReductionStrategy.ParallelReduction
             ),
         )

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -15,7 +15,7 @@ from within import (
     Solver,
     solve,
 )
-from within.config import AdditiveSchwarz, LocalSolverConfig, ScalingConfig
+from within.config import LocalSolverConfig, ScalingConfig
 
 from conftest import as_solver_categories, generate_synthetic_data
 
@@ -112,7 +112,7 @@ def test_one_shot_solve_surfaces_build_warnings():
     from within import solve_batch
 
     design = [Effect(f, True, [z]), Effect(g, True)]
-    precond = AdditiveSchwarz(
+    precond = PreconditionerConfig.additive(
         local_solver=LocalSolverConfig(scaling=ScalingConfig(max_sweeps=0))
     )
 
@@ -185,13 +185,13 @@ class TestPreconditioners:
         assert result.converged
 
     def test_advanced_additive_schwarz(self, problem):
-        """Test advanced config via AdditiveSchwarz."""
+        """Test advanced config via PreconditionerConfig.additive()."""
         cats, y = problem
         result = solve(
             as_solver_categories(cats),
             y,
             options=LsmrOptions(),
-            preconditioner=AdditiveSchwarz(),
+            preconditioner=PreconditionerConfig.additive(),
         )
         assert result.converged
 
@@ -460,18 +460,6 @@ class TestSolverSerde:
         solver2 = Solver(categories, preconditioner=precond2)
         r2 = solver2.solve(y)
         np.testing.assert_allclose(r2.x, r1.x, atol=1e-10)
-
-
-# ---------------------------------------------------------------------------
-# Convenience alias tests
-# ---------------------------------------------------------------------------
-
-
-class TestAliases:
-    def test_additive_alias(self, problem):
-        cats, y = problem
-        result = solve(as_solver_categories(cats), y, preconditioner=AdditiveSchwarz())
-        assert result.converged
 
 
 class TestSolveBatchFreeFunction:


### PR DESCRIPTION
This PR removes the `AdditiveSchwarz` object in favour of the new `PreconditionerConfig` class introduced in #274 which allows to instantiate the equivalent config using `PreconditionerConfig.additive`.

This is not strictly necessary to close #236 but I think brings greater coherence to the `PreconditionerConfig` API.