### PR TITLE
feat(domain): warn on cross-term collinear slope covariates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Python `Preconditioner.build_duration_seconds` and Rust `Preconditioner::build_duration()` expose the original preconditioner build duration, preserved across serialization and reuse.
+- `BuildWarning::CollinearSlopeCovariate` reports a slope covariate that is (nearly) a per-level combination of another term's columns — a cross-term near-null direction that per-term whitening cannot see and that can inflate iteration counts by orders of magnitude (#281).
 - `schwarz_precond::EscalationPolicy` builds a per-run `EscalationHandler` that ends a solve with `LsmrStopReason::Escalated` and an iterate that warm-starts the next preconditioner; `Staleness` implements it from the trailing contraction window.
 - `schwarz_precond::MlsmrOptions::warm_start` carries an initial iterate through a change of preconditioner.
 - `LocalSolverConfig::ridge` (Python `LocalSolverConfig(ridge=...)`) floors the local spectrum of grounded slope-pair components at a fraction of their largest diagonal; `0` disables it (#290).

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -1,5 +1,6 @@
 //! Domain layer: [`Design`] (design-matrix metadata) and factor-pair [`Subdomain`] construction.
 
+pub(crate) mod collinearity;
 pub(crate) mod cross_tab;
 mod effect;
 pub(crate) mod factor_pairs;

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -4,6 +4,7 @@ pub(crate) mod collinearity;
 pub(crate) mod cross_tab;
 mod effect;
 pub(crate) mod factor_pairs;
+pub(crate) mod level_moments;
 
 pub(crate) use cross_tab::{find_all_active_levels, BlockDiagonals, CrossTab};
 

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -1,0 +1,257 @@
+//! Cross-term collinearity screen (#281): a slope covariate that is (nearly) a per-level
+//! combination of another term's columns adds a null direction whitening cannot see.
+
+use rayon::prelude::*;
+
+use super::{Design, Loading};
+use crate::channel::Channel;
+use crate::BuildWarning;
+
+/// Residual share below which a covariate counts as reproduced by the other term.
+const COLLINEARITY_TOL: f64 = 1e-3;
+
+/// Pivots below this share of the largest diagonal count as a dependent column.
+const PIVOT_FLOOR: f64 = 1e-12;
+
+pub(crate) fn detect_collinear_slopes(
+    design: &Design<'_>,
+    weights: Option<&[f64]>,
+) -> Vec<BuildWarning> {
+    let mut pairs: Vec<(Channel, u32, usize)> = Vec::new();
+    for term in 0..design.n_factors() {
+        for slope in design.channels(term) {
+            let Loading::Covariate(column) = design.loading(slope) else {
+                continue;
+            };
+            pairs.extend(
+                (0..design.n_factors())
+                    .filter(|&t| t != term)
+                    .map(|t| (slope, column, t)),
+            );
+        }
+    }
+    pairs
+        .par_iter()
+        .filter_map(|&(slope, covariate, term)| {
+            let relative_residual = relative_residual(design, weights, covariate, term);
+            (relative_residual <= COLLINEARITY_TOL).then_some(
+                BuildWarning::CollinearSlopeCovariate {
+                    slope,
+                    term,
+                    relative_residual,
+                },
+            )
+        })
+        .collect()
+}
+
+/// Share of the covariate's (weighted) sum of squares outside `term`'s column span.
+fn relative_residual(
+    design: &Design<'_>,
+    weights: Option<&[f64]>,
+    covariate: u32,
+    term: usize,
+) -> f64 {
+    let target = design.frame.loading_column(covariate as usize);
+    let levels = design.frame.level_column(term);
+    let columns = &design.terms[term].columns;
+    let p = columns.len();
+    let stride = p * p + p;
+
+    let covariate_slots: Vec<(usize, &[f64])> = columns
+        .iter()
+        .enumerate()
+        .filter_map(|(slot, c)| {
+            c.covariate()
+                .map(|&k| (slot, design.frame.loading_column(k as usize)))
+        })
+        .collect();
+
+    let mut per_level = vec![0.0f64; design.terms[term].n_levels * stride];
+    let mut ss_total = 0.0;
+    let mut x = vec![1.0f64; p];
+    for (obs, (&value, &level)) in target.iter().zip(levels).enumerate() {
+        let w = weights.map_or(1.0, |w| w[obs]);
+        ss_total += w * value * value;
+        for &(slot, loadings) in &covariate_slots {
+            x[slot] = loadings[obs];
+        }
+        let (gram, cross) =
+            per_level[level as usize * stride..(level as usize + 1) * stride].split_at_mut(p * p);
+        for q in 0..p {
+            let wx = w * x[q];
+            cross[q] += wx * value;
+            for r in 0..p {
+                gram[q * p + r] += wx * x[r];
+            }
+        }
+    }
+    if ss_total <= 0.0 {
+        return 1.0;
+    }
+
+    let mut ss_projected = 0.0;
+    let mut active = Vec::with_capacity(p);
+    for level in per_level.chunks_exact_mut(stride) {
+        let (gram, cross) = level.split_at_mut(p * p);
+        ss_projected += projected_ss(gram, cross, &mut active);
+    }
+    ((ss_total - ss_projected) / ss_total).max(0.0)
+}
+
+/// `cᵀ G⁺ c` for one level's tiny PSD Gram, by pivoted outer-product Cholesky.
+fn projected_ss(gram: &mut [f64], cross: &mut [f64], active: &mut Vec<usize>) -> f64 {
+    let p = cross.len();
+    let floor = PIVOT_FLOOR * (0..p).map(|q| gram[q * p + q]).fold(0.0f64, f64::max);
+    active.clear();
+    active.extend(0..p);
+    let mut ss = 0.0;
+    while let Some((position, &pivot)) = active
+        .iter()
+        .enumerate()
+        .max_by(|a, b| gram[a.1 * p + a.1].total_cmp(&gram[b.1 * p + b.1]))
+    {
+        let diagonal = gram[pivot * p + pivot];
+        if diagonal <= floor {
+            break;
+        }
+        active.swap_remove(position);
+        ss += cross[pivot] * cross[pivot] / diagonal;
+        for &row in active.iter() {
+            let multiplier = gram[row * p + pivot] / diagonal;
+            cross[row] -= multiplier * cross[pivot];
+            for &col in active.iter() {
+                gram[row * p + col] -= multiplier * gram[pivot * p + col];
+            }
+        }
+    }
+    ss
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Effect;
+
+    fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usize)> {
+        detect_collinear_slopes(design, weights)
+            .into_iter()
+            .map(|w| match w {
+                BuildWarning::CollinearSlopeCovariate { slope, term, .. } => (slope, term),
+                other => panic!("unexpected warning {other:?}"),
+            })
+            .collect()
+    }
+
+    fn two_factor_levels(n: usize) -> (Vec<u32>, Vec<u32>) {
+        let a = (0..n).map(|i| (i % 40) as u32).collect();
+        let b = (0..n).map(|i| ((i / 40) % 25) as u32).collect();
+        (a, b)
+    }
+
+    fn pseudo_noise(n: usize, seed: u64) -> Vec<f64> {
+        let mut state = seed;
+        (0..n)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                (state >> 11) as f64 / (1u64 << 53) as f64 - 0.5
+            })
+            .collect()
+    }
+
+    #[test]
+    fn shared_covariate_across_two_terms_warns_both_ways() {
+        let n = 4000;
+        let (a, b) = two_factor_levels(n);
+        let z = pseudo_noise(n, 3);
+        let design = Design::new(vec![
+            Effect::new(&a, true, [&z[..]]).unwrap(),
+            Effect::new(&b, true, [&z[..]]).unwrap(),
+        ])
+        .unwrap();
+        let pairs = warn_pairs(&design, None);
+        assert!(
+            pairs.contains(&(Channel { term: 0, column: 1 }, 1)),
+            "{pairs:?}"
+        );
+        assert!(
+            pairs.contains(&(Channel { term: 1, column: 1 }, 0)),
+            "{pairs:?}"
+        );
+    }
+
+    #[test]
+    fn per_level_affine_transform_of_a_shared_covariate_warns() {
+        let n = 4000;
+        let (a, b) = two_factor_levels(n);
+        let z = pseudo_noise(n, 5);
+        let scaled: Vec<f64> = z
+            .iter()
+            .zip(&b)
+            .map(|(&v, &level)| v * (1.0 + level as f64) - 0.25 * level as f64)
+            .collect();
+        let design = Design::new(vec![
+            Effect::new(&a, true, [&z[..]]).unwrap(),
+            Effect::new(&b, true, [&scaled[..]]).unwrap(),
+        ])
+        .unwrap();
+        let pairs = warn_pairs(&design, None);
+        assert!(
+            pairs.contains(&(Channel { term: 0, column: 1 }, 1)),
+            "{pairs:?}"
+        );
+    }
+
+    #[test]
+    fn factor_measurable_covariate_warns_against_the_intercept_term() {
+        let n = 4000;
+        let (a, b) = two_factor_levels(n);
+        let of_b: Vec<f64> = b.iter().map(|&level| level as f64 + 1.0).collect();
+        let design = Design::new(vec![
+            Effect::new(&a, true, [&of_b[..]]).unwrap(),
+            Effect::new(&b, true, []).unwrap(),
+        ])
+        .unwrap();
+        let pairs = warn_pairs(&design, None);
+        assert_eq!(pairs, vec![(Channel { term: 0, column: 1 }, 1)]);
+    }
+
+    #[test]
+    fn independent_covariates_stay_silent() {
+        let n = 4000;
+        let (a, b) = two_factor_levels(n);
+        let z1 = pseudo_noise(n, 7);
+        let z2 = pseudo_noise(n, 11);
+        let design = Design::new(vec![
+            Effect::new(&a, true, [&z1[..]]).unwrap(),
+            Effect::new(&b, true, [&z2[..]]).unwrap(),
+        ])
+        .unwrap();
+        assert_eq!(warn_pairs(&design, None), Vec::new());
+    }
+
+    #[test]
+    fn zero_weight_rows_are_excluded_from_the_screen() {
+        // The covariates disagree only on rows whose weight is zero (row removal).
+        let n = 4000;
+        let (a, b) = two_factor_levels(n);
+        let z = pseudo_noise(n, 13);
+        let mut spoiled = z.clone();
+        let mut weights = vec![1.0; n];
+        for i in (0..n).step_by(7) {
+            spoiled[i] += 10.0;
+            weights[i] = 0.0;
+        }
+        let design = Design::new(vec![
+            Effect::new(&a, true, [&z[..]]).unwrap(),
+            Effect::new(&b, true, [&spoiled[..]]).unwrap(),
+        ])
+        .unwrap();
+        // The screen reads frame order, so caller weights go through the locality permutation.
+        let weights = design.permute_obs_in(&weights).into_owned();
+        assert!(!warn_pairs(&design, Some(&weights)).is_empty());
+        assert_eq!(warn_pairs(&design, None), Vec::new());
+    }
+}

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -3,6 +3,7 @@
 
 use rayon::prelude::*;
 
+use super::level_moments::{BasisScratch, TermMoments};
 use super::{Design, Loading};
 use crate::channel::Channel;
 use crate::BuildWarning;
@@ -10,122 +11,145 @@ use crate::BuildWarning;
 /// Residual share below which a covariate counts as reproduced by the other term.
 const COLLINEARITY_TOL: f64 = 1e-3;
 
-/// Pivots below this share of the largest diagonal count as a dependent column.
-const PIVOT_FLOOR: f64 = 1e-12;
-
 pub(crate) fn detect_collinear_slopes(
     design: &Design<'_>,
     weights: Option<&[f64]>,
+    moments: &TermMoments,
 ) -> Vec<BuildWarning> {
-    let mut pairs: Vec<(Channel, u32, usize)> = Vec::new();
-    for term in 0..design.n_factors() {
-        for slope in design.channels(term) {
-            let Loading::Covariate(column) = design.loading(slope) else {
-                continue;
-            };
-            pairs.extend(
-                (0..design.n_factors())
-                    .filter(|&t| t != term)
-                    .map(|t| (slope, column, t)),
-            );
-        }
-    }
-    pairs
-        .par_iter()
-        .filter_map(|&(slope, covariate, term)| {
-            let relative_residual = relative_residual(design, weights, covariate, term);
-            (relative_residual <= COLLINEARITY_TOL).then_some(
-                BuildWarning::CollinearSlopeCovariate {
-                    slope,
-                    term,
-                    relative_residual,
-                },
-            )
+    (0..design.n_factors())
+        .into_par_iter()
+        .flat_map_iter(|term| {
+            let targets: Vec<(Channel, u32)> = (0..design.n_factors())
+                .filter(|&t| t != term)
+                .flat_map(|t| design.channels(t))
+                .filter_map(|slope| match design.loading(slope) {
+                    Loading::Covariate(column) => Some((slope, column)),
+                    Loading::Constant => None,
+                })
+                .collect();
+            residual_shares(design, weights, moments, term, &targets)
+                .into_iter()
+                .zip(targets)
+                .filter(|&(share, _)| share <= COLLINEARITY_TOL)
+                .map(
+                    move |(relative_residual, (slope, _))| BuildWarning::CollinearSlopeCovariate {
+                        slope,
+                        term,
+                        relative_residual,
+                    },
+                )
         })
         .collect()
 }
 
-/// Share of the covariate's (weighted) sum of squares outside `term`'s column span.
-fn relative_residual(
+/// Each target's share of (weighted) sum of squares outside `term`'s column span.
+///
+/// One pass accumulates only the per-level cross moments `Σw·c` and `Σw·z·c`; the
+/// span's own geometry comes from the shared [`TermMoments`], so the projection is
+/// `Σ_q (W_q·d)²` against an orthonormal basis rather than a per-level solve.
+fn residual_shares(
     design: &Design<'_>,
     weights: Option<&[f64]>,
-    covariate: u32,
+    moments: &TermMoments,
     term: usize,
-) -> f64 {
-    let target = design.frame.loading_column(covariate as usize);
-    let levels = design.frame.level_column(term);
-    let columns = &design.terms[term].columns;
-    let p = columns.len();
-    let stride = p * p + p;
+    targets: &[(Channel, u32)],
+) -> Vec<f64> {
+    let moments = &moments[term];
+    let m = targets.len();
+    let v = moments.n_slopes();
+    let intercept = moments.intercept();
+    if m == 0 || (v == 0 && !intercept) {
+        return vec![1.0; m];
+    }
 
-    let covariate_slots: Vec<(usize, &[f64])> = columns
+    let columns: Vec<&[f64]> = targets
         .iter()
-        .enumerate()
-        .filter_map(|(slot, c)| {
-            c.covariate()
-                .map(|&k| (slot, design.frame.loading_column(k as usize)))
-        })
+        .map(|&(_, c)| design.frame.loading_column(c as usize))
+        .collect();
+    let zs: Vec<&[f64]> = moments
+        .covariates()
+        .iter()
+        .map(|&c| design.frame.loading_column(c as usize))
         .collect();
 
-    let mut per_level = vec![0.0f64; design.terms[term].n_levels * stride];
-    let mut ss_total = 0.0;
-    let mut x = vec![1.0f64; p];
-    for (obs, (&value, &level)) in target.iter().zip(levels).enumerate() {
+    // Per level and target: [Σw·c, Σw·z·c].
+    let stride = m * (v + 1);
+    let mut cross = vec![0.0f64; moments.n_levels() * stride];
+    let mut ss_total = vec![0.0f64; m];
+    for (obs, &level) in design.frame.level_column(term).iter().enumerate() {
         let w = weights.map_or(1.0, |w| w[obs]);
-        ss_total += w * value * value;
-        for &(slot, loadings) in &covariate_slots {
-            x[slot] = loadings[obs];
+        if w <= 0.0 {
+            continue;
         }
-        let (gram, cross) =
-            per_level[level as usize * stride..(level as usize + 1) * stride].split_at_mut(p * p);
-        for q in 0..p {
-            let wx = w * x[q];
-            cross[q] += wx * value;
-            for r in 0..p {
-                gram[q * p + r] += wx * x[r];
+        let level = &mut cross[level as usize * stride..][..stride];
+        for ((slot, column), ss) in level
+            .chunks_exact_mut(v + 1)
+            .zip(&columns)
+            .zip(&mut ss_total)
+        {
+            let wc = w * column[obs];
+            *ss += wc * column[obs];
+            slot[0] += wc;
+            for (s, z) in slot[1..].iter_mut().zip(&zs) {
+                *s += wc * z[obs];
             }
         }
     }
-    if ss_total <= 0.0 {
-        return 1.0;
-    }
 
-    let mut ss_projected = 0.0;
-    let mut active = Vec::with_capacity(p);
-    for level in per_level.chunks_exact_mut(stride) {
-        let (gram, cross) = level.split_at_mut(p * p);
-        ss_projected += projected_ss(gram, cross, &mut active);
-    }
-    ((ss_total - ss_projected) / ss_total).max(0.0)
-}
-
-/// `cᵀ G⁺ c` for one level's tiny PSD Gram, by pivoted outer-product Cholesky.
-fn projected_ss(gram: &mut [f64], cross: &mut [f64], active: &mut Vec<usize>) -> f64 {
-    let p = cross.len();
-    let floor = PIVOT_FLOOR * (0..p).map(|q| gram[q * p + q]).fold(0.0f64, f64::max);
-    active.clear();
-    active.extend(0..p);
-    let mut ss = 0.0;
-    while let Some((position, &pivot)) = active
-        .iter()
+    let ss_projected = cross
+        .par_chunks_exact(stride)
         .enumerate()
-        .max_by(|a, b| gram[a.1 * p + a.1].total_cmp(&gram[b.1 * p + b.1]))
-    {
-        let diagonal = gram[pivot * p + pivot];
-        if diagonal <= floor {
-            break;
-        }
-        active.swap_remove(position);
-        ss += cross[pivot] * cross[pivot] / diagonal;
-        for &row in active.iter() {
-            let multiplier = gram[row * p + pivot] / diagonal;
-            cross[row] -= multiplier * cross[pivot];
-            for &col in active.iter() {
-                gram[row * p + col] -= multiplier * gram[pivot * p + col];
+        .fold(
+            || (vec![0.0f64; m], BasisScratch::new(v), vec![0.0f64; v]),
+            |(mut ss_projected, mut scratch, mut d), (level, cross)| {
+                let w_sum = moments.w_sum(level);
+                if w_sum > 0.0 {
+                    if v > 0 {
+                        moments.basis(level, &mut scratch);
+                    }
+                    let mean = moments.mean(level);
+                    for (slot, ss) in cross.chunks_exact(v + 1).zip(&mut ss_projected) {
+                        if intercept {
+                            *ss += slot[0] * slot[0] / w_sum;
+                            for ((dj, &xj), &mj) in d.iter_mut().zip(&slot[1..]).zip(mean) {
+                                *dj = xj - slot[0] * mj;
+                            }
+                        } else {
+                            d.copy_from_slice(&slot[1..]);
+                        }
+                        if v > 0 {
+                            for row in scratch.basis.chunks_exact(v) {
+                                let projection = crate::linalg::dot(row, &d);
+                                *ss += projection * projection;
+                            }
+                        }
+                    }
+                }
+                (ss_projected, scratch, d)
+            },
+        )
+        .map(|(ss_projected, ..)| ss_projected)
+        .reduce(
+            || vec![0.0f64; m],
+            |mut a, b| {
+                for (aj, bj) in a.iter_mut().zip(b) {
+                    *aj += bj;
+                }
+                a
+            },
+        );
+
+    ss_projected
+        .into_iter()
+        .zip(ss_total)
+        .map(|(projected, total)| {
+            if total <= 0.0 {
+                1.0
+            } else {
+                ((total - projected) / total).max(0.0)
             }
-        }
-    }
-    ss
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -134,7 +158,8 @@ mod tests {
     use crate::Effect;
 
     fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usize)> {
-        detect_collinear_slopes(design, weights)
+        let moments = TermMoments::build(design, weights).expect("design carries slopes");
+        detect_collinear_slopes(design, weights, &moments)
             .into_iter()
             .map(|w| match w {
                 BuildWarning::CollinearSlopeCovariate { slope, term, .. } => (slope, term),
@@ -180,6 +205,24 @@ mod tests {
             pairs.contains(&(Channel { term: 1, column: 1 }, 0)),
             "{pairs:?}"
         );
+    }
+
+    /// The disease is scale-invariant, so the screen must be too: the raw Gram's
+    /// intercept diagonal dwarfs a small covariate's.
+    #[test]
+    fn a_rescaled_shared_covariate_still_warns_both_ways() {
+        let n = 4000;
+        let (a, b) = two_factor_levels(n);
+        let z = pseudo_noise(n, 3);
+        for scale in [1.0, 1e-6, 1e-9] {
+            let scaled: Vec<f64> = z.iter().map(|v| v * scale).collect();
+            let design = Design::new(vec![
+                Effect::new(&a, true, [&scaled[..]]).unwrap(),
+                Effect::new(&b, true, [&scaled[..]]).unwrap(),
+            ])
+            .unwrap();
+            assert_eq!(warn_pairs(&design, None).len(), 2, "scale {scale:e}");
+        }
     }
 
     #[test]

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -42,7 +42,7 @@ pub(crate) fn detect_collinear_slopes(
         .collect()
 }
 
-/// Each target's share of (weighted) sum of squares outside `term`'s column span.
+/// Each target's share of (weighted) variation outside `term`'s column span.
 ///
 /// One pass accumulates only the per-level cross moments `Σw·c` and `Σw·z·c`; the
 /// span's own geometry comes from the shared [`TermMoments`], so the projection is
@@ -139,14 +139,31 @@ fn residual_shares(
             },
         );
 
+    // An intercept puts every level's constant in the span, so the share has to be
+    // measured against the covariate's variation — against `Σw·c²` it would only
+    // report how far the covariate's mean sits from zero.
+    let (mut sum_wc, mut w_total) = (vec![0.0f64; m], 0.0);
+    for (level, chunk) in cross.chunks_exact(stride).enumerate() {
+        w_total += moments.w_sum(level);
+        for (slot, sum) in chunk.chunks_exact(v + 1).zip(&mut sum_wc) {
+            *sum += slot[0];
+        }
+    }
+
     ss_projected
         .into_iter()
         .zip(ss_total)
-        .map(|(projected, total)| {
-            if total <= 0.0 {
-                1.0
-            } else {
-                ((total - projected) / total).max(0.0)
+        .zip(sum_wc)
+        .map(|((projected, total), sum_wc)| {
+            let variation = match intercept {
+                true => total - sum_wc * sum_wc / w_total,
+                false => total,
+            };
+            // A covariate with no variation carries no slope at all; that is a
+            // within-term degeneracy the whitening's rank test already reports.
+            match variation > 0.0 {
+                true => ((total - projected) / variation).max(0.0),
+                false => 1.0,
             }
         })
         .collect()
@@ -259,6 +276,24 @@ mod tests {
         .unwrap();
         let pairs = warn_pairs(&design, None);
         assert_eq!(pairs, vec![(Channel { term: 0, column: 1 }, 1)]);
+    }
+
+    /// The span holds every level's constant, so a covariate's offset must not
+    /// enter the share: measured against `Σw·c²`, `mean=2005, sd=6` reads 7.6e-7.
+    #[test]
+    fn an_independent_covariate_stays_silent_at_any_offset() {
+        let n = 4000;
+        let (a, b) = two_factor_levels(n);
+        let z = pseudo_noise(n, 5);
+        for mean in [0.0, 1.0, 100.0, 2005.0, 1e6] {
+            let shifted: Vec<f64> = z.iter().map(|v| mean + 6.0 * v).collect();
+            let design = Design::new(vec![
+                Effect::new(&a, true, [&shifted[..]]).unwrap(),
+                Effect::new(&b, true, []).unwrap(),
+            ])
+            .unwrap();
+            assert_eq!(warn_pairs(&design, None), Vec::new(), "mean {mean:e}");
+        }
     }
 
     #[test]

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -1,0 +1,281 @@
+//! Per-level weighted moments of a term's loading columns, built once and read
+//! by both the collinearity screen and the slope whitening.
+
+use rayon::prelude::*;
+
+use super::Design;
+
+/// Relative rank tolerance: a slope direction drops once its remaining
+/// within-level variance falls to `RANK_TOL` × its own initial variance.
+pub(crate) const RANK_TOL: f64 = 1e-10;
+
+/// Every term's [`LevelMoments`], indexed by term.
+pub(crate) struct TermMoments(Vec<LevelMoments>);
+
+impl TermMoments {
+    /// `None` when no term carries a covariate, so nothing downstream has work.
+    pub(crate) fn build(design: &Design<'_>, weights: Option<&[f64]>) -> Option<Self> {
+        let has_slopes = design
+            .terms
+            .iter()
+            .any(|t| t.columns.iter().any(|c| c.covariate().is_some()));
+        has_slopes.then(|| {
+            Self(
+                (0..design.terms.len())
+                    .into_par_iter()
+                    .map(|term| LevelMoments::build(design, term, weights))
+                    .collect(),
+            )
+        })
+    }
+}
+
+impl std::ops::Index<usize> for TermMoments {
+    type Output = LevelMoments;
+
+    fn index(&self, term: usize) -> &LevelMoments {
+        &self.0[term]
+    }
+}
+
+/// One-pass weighted within-level moments (multivariate Welford); structural
+/// zeros stay exact, so rank drops survive a zero tolerance.
+pub(crate) struct LevelMoments {
+    /// Frame columns of the term's covariates, in coefficient-column order.
+    covariates: Box<[u32]>,
+    intercept: bool,
+    w_sum: Vec<f64>,
+    mean: Vec<f64>,
+    /// Per level, `Σ w (z−μ)(z−μ)ᵀ` packed as a row-major lower triangle.
+    comoment: Vec<f64>,
+}
+
+/// Index of `(j, k)`, `k ≤ j`, in a packed row-major lower triangle.
+fn tri_index(j: usize, k: usize) -> usize {
+    j * (j + 1) / 2 + k
+}
+
+fn tri_len(v: usize) -> usize {
+    v * (v + 1) / 2
+}
+
+impl LevelMoments {
+    fn build(design: &Design<'_>, term: usize, weights: Option<&[f64]>) -> Self {
+        let meta = &design.terms[term];
+        let covariates: Box<[u32]> = meta
+            .columns
+            .iter()
+            .filter_map(|c| c.covariate().copied())
+            .collect();
+        let v = covariates.len();
+        let mut moments = Self {
+            intercept: v < meta.columns.len(),
+            w_sum: vec![0.0; meta.n_levels],
+            mean: vec![0.0; meta.n_levels * v],
+            comoment: vec![0.0; meta.n_levels * tri_len(v)],
+            covariates,
+        };
+        let zs: Vec<&[f64]> = moments
+            .covariates
+            .iter()
+            .map(|&c| design.frame.loading_column(c as usize))
+            .collect();
+        let mut z_row = vec![0.0; v];
+        let mut delta = vec![0.0; v];
+        for (obs, &level) in design.frame.level_column(term).iter().enumerate() {
+            for (zr, col) in z_row.iter_mut().zip(&zs) {
+                *zr = col[obs];
+            }
+            let w = weights.map_or(1.0, |w| w[obs]);
+            moments.observe(level as usize, &z_row, w, &mut delta);
+        }
+        moments
+    }
+
+    fn observe(&mut self, level: usize, z: &[f64], w: f64, delta: &mut [f64]) {
+        if w <= 0.0 {
+            return;
+        }
+        let v = self.n_slopes();
+        self.w_sum[level] += w;
+        let ratio = w / self.w_sum[level];
+        let mean = &mut self.mean[level * v..][..v];
+        for (dj, (zj, mj)) in delta.iter_mut().zip(z.iter().zip(mean.iter_mut())) {
+            *dj = zj - *mj;
+            *mj += ratio * *dj;
+        }
+        let com = &mut self.comoment[level * tri_len(v)..][..tri_len(v)];
+        for j in 0..v {
+            let dev = w * (z[j] - mean[j]);
+            for k in 0..=j {
+                com[tri_index(j, k)] += delta[k] * dev;
+            }
+        }
+    }
+
+    pub(crate) fn n_slopes(&self) -> usize {
+        self.covariates.len()
+    }
+
+    /// Frame columns of the term's covariates, in coefficient-column order.
+    pub(crate) fn covariates(&self) -> &[u32] {
+        &self.covariates
+    }
+
+    pub(crate) fn intercept(&self) -> bool {
+        self.intercept
+    }
+
+    pub(crate) fn n_levels(&self) -> usize {
+        self.w_sum.len()
+    }
+
+    pub(crate) fn w_sum(&self, level: usize) -> f64 {
+        self.w_sum[level]
+    }
+
+    pub(crate) fn mean(&self, level: usize) -> &[f64] {
+        let v = self.n_slopes();
+        &self.mean[level * v..][..v]
+    }
+
+    /// The level's orthonormal rows `w` (`w·G·wᵀ = I`) and kept-column mask,
+    /// left in `scratch` so a sweep over levels allocates nothing. `G` is
+    /// centered against a pinned intercept, raw (`M2 + w·μμᵀ`) without one.
+    pub(crate) fn basis(&self, level: usize, scratch: &mut BasisScratch) {
+        let v = self.n_slopes();
+        let com = &self.comoment[level * tri_len(v)..][..tri_len(v)];
+        let mean = self.mean(level);
+        let w = self.w_sum[level];
+        for j in 0..v {
+            for k in 0..=j {
+                let mut g = com[tri_index(j, k)];
+                if !self.intercept {
+                    g += w * mean[j] * mean[k];
+                }
+                scratch.gram[j * v + k] = g;
+                scratch.gram[k * v + j] = g;
+            }
+        }
+        scratch.orthonormalize(v, RANK_TOL);
+    }
+}
+
+/// Reusable buffers for a sweep of [`LevelMoments::basis`] over many levels.
+pub(crate) struct BasisScratch {
+    gram: Vec<f64>,
+    residual: Vec<f64>,
+    q: Vec<f64>,
+    /// The last level's `rank × v` orthonormal rows.
+    pub(crate) basis: Vec<f64>,
+    /// The last level's kept-column mask.
+    pub(crate) kept: Vec<bool>,
+}
+
+impl BasisScratch {
+    pub(crate) fn new(v: usize) -> Self {
+        Self {
+            gram: vec![0.0; v * v],
+            residual: vec![0.0; v],
+            q: vec![0.0; v],
+            basis: Vec::with_capacity(v * v),
+            kept: vec![false; v],
+        }
+    }
+}
+
+impl BasisScratch {
+    /// Pivoted Gram–Schmidt on the raw slope columns, run in coordinates:
+    /// column `j` enters as `e_j` and all geometry goes through the dense
+    /// row-major `v×v` level Gram in `self.gram`, `⟨a, b⟩ = a·g·bᵀ`. Leaves the
+    /// `rank × v` orthonormal rows in `self.basis` — `w·g·wᵀ = I` — plus the
+    /// kept-column mask. A column drops once its residual variance falls to
+    /// `tol` × its initial variance; pivots keep their original column indices
+    /// — nothing is swapped.
+    fn orthonormalize(&mut self, v: usize, tol: f64) {
+        let Self {
+            gram: g,
+            residual,
+            q,
+            basis,
+            kept,
+        } = self;
+        for (r, j) in residual.iter_mut().zip(0..v) {
+            *r = g[j * v + j];
+        }
+        kept.fill(false);
+        basis.clear();
+        while let Some(p) = (0..v)
+            .filter(|&j| !kept[j] && residual[j].is_finite() && residual[j] > tol * g[j * v + j])
+            .max_by(|&a, &b| residual[a].total_cmp(&residual[b]))
+        {
+            kept[p] = true;
+
+            // q = e_p − Σₜ ⟨e_p, qₜ⟩·qₜ, whose norm is already √residual[p].
+            q.fill(0.0);
+            q[p] = 1.0;
+            for q_t in basis.chunks_exact(v) {
+                let c = crate::linalg::dot(&g[p * v..][..v], q_t);
+                for (qj, &qtj) in q.iter_mut().zip(q_t) {
+                    *qj -= c * qtj;
+                }
+            }
+            let norm = residual[p].sqrt();
+            for qj in q.iter_mut() {
+                *qj /= norm;
+            }
+
+            // Pythagoras: projecting out q costs every column ⟨e_j, q⟩² of variance.
+            for (r, g_row) in residual.iter_mut().zip(g.chunks_exact(v)) {
+                let c = crate::linalg::dot(g_row, q);
+                *r -= c * c;
+            }
+            basis.extend_from_slice(q);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pivoted_gram_schmidt(g: &[f64], v: usize, tol: f64) -> (Vec<f64>, Vec<bool>) {
+        let mut scratch = BasisScratch::new(v);
+        scratch.gram.copy_from_slice(g);
+        scratch.orthonormalize(v, tol);
+        (scratch.basis, scratch.kept)
+    }
+
+    #[test]
+    fn gram_schmidt_orthonormalizes_under_a_non_monotonic_pivot_order() {
+        // Diagonals [2, 5, 3] force the pivot sequence 1 → 2 → 0, breaking order assumptions.
+        let g = [2.0, 1.0, 0.5, 1.0, 5.0, 2.0, 0.5, 2.0, 3.0];
+        let (w, kept) = pivoted_gram_schmidt(&g, 3, RANK_TOL);
+        assert_eq!(kept, [true; 3]);
+        assert_eq!(w.len(), 9);
+
+        for r in 0..3 {
+            for s in 0..3 {
+                let wgw: f64 = (0..3)
+                    .flat_map(|j| (0..3).map(move |k| (j, k)))
+                    .map(|(j, k)| w[r * 3 + j] * g[j * 3 + k] * w[s * 3 + k])
+                    .sum();
+                let expected = if r == s { 1.0 } else { 0.0 };
+                assert!(
+                    (wgw - expected).abs() < 1e-12,
+                    "(W·G·Wᵀ)[{r}][{s}] = {wgw}, expected {expected}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn zero_tolerance_keeps_a_near_degenerate_direction_the_default_drops() {
+        let eps = 1e-12;
+        let g = [1.0, 1.0 - eps, 1.0 - eps, 1.0];
+        let (_, kept) = pivoted_gram_schmidt(&g, 2, RANK_TOL);
+        assert_eq!(kept.iter().filter(|&&k| k).count(), 1);
+        let (_, kept) = pivoted_gram_schmidt(&g, 2, 0.0);
+        assert_eq!(kept, [true, true]);
+    }
+}

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -127,7 +127,7 @@ pub enum BuildWarning {
         slope: Channel,
         /// The term whose columns (nearly) reproduce the covariate.
         term: usize,
-        /// Share of the covariate's sum of squares outside that term's span.
+        /// Share of the covariate's weighted variation outside that term's span.
         relative_residual: f64,
     },
 }

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -2,7 +2,7 @@
 
 use thiserror::Error;
 
-use crate::channel::ChannelPair;
+use crate::channel::{Channel, ChannelPair};
 
 pub use schwarz_precond::SolveError;
 
@@ -107,7 +107,7 @@ pub enum BuildError {
     },
 }
 
-/// A non-fatal preconditioner-build event.
+/// A non-fatal solver-build event.
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum BuildWarning {
@@ -119,6 +119,16 @@ pub enum BuildWarning {
         iterations: usize,
         /// Largest relative dominance violation at hand-over.
         violation: f64,
+    },
+    /// A slope covariate is (nearly) a per-level combination of another term's
+    /// columns, so the design has a (near-)null direction spanning both terms.
+    CollinearSlopeCovariate {
+        /// The slope channel carrying the covariate.
+        slope: Channel,
+        /// The term whose columns (nearly) reproduce the covariate.
+        term: usize,
+        /// Share of the covariate's sum of squares outside that term's span.
+        relative_residual: f64,
     },
 }
 
@@ -134,6 +144,16 @@ impl std::fmt::Display for BuildWarning {
                 "signed component between {pair}: dominance scaling uncertified after \
                  {iterations} iterations (max relative violation {violation:.2e}); deficits \
                  clamped, preconditioner quality may degrade"
+            ),
+            Self::CollinearSlopeCovariate {
+                slope,
+                term,
+                relative_residual,
+            } => write!(
+                f,
+                "slope covariate of {slope} is nearly collinear with the columns of term \
+                 {term} (relative residual {relative_residual:.2e}); the near-null direction \
+                 spanning both terms can inflate iteration counts by orders of magnitude"
             ),
         }
     }

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -12,6 +12,7 @@ use schwarz_precond::{lsmr as lsmr_solve, mlsmr, MlsmrOptions};
 use crate::channel::Channel;
 use crate::config::{LsmrOptions, PreconditionerConfig};
 use crate::domain::collinearity::detect_collinear_slopes;
+use crate::domain::level_moments::TermMoments;
 use crate::domain::{Design, Effect};
 use crate::observation::ObservationFrame;
 use crate::operator::design::gather_apply;
@@ -371,11 +372,17 @@ impl<'a> Solver<'a> {
             None => weights,
         };
 
-        // The screen reads raw loadings, so it runs before whitening rewrites them.
-        let mut warnings = detect_collinear_slopes(&design, weights.as_deref());
+        // Both readers below need the raw loadings, so the moments precede whitening.
+        let moments = TermMoments::build(&design, weights.as_deref());
+        let mut warnings = moments
+            .as_ref()
+            .map(|m| detect_collinear_slopes(&design, weights.as_deref(), m))
+            .unwrap_or_default();
 
         // Reparametrize the slope columns (if any) before the preconditioner reads the frame.
-        let reparam = SlopeReparam::build(&mut design, weights.as_deref());
+        let reparam = moments
+            .as_ref()
+            .and_then(|m| SlopeReparam::build(&mut design, m));
 
         let (preconditioner, build_warnings) = match preconditioner.into() {
             PreconditionerInput::Default => {

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -11,6 +11,7 @@ use schwarz_precond::{lsmr as lsmr_solve, mlsmr, MlsmrOptions};
 
 use crate::channel::Channel;
 use crate::config::{LsmrOptions, PreconditionerConfig};
+use crate::domain::collinearity::detect_collinear_slopes;
 use crate::domain::{Design, Effect};
 use crate::observation::ObservationFrame;
 use crate::operator::design::gather_apply;
@@ -212,8 +213,7 @@ pub struct SolveResult {
     pub x: Vec<f64>,
     /// Per-level directions the data cannot identify.
     pub unidentified: Vec<CoefficientAddress>,
-    /// Non-fatal preconditioner-build warnings (see [`Solver::warnings`]);
-    /// empty when a pre-built preconditioner was reused.
+    /// Non-fatal build warnings (see [`Solver::warnings`]).
     pub warnings: Vec<BuildWarning>,
     /// Address ↔ flat-`x`-index translation for this design's coefficients.
     pub layout: CoefficientLayout,
@@ -253,8 +253,7 @@ pub struct BatchSolveResult {
     /// Per-level directions the data cannot identify, shared across all RHS:
     /// identification depends only on the design and weights, never on `y`.
     pub unidentified: Vec<CoefficientAddress>,
-    /// Non-fatal preconditioner-build warnings, shared across all RHS; see
-    /// [`SolveResult::warnings`].
+    /// Non-fatal build warnings, shared across all RHS; see [`SolveResult::warnings`].
     pub warnings: Vec<BuildWarning>,
     /// Address ↔ flat-`x`-index translation for this design's coefficients.
     pub layout: CoefficientLayout,
@@ -372,10 +371,13 @@ impl<'a> Solver<'a> {
             None => weights,
         };
 
+        // The screen reads raw loadings, so it runs before whitening rewrites them.
+        let mut warnings = detect_collinear_slopes(&design, weights.as_deref());
+
         // Reparametrize the slope columns (if any) before the preconditioner reads the frame.
         let reparam = SlopeReparam::build(&mut design, weights.as_deref());
 
-        let (preconditioner, warnings) = match preconditioner.into() {
+        let (preconditioner, build_warnings) = match preconditioner.into() {
             PreconditionerInput::Default => {
                 build_preconditioner(&design, weights.as_deref(), None)?
             }
@@ -394,6 +396,8 @@ impl<'a> Solver<'a> {
             }
         };
 
+        warnings.extend(build_warnings);
+
         let sqrt_weights = weights.map(|mut w| {
             for wi in &mut w {
                 *wi = wi.sqrt();
@@ -410,8 +414,8 @@ impl<'a> Solver<'a> {
         })
     }
 
-    /// Non-fatal events from the preconditioner build; empty when reusing a
-    /// pre-built preconditioner (its warnings were reported when it was built).
+    /// Non-fatal events from design screening and the preconditioner build; a reused
+    /// pre-built preconditioner contributes none (its own were reported when built).
     pub fn warnings(&self) -> &[BuildWarning] {
         &self.warnings
     }

--- a/crates/within/src/solver/reparam.rs
+++ b/crates/within/src/solver/reparam.rs
@@ -1,5 +1,6 @@
 //! Within-level reparametrization of a design's varying-slope terms.
 
+use crate::domain::level_moments::{BasisScratch, TermMoments};
 use crate::domain::Design;
 
 use super::CoefficientAddress;
@@ -8,10 +9,6 @@ use crate::linalg::dot;
 
 #[cfg(test)]
 mod tests;
-
-/// Relative rank tolerance: a slope direction drops once its remaining
-/// within-level variance falls to `RANK_TOL` × its own initial variance.
-const RANK_TOL: f64 = 1e-10;
 
 /// Per-level change of basis making each slope-bearing term's within-level
 /// Gram the identity; [`Self::back_transform`] restores the user's
@@ -46,7 +43,7 @@ impl SlopeReparam {
     /// `None` for slope-free designs. Unidentified directions become
     /// exact-zero columns, so the minimal-norm solve leaves exact-`0`
     /// coefficients.
-    pub(crate) fn build(design: &mut Design<'_>, weights: Option<&[f64]>) -> Option<Self> {
+    pub(crate) fn build(design: &mut Design<'_>, moments: &TermMoments) -> Option<Self> {
         let mut terms = Vec::new();
         let mut unidentified = Vec::new();
         for term in 0..design.terms.len() {
@@ -57,7 +54,7 @@ impl SlopeReparam {
             {
                 continue;
             }
-            terms.push(TermReparam::build(design, term, weights, &mut unidentified));
+            terms.push(TermReparam::build(design, term, moments, &mut unidentified));
         }
         (!terms.is_empty()).then_some(Self {
             terms,
@@ -79,46 +76,36 @@ impl TermReparam {
     fn build(
         design: &mut Design<'_>,
         term: usize,
-        weights: Option<&[f64]>,
+        moments: &TermMoments,
         unidentified: &mut Vec<CoefficientAddress>,
     ) -> Self {
         let meta = &design.terms[term];
         let (offset, n_levels) = (meta.offset, meta.n_levels);
         let mut intercept_column = None;
         let mut slope_columns = Vec::new();
-        let mut z_cols = Vec::new();
         for (column, loading) in meta.columns.iter().enumerate() {
             match loading.covariate() {
-                Some(&k) => {
-                    slope_columns.push(column);
-                    z_cols.push(k as usize);
-                }
+                Some(_) => slope_columns.push(column),
                 None => intercept_column = Some(column),
             }
         }
         let intercept = intercept_column.is_some();
-        let v = z_cols.len();
+        let moments = &moments[term];
+        let v = moments.n_slopes();
+        let z_cols: Vec<usize> = moments.covariates().iter().map(|&c| c as usize).collect();
         let levels = design.frame.level_column(term);
         let zs: Vec<&[f64]> = z_cols
             .iter()
             .map(|&c| design.frame.loading_column(c))
             .collect();
 
-        let mut moments = LevelMoments::new(n_levels, v);
         let mut z_row = vec![0.0; v];
-        for (i, &level) in levels.iter().enumerate() {
-            for (zr, col) in z_row.iter_mut().zip(&zs) {
-                *zr = col[i];
-            }
-            moments.observe(level as usize, &z_row, weights.map_or(1.0, |ws| ws[i]));
-        }
-
         let mut transforms = Vec::with_capacity(n_levels);
-        let mut gram = vec![0.0; v * v];
+        let mut scratch = BasisScratch::new(v);
         for level in 0..n_levels {
-            moments.gram(level, intercept, &mut gram);
-            let (w, kept) = pivoted_gram_schmidt(&gram, v, RANK_TOL);
-            if intercept && moments.w_sum[level] == 0.0 {
+            moments.basis(level, &mut scratch);
+            let (w, kept) = (&scratch.basis, &scratch.kept);
+            if intercept && moments.w_sum(level) == 0.0 {
                 unidentified.push(CoefficientAddress {
                     channel: Channel { term, column: 0 },
                     level,
@@ -141,7 +128,7 @@ impl TermReparam {
                 vec![0.0; v].into()
             };
             transforms.push(LevelTransform {
-                w: w.into(),
+                w: w.clone().into(),
                 center,
             });
         }
@@ -197,121 +184,4 @@ impl TermReparam {
     fn slope_slot(&self, j: usize, level: usize) -> usize {
         self.offset + self.slope_columns[j] * self.n_levels + level
     }
-}
-
-/// One-pass weighted within-level moments (multivariate Welford); structural
-/// zeros stay exact, so rank drops survive a zero tolerance.
-struct LevelMoments {
-    n_slopes: usize,
-    w_sum: Vec<f64>,
-    mean: Vec<f64>,
-    /// Per level, `Σ w (z−μ)(z−μ)ᵀ` packed as a row-major lower triangle.
-    comoment: Vec<f64>,
-    /// Scratch: deviations from the pre-update means.
-    delta: Vec<f64>,
-}
-
-/// Index of `(j, k)`, `k ≤ j`, in a packed row-major lower triangle.
-fn tri_index(j: usize, k: usize) -> usize {
-    j * (j + 1) / 2 + k
-}
-
-fn tri_len(v: usize) -> usize {
-    v * (v + 1) / 2
-}
-
-impl LevelMoments {
-    fn new(n_levels: usize, n_slopes: usize) -> Self {
-        Self {
-            n_slopes,
-            w_sum: vec![0.0; n_levels],
-            mean: vec![0.0; n_levels * n_slopes],
-            comoment: vec![0.0; n_levels * tri_len(n_slopes)],
-            delta: vec![0.0; n_slopes],
-        }
-    }
-
-    fn observe(&mut self, level: usize, z: &[f64], w: f64) {
-        if w <= 0.0 {
-            return;
-        }
-        let v = self.n_slopes;
-        self.w_sum[level] += w;
-        let ratio = w / self.w_sum[level];
-        let mean = &mut self.mean[level * v..][..v];
-        for (dj, (zj, mj)) in self.delta.iter_mut().zip(z.iter().zip(mean.iter_mut())) {
-            *dj = zj - *mj;
-            *mj += ratio * *dj;
-        }
-        let com = &mut self.comoment[level * tri_len(v)..][..tri_len(v)];
-        for j in 0..v {
-            let dev = w * (z[j] - mean[j]);
-            for k in 0..=j {
-                com[tri_index(j, k)] += self.delta[k] * dev;
-            }
-        }
-    }
-
-    fn mean(&self, level: usize) -> &[f64] {
-        &self.mean[level * self.n_slopes..][..self.n_slopes]
-    }
-
-    /// The level's V×V slope Gram: centered against a pinned intercept, raw
-    /// (`M2 + w·μμᵀ`) for a slope-only term.
-    fn gram(&self, level: usize, intercept: bool, out: &mut [f64]) {
-        let v = self.n_slopes;
-        let com = &self.comoment[level * tri_len(v)..][..tri_len(v)];
-        let mean = self.mean(level);
-        let w = self.w_sum[level];
-        for j in 0..v {
-            for k in 0..=j {
-                let mut g = com[tri_index(j, k)];
-                if !intercept {
-                    g += w * mean[j] * mean[k];
-                }
-                out[j * v + k] = g;
-                out[k * v + j] = g;
-            }
-        }
-    }
-}
-
-/// Pivoted Gram–Schmidt on the raw slope columns, run in coordinates:
-/// column `j` enters as `e_j` and all geometry goes through the dense
-/// row-major `v×v` level Gram, `⟨a, b⟩ = a·g·bᵀ`. Returns the `rank × v`
-/// orthonormal rows `w` — `w·g·wᵀ = I` — plus the kept-column mask. A column
-/// drops once its residual variance falls to `tol` × its initial variance;
-/// pivots keep their original column indices — nothing is swapped.
-fn pivoted_gram_schmidt(g: &[f64], v: usize, tol: f64) -> (Vec<f64>, Vec<bool>) {
-    let mut residual: Vec<f64> = (0..v).map(|j| g[j * v + j]).collect();
-    let mut kept = vec![false; v];
-    let mut basis = Vec::new();
-    while let Some(p) = (0..v)
-        .filter(|&j| !kept[j] && residual[j].is_finite() && residual[j] > tol * g[j * v + j])
-        .max_by(|&a, &b| residual[a].total_cmp(&residual[b]))
-    {
-        kept[p] = true;
-
-        // q = e_p − Σₜ ⟨e_p, qₜ⟩·qₜ, whose norm is already √residual[p].
-        let mut q = vec![0.0; v];
-        q[p] = 1.0;
-        for q_t in basis.chunks_exact(v) {
-            let c = dot(&g[p * v..][..v], q_t);
-            for (qj, &qtj) in q.iter_mut().zip(q_t) {
-                *qj -= c * qtj;
-            }
-        }
-        let norm = residual[p].sqrt();
-        for qj in &mut q {
-            *qj /= norm;
-        }
-
-        // Pythagoras: projecting out q costs every column ⟨e_j, q⟩² of variance.
-        for (r, g_row) in residual.iter_mut().zip(g.chunks_exact(v)) {
-            let c = dot(g_row, &q);
-            *r -= c * c;
-        }
-        basis.extend_from_slice(&q);
-    }
-    (basis, kept)
 }

--- a/crates/within/src/solver/reparam/tests.rs
+++ b/crates/within/src/solver/reparam/tests.rs
@@ -1,44 +1,11 @@
-//! Seam tests for the per-level pivoted Gram–Schmidt (pivot bookkeeping,
-//! rank-tolerance contract — neither reachable through the public API) and
-//! for the per-term independence of the multi-term whitening.
+//! Seam tests for the per-term independence of the multi-term whitening,
+//! not reachable through the public API.
 
 use crate::channel::Channel;
+use crate::domain::level_moments::TermMoments;
 use crate::domain::Effect;
 
 use super::*;
-
-#[test]
-fn gram_schmidt_orthonormalizes_under_a_non_monotonic_pivot_order() {
-    // Diagonals [2, 5, 3] force the pivot sequence 1 → 2 → 0, breaking order assumptions.
-    let g = [2.0, 1.0, 0.5, 1.0, 5.0, 2.0, 0.5, 2.0, 3.0];
-    let (w, kept) = pivoted_gram_schmidt(&g, 3, RANK_TOL);
-    assert_eq!(kept, [true; 3]);
-    assert_eq!(w.len(), 9);
-
-    for r in 0..3 {
-        for s in 0..3 {
-            let wgw: f64 = (0..3)
-                .flat_map(|j| (0..3).map(move |k| (j, k)))
-                .map(|(j, k)| w[r * 3 + j] * g[j * 3 + k] * w[s * 3 + k])
-                .sum();
-            let expected = if r == s { 1.0 } else { 0.0 };
-            assert!(
-                (wgw - expected).abs() < 1e-12,
-                "(W·G·Wᵀ)[{r}][{s}] = {wgw}, expected {expected}"
-            );
-        }
-    }
-}
-
-#[test]
-fn zero_tolerance_keeps_a_near_degenerate_direction_the_default_drops() {
-    let eps = 1e-12;
-    let g = [1.0, 1.0 - eps, 1.0 - eps, 1.0];
-    let (_, kept) = pivoted_gram_schmidt(&g, 2, RANK_TOL);
-    assert_eq!(kept.iter().filter(|&&k| k).count(), 1);
-    let (_, kept) = pivoted_gram_schmidt(&g, 2, 0.0);
-    assert_eq!(kept, [true, true]);
-}
 
 const F0: [u32; 6] = [0, 0, 0, 1, 1, 1];
 const Z0: [f64; 6] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
@@ -60,7 +27,8 @@ fn three_term_effects() -> Vec<Effect<'static>> {
 #[test]
 fn build_whitens_each_slope_bearing_term() {
     let mut design = Design::new(three_term_effects()).unwrap();
-    let rp = SlopeReparam::build(&mut design, None).unwrap();
+    let moments = TermMoments::build(&design, None).unwrap();
+    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
     assert!(rp.unidentified.is_empty());
 
     for term in [0, 2] {
@@ -104,7 +72,8 @@ fn unidentified_directions_ascend_across_terms() {
         Effect::new(&f1, true, [&z1[..]]).unwrap(),
     ];
     let mut design = Design::new(effects).unwrap();
-    let rp = SlopeReparam::build(&mut design, None).unwrap();
+    let moments = TermMoments::build(&design, None).unwrap();
+    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
     assert_eq!(
         rp.unidentified,
         vec![
@@ -123,7 +92,8 @@ fn unidentified_directions_ascend_across_terms() {
 #[test]
 fn back_transform_leaves_other_terms_untouched() {
     let mut design = Design::new(three_term_effects()).unwrap();
-    let rp = SlopeReparam::build(&mut design, None).unwrap();
+    let moments = TermMoments::build(&design, None).unwrap();
+    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
 
     let mut x: Vec<f64> = (0..design.n_dofs).map(|i| 1.0 + i as f64).collect();
     let before = x.clone();

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -2,6 +2,7 @@ use super::reparam::SlopeReparam;
 use super::{CoefficientAddress, CoefficientLayout};
 use crate::channel::Channel;
 use crate::config::{LocalSolverConfig, DEFAULT_DENSE_SCHUR_THRESHOLD};
+use crate::domain::level_moments::TermMoments;
 use crate::domain::{build_local_domains, Design, Grounding, MatrixForm};
 use crate::Effect;
 
@@ -34,7 +35,8 @@ fn positive_slope_only_pair_grounds_beyond_dense_threshold() {
         Effect::new(&g, true, []).expect("plain effect"),
     ];
     let mut design = Design::new(effects).expect("design");
-    let _reparam = SlopeReparam::build(&mut design, None);
+    let moments = TermMoments::build(&design, None).expect("slopes");
+    let _reparam = SlopeReparam::build(&mut design, &moments);
     let (domains, warnings) =
         build_local_domains(&design, None, &LocalSolverConfig::default()).expect("domains");
     assert!(


### PR DESCRIPTION
Solver construction screens each raw slope covariate against every other term's per-level column span and emits `BuildWarning::CollinearSlopeCovariate` when the relative residual falls below 1e-3 — catching the exactly-shared case, affine and per-level-affine transforms, and factor-measurable covariates, while independent covariates sit near 0.9. The screen runs before whitening rewrites the loadings and reaches Python as a `UserWarning`.

No pair-local fix exists for this null direction (whitening spreads it across four channels), so detection is the sound scope here; the detector's projection coefficients are the input for the planned deflation-based coarse space.

The second commit makes the screen scale-invariant by sharing a rank test with the whitening instead of rolling its own. `TermMoments` is built once per term in `Solver::new` and read by both the screen and `SlopeReparam`, so the observation pass accumulates only the cross moments and projects against the whitening's orthonormal basis. `projected_ss` and its pivot floor at `1e-12 ×` the largest per-level diagonal are gone — that floor let the intercept diagonal hide a covariate scaled below ~1e-6, taking an exactly-shared covariate from 2 warnings to 0 under a pure change of units. Screen wall time is 1.3–3.1× lower; the projections agree with the previous formulation to 4.6e-16 absolute over 40 random designs, and `akm_slopes` iteration counts are bitwise identical single-threaded.

Closes #281
