### PR TITLE
Mirror enum preconditioner config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **BREAKING:** The serialized `Preconditioner` wire format changed (v13 → v14) to retain its complete construction config and configured reduction strategy; older additive payloads no longer decode.
 - Rust `Preconditioner` objects expose their normalized construction configuration through `Preconditioner::config()`.
 - Serialized `schwarz_precond::SchwarzPreconditioner` values now preserve the configured reduction strategy.
 - **BREAKING:** `schwarz_precond::mlsmr` takes an `MlsmrOptions` in place of its trailing `local_size`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **BREAKING:** Python `PreconditionerConfig` is now a tagged union: construct variants as `PreconditionerConfig.Off()`, `.Diagonal()`, or `.Additive(local_solver=..., reduction=...)` (previously class-attribute singletons plus an `.additive()` factory). Instances compare by value, support `match`/`case` on Python ≥3.10, and pickle.
 - **BREAKING:** The serialized `Preconditioner` wire format changed (v13 → v14) to retain its complete construction config and configured reduction strategy; older additive payloads no longer decode.
 - Rust `Preconditioner` objects expose their normalized construction configuration through `Preconditioner::config()`.
 - Serialized `schwarz_precond::SchwarzPreconditioner` values now preserve the configured reduction strategy.

--- a/README.md
+++ b/README.md
@@ -137,16 +137,15 @@ The `preconditioner` argument accepts any of:
 | Form | Meaning |
 |---|---|
 | `None` (default) | Library default — Additive Schwarz with sensible defaults. |
-| `PreconditionerConfig.Off` | Explicit identity — solve unpreconditioned. |
-| `PreconditionerConfig.Additive` | Additive Schwarz shortcut, equivalent to `None`. |
-| `PreconditionerConfig.Diagonal` | Diagonal/Jacobi preconditioner using `diag(D^T W D)^{-1}`. |
-| `PreconditionerConfig.additive(local_solver?, reduction?)` | Tuned additive Schwarz configuration. Advanced argument types are available from `within.config`. |
-| `AdditiveSchwarz(local_solver?, reduction?)` | Existing tuned Schwarz configuration API — import from `within.config`. |
+| `PreconditionerConfig.Off()` | Explicit identity — solve unpreconditioned. |
+| `PreconditionerConfig.Additive()` | Additive Schwarz shortcut, equivalent to `None`. |
+| `PreconditionerConfig.Diagonal()` | Diagonal/Jacobi preconditioner using `diag(D^T W D)^{-1}`. |
+| `PreconditionerConfig.Additive(local_solver?, reduction?)` | Tuned additive Schwarz. Argument types import from `within.config`. |
 | `Preconditioner` instance | Reuse a previously-built preconditioner across solvers. |
 
-`PreconditionerConfig` instances compare by value. A built preconditioner exposes
-the configuration used to construct it as `.config`, including after pickling,
-so cached preconditioners can be checked with `precond.config == requested_config`.
+`PreconditionerConfig` is a tagged union: each variant is a subclass, so instances
+support `match`/`case`, compare by value, and pickle. A built preconditioner exposes
+the configuration used to construct it as `.config` (preserved across pickling).
 
 ### Local solver configuration (advanced — `within.config`)
 

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -66,7 +66,7 @@ pub fn solve<'py>(
     preconditioner: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<PySolveResult> {
     let params = resolve_lsmr_config(options)?;
-    let precond = resolve_precond_input(py, preconditioner)?;
+    let precond = resolve_precond_input(preconditioner)?;
     let y = readonly_f64_1d("y", y)?;
     let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
 
@@ -107,7 +107,7 @@ pub fn solve_batch<'py>(
     preconditioner: Option<&Bound<'py, PyAny>>,
 ) -> PyResult<PyBatchSolveResult> {
     let params = resolve_lsmr_config(options)?;
-    let precond = resolve_precond_input(py, preconditioner)?;
+    let precond = resolve_precond_input(preconditioner)?;
     let y = readonly_f64_2d("Y", Y)?;
     let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
 
@@ -254,7 +254,7 @@ impl PySolver {
     ) -> PyResult<Self> {
         let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
         let weights_vec: Option<Vec<f64>> = weights.as_ref().map(|w| w.as_array().to_vec());
-        let precond = resolve_precond_input(py, preconditioner)?;
+        let precond = resolve_precond_input(preconditioner)?;
 
         // `BuildError` carries no Python types, so it maps to an exception once the GIL is back.
         let solver = match extract_design(py, design)? {

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -184,7 +184,7 @@ impl PyScalingConfig {
     pub(crate) fn from_native(config: &ScalingConfig) -> Self {
         Self {
             tolerance: config.tolerance,
-            max_sweeps: config.max_sweeps,
+            max_iterations: config.max_iterations,
             on_failure: config.on_failure,
         }
     }

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -177,64 +177,126 @@ impl PyScalingConfig {
     }
 }
 
-/// Complete construction configuration for a given preconditioner variant.
-#[pyclass(frozen, eq, module = "within._within")]
+/// Construction configuration for a preconditioner, mirroring the native enum.
+///
+/// Complex enum: each variant is a Python-visible subclass supporting ``match``
+/// and per-field getters. Unit variants are spelled ``Off()`` / ``Diagonal()``.
+#[pyclass(frozen, module = "within._within")]
 #[pyo3(name = "PreconditionerConfig")]
-#[derive(PartialEq)]
-pub struct PyPreconditionerConfig {
-    inner: PreconditionerConfig,
+pub enum PyPreconditionerConfig {
+    Off(),
+    #[pyo3(constructor = (local_solver=None, reduction=PyReductionStrategy::Auto))]
+    Additive {
+        local_solver: Option<Py<PyLocalSolverConfig>>,
+        reduction: PyReductionStrategy,
+    },
+    Diagonal(),
 }
 
 impl PyPreconditionerConfig {
-    pub(crate) fn to_native(&self) -> PreconditionerConfig {
-        self.inner.clone()
+    pub(crate) fn to_native(&self, py: Python<'_>) -> PreconditionerConfig {
+        match self {
+            Self::Off() => PreconditionerConfig::Off,
+            Self::Diagonal() => PreconditionerConfig::Diagonal,
+            Self::Additive {
+                local_solver,
+                reduction,
+            } => PreconditionerConfig::Additive {
+                local_solver: local_solver
+                    .as_ref()
+                    .map(|c| c.bind(py).get().to_native(py))
+                    .unwrap_or_default(),
+                reduction: reduction.to_native(),
+            },
+        }
+    }
+
+    pub(crate) fn from_native(py: Python<'_>, config: &PreconditionerConfig) -> PyResult<Self> {
+        Ok(match config {
+            PreconditionerConfig::Off => Self::Off(),
+            PreconditionerConfig::Diagonal => Self::Diagonal(),
+            PreconditionerConfig::Additive {
+                local_solver,
+                reduction,
+            } => {
+                let local = PyLocalSolverConfig {
+                    approx_chol: Some(Py::new(
+                        py,
+                        PyApproxCholConfig {
+                            seed: local_solver.approx_chol.seed,
+                            split_merge: local_solver.approx_chol.split_merge,
+                        },
+                    )?),
+                    schur: Some(Py::new(
+                        py,
+                        PySchur {
+                            inner: local_solver.schur.clone(),
+                        },
+                    )?),
+                    dense_threshold: local_solver.dense_threshold,
+                    scaling: Some(Py::new(
+                        py,
+                        PyScalingConfig {
+                            tolerance: local_solver.scaling.tolerance,
+                            max_sweeps: local_solver.scaling.max_sweeps,
+                            on_failure: local_solver.scaling.on_failure,
+                        },
+                    )?),
+                };
+                Self::Additive {
+                    local_solver: Some(Py::new(py, local)?),
+                    reduction: match reduction {
+                        ReductionStrategy::Auto => PyReductionStrategy::Auto,
+                        ReductionStrategy::AtomicScatter => PyReductionStrategy::AtomicScatter,
+                        ReductionStrategy::ParallelReduction => {
+                            PyReductionStrategy::ParallelReduction
+                        }
+                    },
+                }
+            }
+            _ => {
+                return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                    "unsupported preconditioner configuration",
+                ))
+            }
+        })
     }
 }
 
 #[pymethods]
 impl PyPreconditionerConfig {
-    #[classattr]
-    #[pyo3(name = "Additive")]
-    fn additive_default() -> Self {
-        Self {
-            inner: PreconditionerConfig::default(),
-        }
+    fn __eq__(&self, py: Python<'_>, other: &Bound<'_, PyAny>) -> bool {
+        other
+            .cast::<PyPreconditionerConfig>()
+            .map(|o| self.to_native(py) == o.get().to_native(py))
+            .unwrap_or(false)
     }
 
-    #[classattr]
-    #[pyo3(name = "Off")]
-    fn off() -> Self {
-        Self {
-            inner: PreconditionerConfig::Off,
-        }
+    /// Complex enums have no default pickle support; round-trip via native serde.
+    fn __reduce__<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<(Bound<'py, PyAny>, (Bound<'py, pyo3::types::PyBytes>,))> {
+        let bytes = postcard::to_stdvec(&self.to_native(py))
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        let ctor = py
+            .import("within._within")?
+            .getattr("_preconditioner_config_from_postcard")?;
+        Ok((ctor, (pyo3::types::PyBytes::new(py, &bytes),)))
     }
+}
 
-    #[classattr]
-    #[pyo3(name = "Diagonal")]
-    fn diagonal() -> Self {
-        Self {
-            inner: PreconditionerConfig::Diagonal,
-        }
-    }
-
-    #[staticmethod]
-    #[pyo3(signature = (local_solver=None, reduction=PyReductionStrategy::Auto))]
-    fn additive(
-        py: Python<'_>,
-        local_solver: Option<Py<PyLocalSolverConfig>>,
-        reduction: PyReductionStrategy,
-    ) -> Self {
-        let local_solver = local_solver
-            .map(|config| config.bind(py).get().to_native(py))
-            .unwrap_or_default();
-
-        Self {
-            inner: PreconditionerConfig::Additive {
-                local_solver,
-                reduction: reduction.to_native(),
-            },
-        }
-    }
+#[pyfunction]
+pub(crate) fn _preconditioner_config_from_postcard(
+    py: Python<'_>,
+    data: &[u8],
+) -> PyResult<PyPreconditionerConfig> {
+    let native: PreconditionerConfig = postcard::from_bytes(data).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!(
+            "failed to deserialize preconditioner config: {e}"
+        ))
+    })?;
+    PyPreconditionerConfig::from_native(py, &native)
 }
 
 #[pyclass(frozen, eq, eq_int, from_py_object, module = "within._within")]
@@ -311,27 +373,6 @@ impl PyLocalSolverConfig {
             schur,
             dense_threshold: self.dense_threshold,
             scaling,
-        }
-    }
-}
-
-#[pyclass(frozen, module = "within._within")]
-#[pyo3(name = "AdditiveSchwarz")]
-pub struct PyAdditiveSchwarz {
-    #[pyo3(get)]
-    pub local_solver: Option<Py<PyLocalSolverConfig>>,
-    #[pyo3(get)]
-    pub reduction: PyReductionStrategy,
-}
-
-#[pymethods]
-impl PyAdditiveSchwarz {
-    #[new]
-    #[pyo3(signature = (local_solver=None, reduction=PyReductionStrategy::Auto))]
-    fn new(local_solver: Option<Py<PyLocalSolverConfig>>, reduction: PyReductionStrategy) -> Self {
-        Self {
-            local_solver,
-            reduction,
         }
     }
 }
@@ -439,10 +480,8 @@ impl PyPreconditioner {
 
     /// Complete normalized configuration used to build this preconditioner.
     #[getter]
-    fn config(&self) -> PyPreconditionerConfig {
-        PyPreconditionerConfig {
-            inner: self.inner.config().clone(),
-        }
+    fn config(&self, py: Python<'_>) -> PyResult<PyPreconditionerConfig> {
+        PyPreconditionerConfig::from_native(py, self.inner.config())
     }
 }
 
@@ -469,26 +508,12 @@ fn extract_preconditioner_config(
     };
 
     if let Ok(config) = obj.cast::<PyPreconditionerConfig>() {
-        return Ok(Some(config.get().to_native()));
-    }
-
-    if let Ok(schwarz) = obj.cast::<PyAdditiveSchwarz>() {
-        let s = schwarz.get();
-        let local = s
-            .local_solver
-            .as_ref()
-            .map(|c| c.bind(py).get().to_native(py))
-            .unwrap_or_default();
-        let reduction = s.reduction.to_native();
-        return Ok(Some(PreconditionerConfig::Additive {
-            local_solver: local,
-            reduction,
-        }));
+        return Ok(Some(config.get().to_native(py)));
     }
 
     Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-        "preconditioner must be PreconditionerConfig.Additive, PreconditionerConfig.Off, \
-         PreconditionerConfig.Diagonal, AdditiveSchwarz(...), a pre-built Preconditioner, or None",
+        "preconditioner must be PreconditionerConfig.Off(), PreconditionerConfig.Diagonal(), \
+         PreconditionerConfig.Additive(...), a pre-built Preconditioner, or None",
     ))
 }
 

--- a/crates/within-py/src/config.rs
+++ b/crates/within-py/src/config.rs
@@ -34,6 +34,13 @@ impl PyApproxCholConfig {
 }
 
 impl PyApproxCholConfig {
+    pub(crate) fn from_native(config: &ApproxCholConfig) -> Self {
+        Self {
+            seed: config.seed,
+            split_merge: config.split_merge,
+        }
+    }
+
     pub(crate) fn to_native(&self) -> ApproxCholConfig {
         ApproxCholConfig {
             seed: self.seed,
@@ -115,6 +122,12 @@ impl PySchur {
 }
 
 impl PySchur {
+    pub(crate) fn from_native(config: &SchurMode) -> Self {
+        Self {
+            inner: config.clone(),
+        }
+    }
+
     pub(crate) fn to_native(&self) -> SchurMode {
         self.inner.clone()
     }
@@ -168,6 +181,14 @@ impl PyScalingConfig {
 }
 
 impl PyScalingConfig {
+    pub(crate) fn from_native(config: &ScalingConfig) -> Self {
+        Self {
+            tolerance: config.tolerance,
+            max_sweeps: config.max_sweeps,
+            on_failure: config.on_failure,
+        }
+    }
+
     pub(crate) fn to_native(&self) -> ScalingConfig {
         ScalingConfig {
             tolerance: self.tolerance,
@@ -181,20 +202,24 @@ impl PyScalingConfig {
 ///
 /// Complex enum: each variant is a Python-visible subclass supporting ``match``
 /// and per-field getters. Unit variants are spelled ``Off()`` / ``Diagonal()``.
-#[pyclass(frozen, module = "within._within")]
+#[pyclass(frozen, eq, module = "within._within")]
 #[pyo3(name = "PreconditionerConfig")]
+#[derive(PartialEq)]
 pub enum PyPreconditionerConfig {
     Off(),
-    #[pyo3(constructor = (local_solver=None, reduction=PyReductionStrategy::Auto))]
+    #[pyo3(constructor = (
+        local_solver=PyLocalSolverConfig::default(),
+        reduction=PyReductionStrategy::Auto
+    ))]
     Additive {
-        local_solver: Option<Py<PyLocalSolverConfig>>,
+        local_solver: PyLocalSolverConfig,
         reduction: PyReductionStrategy,
     },
     Diagonal(),
 }
 
 impl PyPreconditionerConfig {
-    pub(crate) fn to_native(&self, py: Python<'_>) -> PreconditionerConfig {
+    pub(crate) fn to_native(&self) -> PreconditionerConfig {
         match self {
             Self::Off() => PreconditionerConfig::Off,
             Self::Diagonal() => PreconditionerConfig::Diagonal,
@@ -202,58 +227,23 @@ impl PyPreconditionerConfig {
                 local_solver,
                 reduction,
             } => PreconditionerConfig::Additive {
-                local_solver: local_solver
-                    .as_ref()
-                    .map(|c| c.bind(py).get().to_native(py))
-                    .unwrap_or_default(),
+                local_solver: local_solver.to_native(),
                 reduction: reduction.to_native(),
             },
         }
     }
 
-    pub(crate) fn from_native(py: Python<'_>, config: &PreconditionerConfig) -> PyResult<Self> {
+    pub(crate) fn from_native(config: &PreconditionerConfig) -> PyResult<Self> {
         Ok(match config {
             PreconditionerConfig::Off => Self::Off(),
             PreconditionerConfig::Diagonal => Self::Diagonal(),
             PreconditionerConfig::Additive {
                 local_solver,
                 reduction,
-            } => {
-                let local = PyLocalSolverConfig {
-                    approx_chol: Some(Py::new(
-                        py,
-                        PyApproxCholConfig {
-                            seed: local_solver.approx_chol.seed,
-                            split_merge: local_solver.approx_chol.split_merge,
-                        },
-                    )?),
-                    schur: Some(Py::new(
-                        py,
-                        PySchur {
-                            inner: local_solver.schur.clone(),
-                        },
-                    )?),
-                    dense_threshold: local_solver.dense_threshold,
-                    scaling: Some(Py::new(
-                        py,
-                        PyScalingConfig {
-                            tolerance: local_solver.scaling.tolerance,
-                            max_sweeps: local_solver.scaling.max_sweeps,
-                            on_failure: local_solver.scaling.on_failure,
-                        },
-                    )?),
-                };
-                Self::Additive {
-                    local_solver: Some(Py::new(py, local)?),
-                    reduction: match reduction {
-                        ReductionStrategy::Auto => PyReductionStrategy::Auto,
-                        ReductionStrategy::AtomicScatter => PyReductionStrategy::AtomicScatter,
-                        ReductionStrategy::ParallelReduction => {
-                            PyReductionStrategy::ParallelReduction
-                        }
-                    },
-                }
-            }
+            } => Self::Additive {
+                local_solver: PyLocalSolverConfig::from_native(local_solver),
+                reduction: PyReductionStrategy::from_native(*reduction),
+            },
             _ => {
                 return Err(pyo3::exceptions::PyRuntimeError::new_err(
                     "unsupported preconditioner configuration",
@@ -265,19 +255,12 @@ impl PyPreconditionerConfig {
 
 #[pymethods]
 impl PyPreconditionerConfig {
-    fn __eq__(&self, py: Python<'_>, other: &Bound<'_, PyAny>) -> bool {
-        other
-            .cast::<PyPreconditionerConfig>()
-            .map(|o| self.to_native(py) == o.get().to_native(py))
-            .unwrap_or(false)
-    }
-
     /// Complex enums have no default pickle support; round-trip via native serde.
     fn __reduce__<'py>(
         &self,
         py: Python<'py>,
     ) -> PyResult<(Bound<'py, PyAny>, (Bound<'py, pyo3::types::PyBytes>,))> {
-        let bytes = postcard::to_stdvec(&self.to_native(py))
+        let bytes = postcard::to_stdvec(&self.to_native())
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
         let ctor = py
             .import("within._within")?
@@ -288,7 +271,6 @@ impl PyPreconditionerConfig {
 
 #[pyfunction]
 pub(crate) fn _preconditioner_config_from_postcard(
-    py: Python<'_>,
     data: &[u8],
 ) -> PyResult<PyPreconditionerConfig> {
     let native: PreconditionerConfig = postcard::from_bytes(data).map_err(|e| {
@@ -296,7 +278,7 @@ pub(crate) fn _preconditioner_config_from_postcard(
             "failed to deserialize preconditioner config: {e}"
         ))
     })?;
-    PyPreconditionerConfig::from_native(py, &native)
+    PyPreconditionerConfig::from_native(&native)
 }
 
 #[pyclass(frozen, eq, eq_int, from_py_object, module = "within._within")]
@@ -309,6 +291,14 @@ pub enum PyReductionStrategy {
 }
 
 impl PyReductionStrategy {
+    pub(crate) fn from_native(strategy: ReductionStrategy) -> Self {
+        match strategy {
+            ReductionStrategy::Auto => Self::Auto,
+            ReductionStrategy::AtomicScatter => Self::AtomicScatter,
+            ReductionStrategy::ParallelReduction => Self::ParallelReduction,
+        }
+    }
+
     pub(crate) fn to_native(self) -> ReductionStrategy {
         match self {
             Self::Auto => ReductionStrategy::Auto,
@@ -318,17 +308,11 @@ impl PyReductionStrategy {
     }
 }
 
-#[pyclass(frozen, module = "within._within")]
+#[pyclass(frozen, eq, from_py_object, module = "within._within")]
 #[pyo3(name = "LocalSolverConfig")]
+#[derive(Clone, Default, PartialEq)]
 pub struct PyLocalSolverConfig {
-    #[pyo3(get)]
-    pub approx_chol: Option<Py<PyApproxCholConfig>>,
-    #[pyo3(get)]
-    pub schur: Option<Py<PySchur>>,
-    #[pyo3(get)]
-    pub dense_threshold: usize,
-    #[pyo3(get)]
-    pub scaling: Option<Py<PyScalingConfig>>,
+    inner: LocalSolverConfig,
 }
 
 #[pymethods]
@@ -336,44 +320,59 @@ impl PyLocalSolverConfig {
     #[new]
     #[pyo3(signature = (approx_chol=None, schur=None, dense_threshold=None, scaling=None))]
     fn new(
+        py: Python<'_>,
         approx_chol: Option<Py<PyApproxCholConfig>>,
         schur: Option<Py<PySchur>>,
         dense_threshold: Option<usize>,
         scaling: Option<Py<PyScalingConfig>>,
     ) -> Self {
+        let defaults = LocalSolverConfig::default();
         Self {
-            approx_chol,
-            schur,
-            dense_threshold: dense_threshold
-                .unwrap_or_else(|| LocalSolverConfig::default().dense_threshold),
-            scaling,
+            inner: LocalSolverConfig {
+                approx_chol: approx_chol
+                    .map(|config| config.bind(py).get().to_native())
+                    .unwrap_or(defaults.approx_chol),
+                schur: schur
+                    .map(|config| config.bind(py).get().to_native())
+                    .unwrap_or(defaults.schur),
+                dense_threshold: dense_threshold.unwrap_or(defaults.dense_threshold),
+                scaling: scaling
+                    .map(|config| config.bind(py).get().to_native())
+                    .unwrap_or(defaults.scaling),
+            },
         }
+    }
+
+    #[getter]
+    fn approx_chol(&self) -> PyApproxCholConfig {
+        PyApproxCholConfig::from_native(&self.inner.approx_chol)
+    }
+
+    #[getter]
+    fn schur(&self) -> PySchur {
+        PySchur::from_native(&self.inner.schur)
+    }
+
+    #[getter]
+    fn dense_threshold(&self) -> usize {
+        self.inner.dense_threshold
+    }
+
+    #[getter]
+    fn scaling(&self) -> PyScalingConfig {
+        PyScalingConfig::from_native(&self.inner.scaling)
     }
 }
 
 impl PyLocalSolverConfig {
-    pub(crate) fn to_native(&self, py: Python<'_>) -> LocalSolverConfig {
-        let approx_chol = self
-            .approx_chol
-            .as_ref()
-            .map(|c| c.bind(py).get().to_native())
-            .unwrap_or_else(|| LocalSolverConfig::default().approx_chol);
-        let schur = self
-            .schur
-            .as_ref()
-            .map(|s| s.bind(py).get().to_native())
-            .unwrap_or_default();
-        let scaling = self
-            .scaling
-            .as_ref()
-            .map(|c| c.bind(py).get().to_native())
-            .unwrap_or_default();
-        LocalSolverConfig {
-            approx_chol,
-            schur,
-            dense_threshold: self.dense_threshold,
-            scaling,
+    pub(crate) fn from_native(config: &LocalSolverConfig) -> Self {
+        Self {
+            inner: config.clone(),
         }
+    }
+
+    pub(crate) fn to_native(&self) -> LocalSolverConfig {
+        self.inner.clone()
     }
 }
 
@@ -480,14 +479,13 @@ impl PyPreconditioner {
 
     /// Complete normalized configuration used to build this preconditioner.
     #[getter]
-    fn config(&self, py: Python<'_>) -> PyResult<PyPreconditionerConfig> {
-        PyPreconditionerConfig::from_native(py, self.inner.config())
+    fn config(&self) -> PyResult<PyPreconditionerConfig> {
+        PyPreconditionerConfig::from_native(self.inner.config())
     }
 }
 
-/// Must run under the GIL; the result is all-native, so it can move into a released closure.
+/// The result is all-native, so it can move into a released closure.
 pub(crate) fn resolve_precond_input(
-    py: Python<'_>,
     preconditioner: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<PreconditionerInput> {
     if let Some(obj) = preconditioner {
@@ -495,12 +493,11 @@ pub(crate) fn resolve_precond_input(
             return Ok(PreconditionerInput::Prebuilt(built.get().inner.clone()));
         }
     }
-    Ok(extract_preconditioner_config(py, preconditioner)?
+    Ok(extract_preconditioner_config(preconditioner)?
         .map_or(PreconditionerInput::Default, PreconditionerInput::Config))
 }
 
 fn extract_preconditioner_config(
-    py: Python<'_>,
     preconditioner: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<Option<PreconditionerConfig>> {
     let Some(obj) = preconditioner else {
@@ -508,7 +505,7 @@ fn extract_preconditioner_config(
     };
 
     if let Ok(config) = obj.cast::<PyPreconditionerConfig>() {
-        return Ok(Some(config.get().to_native(py)));
+        return Ok(Some(config.get().to_native()));
     }
 
     Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(

--- a/crates/within-py/src/lib.rs
+++ b/crates/within-py/src/lib.rs
@@ -18,8 +18,9 @@ mod results;
 
 use api::{solve, solve_batch, PyEffect, PySolver};
 use config::{
-    PyAdditiveSchwarz, PyApproxCholConfig, PyApproxSchurConfig, PyLocalSolverConfig, PyLsmrOptions,
-    PyPreconditioner, PyPreconditionerConfig, PyReductionStrategy, PyScalingConfig, PySchur,
+    _preconditioner_config_from_postcard, PyApproxCholConfig, PyApproxSchurConfig,
+    PyLocalSolverConfig, PyLsmrOptions, PyPreconditioner, PyPreconditionerConfig,
+    PyReductionStrategy, PyScalingConfig, PySchur,
 };
 use results::{PyBatchSolveResult, PyCoefficientLayout, PySolveResult, PyUnidentifiedDirection};
 
@@ -30,7 +31,6 @@ fn _within(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyUnidentifiedDirection>()?;
     m.add_class::<PyCoefficientLayout>()?;
     m.add_class::<PyLsmrOptions>()?;
-    m.add_class::<PyAdditiveSchwarz>()?;
     m.add_class::<PyReductionStrategy>()?;
     m.add_class::<PyPreconditionerConfig>()?;
     m.add_class::<PyApproxCholConfig>()?;
@@ -43,5 +43,6 @@ fn _within(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyEffect>()?;
     m.add_function(wrap_pyfunction!(solve, m)?)?;
     m.add_function(wrap_pyfunction!(solve_batch, m)?)?;
+    m.add_function(wrap_pyfunction!(_preconditioner_config_from_postcard, m)?)?;
     Ok(())
 }

--- a/python/within/README.md
+++ b/python/within/README.md
@@ -32,7 +32,7 @@ y = np.random.randn(n)
 
 result = solve(fe, y)                          # Schwarz-preconditioned LSMR
 result = solve(fe, y, weights=np.ones(n))      # weighted solve
-result = solve(fe, y, preconditioner=PreconditionerConfig.Diagonal)
+result = solve(fe, y, preconditioner=PreconditionerConfig.Diagonal())
 ```
 
 ### FWL regression example
@@ -92,17 +92,16 @@ solver2 = Solver(fe, preconditioner=precond)   # skip re-factorization
 
 | Class | Description |
 |---|---|
-| `PreconditionerConfig.Off` | Disable preconditioning. |
-| `PreconditionerConfig.Additive` | Additive Schwarz shortcut (equivalent to `None`). |
-| `PreconditionerConfig.additive(local_solver?, reduction?)` | Tuned additive Schwarz configuration. Advanced argument types are available from `within.config`. |
-| `PreconditionerConfig.Diagonal` | Diagonal/Jacobi preconditioner using `diag(D^T W D)^{-1}`. |
-| `AdditiveSchwarz(local_solver?, reduction?)` | Existing tuned Schwarz configuration API — import from `within.config`. |
+| `PreconditionerConfig.Off()` | Disable preconditioning. |
+| `PreconditionerConfig.Additive()` | Additive Schwarz shortcut (equivalent to `None`). |
+| `PreconditionerConfig.Additive(local_solver?, reduction?)` | Tuned additive Schwarz. Argument types import from `within.config`. |
+| `PreconditionerConfig.Diagonal()` | Diagonal/Jacobi preconditioner using `diag(D^T W D)^{-1}`. |
 | `Preconditioner` (built) | Reuse a previously-built preconditioner across solvers. |
 
 Pass `None` (the default) to use additive Schwarz with the default local solver.
-`PreconditionerConfig` instances compare by value. A built preconditioner exposes
-the configuration used to construct it as `.config`, including after pickling,
-so cached preconditioners can be checked with `precond.config == requested_config`.
+`PreconditionerConfig` is a tagged union: each variant is a subclass, so instances
+support `match`/`case`, compare by value, and pickle. A built preconditioner exposes
+the configuration used to construct it as `.config` (preserved across pickling).
 
 ### Local solver configuration (advanced)
 

--- a/python/within/__init__.py
+++ b/python/within/__init__.py
@@ -37,8 +37,8 @@ Two-tier public API:
   (``solve``, ``Solver``, ``LsmrOptions``, ``PreconditionerConfig``,
   ``Preconditioner``).
 - :mod:`within.config` re-exports the advanced configuration objects
-  (``AdditiveSchwarz``, ``LocalSolverConfig``, ``ApproxCholConfig``,
-  ``ApproxSchurConfig``, ``ReductionStrategy``).
+  (``LocalSolverConfig``, ``ApproxCholConfig``, ``ApproxSchurConfig``,
+  ``ReductionStrategy``, ``ScalingConfig``, ``Schur``).
 
 Thread safety: the heavy work runs with the interpreter detached and reads the
 caller's arrays in place. As with NumPy itself, an input array must not be

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -9,26 +9,33 @@ import numpy as np
 from numpy.typing import NDArray
 
 class PreconditionerConfig:
-    """Preconditioner selection shortcut for the LSMR solver.
+    """Preconditioner configuration for the LSMR solver.
 
-    Not an ``Enum``: the members below are class attributes (not iterable, so
-    ``list(PreconditionerConfig)`` raises). Use them for defaults, or call
-    :meth:`additive` for fine-grained control.
-
-    Attributes:
-        Additive: Additive Schwarz (default).
-        Off: No preconditioner. Useful for debugging or well-conditioned problems.
-        Diagonal: Diagonal/Jacobi preconditioner.
+    A tagged union: each variant is a subclass. Construct with ``Off()``,
+    ``Diagonal()``, or ``Additive(local_solver=..., reduction=...)``. Instances
+    compare by value, support ``match``/``case``, and pickle.
     """
 
-    Additive: PreconditionerConfig
-    Off: PreconditionerConfig
-    Diagonal: PreconditionerConfig
-    @staticmethod
-    def additive(
-        local_solver: LocalSolverConfig | None = None,
-        reduction: ReductionStrategy = ...,
-    ) -> PreconditionerConfig: ...
+    class Off(PreconditionerConfig):
+        """No preconditioner. Useful for debugging or well-conditioned problems."""
+
+        def __init__(self) -> None: ...
+
+    class Diagonal(PreconditionerConfig):
+        """Diagonal/Jacobi preconditioner using ``diag(D^T W D)^{-1}``."""
+
+        def __init__(self) -> None: ...
+
+    class Additive(PreconditionerConfig):
+        """Additive Schwarz (the default). ``local_solver=None`` uses defaults."""
+
+        local_solver: LocalSolverConfig | None
+        reduction: ReductionStrategy
+        def __init__(
+            self,
+            local_solver: LocalSolverConfig | None = None,
+            reduction: ReductionStrategy = ...,
+        ) -> None: ...
 
 class ReductionStrategy:
     """Strategy for combining subdomain contributions in additive Schwarz.
@@ -220,9 +227,7 @@ def solve(
     y: NDArray[np.float64],
     weights: NDArray[np.float64] | None = None,
     options: LsmrOptions | None = None,
-    preconditioner: (
-        PreconditionerConfig | AdditiveSchwarz | Preconditioner | None
-    ) = None,
+    preconditioner: (PreconditionerConfig | Preconditioner | None) = None,
 ) -> SolveResult:
     """Solve fixed-effects normal equations for a single response vector.
 
@@ -239,13 +244,13 @@ def solve(
             Default: unit weights (unweighted).
         options: LSMR solver tuning. Pass ``LsmrOptions(...)`` to override
             defaults. Default: ``LsmrOptions(tol=1e-8, maxiter=1000)``.
-        preconditioner: Controls preconditioning. Five input forms are accepted:
+        preconditioner: Controls preconditioning. Accepted forms:
             ``None`` (default) builds the additive Schwarz preconditioner with
-            default settings. ``PreconditionerConfig.Off`` disables it.
-            ``PreconditionerConfig.Diagonal`` uses diagonal/Jacobi scaling.
-            ``AdditiveSchwarz(...)`` overrides the local-solver / reduction
-            settings. A previously-built ``Preconditioner`` instance reuses an
-            existing factorisation.
+            default settings. ``PreconditionerConfig.Off()`` disables it.
+            ``PreconditionerConfig.Diagonal()`` uses diagonal/Jacobi scaling.
+            ``PreconditionerConfig.Additive(...)`` overrides the local-solver /
+            reduction settings. A previously-built ``Preconditioner`` instance
+            reuses an existing factorisation.
 
     Returns:
         A ``SolveResult`` with coefficients, demeaned response, convergence
@@ -282,9 +287,7 @@ def solve_batch(
     Y: NDArray[np.float64],
     weights: NDArray[np.float64] | None = None,
     options: LsmrOptions | None = None,
-    preconditioner: (
-        PreconditionerConfig | AdditiveSchwarz | Preconditioner | None
-    ) = None,
+    preconditioner: (PreconditionerConfig | Preconditioner | None) = None,
 ) -> BatchSolveResult:
     """Solve fixed-effects normal equations for multiple response vectors.
 
@@ -346,9 +349,7 @@ class Solver:
         self,
         design: NDArray[np.uint32] | list[Effect],
         weights: NDArray[np.float64] | None = None,
-        preconditioner: (
-            PreconditionerConfig | AdditiveSchwarz | Preconditioner | None
-        ) = None,
+        preconditioner: (PreconditionerConfig | Preconditioner | None) = None,
     ) -> None: ...
     def solve(
         self,
@@ -448,17 +449,4 @@ class LocalSolverConfig:
         schur: Schur | None = None,
         dense_threshold: int | None = None,
         scaling: ScalingConfig | None = None,
-    ) -> None: ...
-
-class AdditiveSchwarz:
-    """Additive Schwarz preconditioner with configurable local solver."""
-
-    @property
-    def local_solver(self) -> LocalSolverConfig | None: ...
-    @property
-    def reduction(self) -> ReductionStrategy: ...
-    def __init__(
-        self,
-        local_solver: LocalSolverConfig | None = None,
-        reduction: ReductionStrategy = ReductionStrategy.Auto,
     ) -> None: ...

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -27,13 +27,13 @@ class PreconditionerConfig:
         def __init__(self) -> None: ...
 
     class Additive(PreconditionerConfig):
-        """Additive Schwarz (the default). ``local_solver=None`` uses defaults."""
+        """Additive Schwarz with a normalized local-solver configuration."""
 
-        local_solver: LocalSolverConfig | None
+        local_solver: LocalSolverConfig
         reduction: ReductionStrategy
         def __init__(
             self,
-            local_solver: LocalSolverConfig | None = None,
+            local_solver: LocalSolverConfig = ...,
             reduction: ReductionStrategy = ...,
         ) -> None: ...
 
@@ -436,13 +436,13 @@ class LocalSolverConfig:
     """
 
     @property
-    def approx_chol(self) -> ApproxCholConfig | None: ...
+    def approx_chol(self) -> ApproxCholConfig: ...
     @property
-    def schur(self) -> Schur | None: ...
+    def schur(self) -> Schur: ...
     @property
     def dense_threshold(self) -> int: ...
     @property
-    def scaling(self) -> ScalingConfig | None: ...
+    def scaling(self) -> ScalingConfig: ...
     def __init__(
         self,
         approx_chol: ApproxCholConfig | None = None,

--- a/python/within/config.py
+++ b/python/within/config.py
@@ -7,9 +7,8 @@ preconditioner live in this submodule.
 
 Typical usage::
 
-    from within import solve, LsmrOptions
+    from within import solve, LsmrOptions, PreconditionerConfig
     from within.config import (
-        AdditiveSchwarz,
         ApproxCholConfig,
         ApproxSchurConfig,
         LocalSolverConfig,
@@ -17,7 +16,7 @@ Typical usage::
         Schur,
     )
 
-    schwarz = AdditiveSchwarz(
+    schwarz = PreconditionerConfig.Additive(
         local_solver=LocalSolverConfig(
             approx_chol=ApproxCholConfig(split_merge=2),
             schur=Schur.approximate(ApproxSchurConfig(split=2)),
@@ -31,7 +30,6 @@ Schur); pass ``Schur.exact()`` for the exact complement.
 """
 
 from within._within import (
-    AdditiveSchwarz,
     ApproxCholConfig,
     ApproxSchurConfig,
     LocalSolverConfig,
@@ -41,7 +39,6 @@ from within._within import (
 )
 
 __all__ = [
-    "AdditiveSchwarz",
     "ApproxCholConfig",
     "ApproxSchurConfig",
     "LocalSolverConfig",

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -86,7 +86,7 @@ class TestDegenerateY:
         """All observations in one group per factor leaves no variation to explain."""
         cats = np.zeros((5, 2), dtype=np.uint32, order="F")
         y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-        result = solve(cats, y, preconditioner=PreconditionerConfig.Off)
+        result = solve(cats, y, preconditioner=PreconditionerConfig.Off())
         assert np.all(np.isfinite(result.x))
 
 
@@ -243,7 +243,7 @@ class TestNoPreconditioner:
             [rng.integers(0, 10, size=200), rng.integers(0, 10, size=200)]
         )
         y = rng.standard_normal(200)
-        result = solve(cats, y, preconditioner=PreconditionerConfig.Off)
+        result = solve(cats, y, preconditioner=PreconditionerConfig.Off())
         assert result.converged
         assert np.all(np.isfinite(result.x))
 
@@ -253,13 +253,13 @@ class TestNoPreconditioner:
             [np.array([0, 1, 0, 1, 2]), np.array([0, 0, 1, 1, 0])]
         )
         y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-        result = solve(cats, y, preconditioner=PreconditionerConfig.Off)
+        result = solve(cats, y, preconditioner=PreconditionerConfig.Off())
         assert np.all(np.isfinite(result.x))
 
     def test_solver_preconditioner_none_returns_none(self):
-        """Solver built with PreconditionerConfig.Off should return None from preconditioner()."""
+        """Solver built with PreconditionerConfig.Off() should return None from preconditioner()."""
         cats = as_solver_categories(
             [np.array([0, 1, 0, 1, 2]), np.array([0, 0, 1, 1, 0])]
         )
-        solver = Solver(cats, preconditioner=PreconditionerConfig.Off)
+        solver = Solver(cats, preconditioner=PreconditionerConfig.Off())
         assert solver.preconditioner is None

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from within import Effect, Solver, solve, solve_batch
+from within import Effect, PreconditionerConfig, Solver, solve, solve_batch
 from within._within import ApproxSchurConfig
-from within.config import AdditiveSchwarz
 
 from conftest import as_solver_categories
 
@@ -101,7 +100,7 @@ class TestErrorHandling:
     def test_additive_schwarz_rejects_local_solver_type(self):
         """A wrong-type local_solver should raise at construction, not at solve."""
         with pytest.raises(TypeError):
-            AdditiveSchwarz(local_solver="invalid")
+            PreconditionerConfig.Additive(local_solver="invalid")
 
     def test_approx_schur_config_split_zero_raises(self):
         """ApproxSchurConfig(split=0) should raise ValueError."""

--- a/tests/test_preconditioner.py
+++ b/tests/test_preconditioner.py
@@ -7,7 +7,6 @@ import pytest
 
 from within import LsmrOptions, Preconditioner, PreconditionerConfig, Solver, solve
 from within._within import (
-    AdditiveSchwarz,
     ApproxCholConfig,
     ApproxSchurConfig,
     LocalSolverConfig,
@@ -41,16 +40,42 @@ def solver_and_precond(problem):
 
 
 class TestAdvancedConfigs:
-    def test_preconditioner_config_additive_factory(self):
-        implicit = PreconditionerConfig.additive()
-        explicit = PreconditionerConfig.additive(
+    def test_preconditioner_config_additive_constructor(self):
+        implicit = PreconditionerConfig.Additive()
+        explicit = PreconditionerConfig.Additive(
             local_solver=LocalSolverConfig(),
             reduction=ReductionStrategy.Auto,
         )
 
         assert implicit == explicit
-        assert implicit == PreconditionerConfig.Additive
-        assert implicit != PreconditionerConfig.Diagonal
+        assert implicit != PreconditionerConfig.Diagonal()
+
+    def test_preconditioner_config_variant_introspection(self):
+        # Each variant is a subclass of PreconditionerConfig (the 3.9-safe
+        # equivalent of ``match``), and Additive exposes its fields as getters.
+        off = PreconditionerConfig.Off()
+        tuned = PreconditionerConfig.Additive(
+            local_solver=LocalSolverConfig(dense_threshold=0),
+            reduction=ReductionStrategy.AtomicScatter,
+        )
+
+        assert isinstance(off, PreconditionerConfig)
+        assert isinstance(tuned, PreconditionerConfig.Additive)
+        assert not isinstance(off, PreconditionerConfig.Additive)
+        assert tuned.reduction == ReductionStrategy.AtomicScatter
+        assert tuned.local_solver.dense_threshold == 0
+
+    def test_preconditioner_config_pickle_roundtrip(self):
+        for config in (
+            PreconditionerConfig.Off(),
+            PreconditionerConfig.Diagonal(),
+            PreconditionerConfig.Additive(),
+            PreconditionerConfig.Additive(
+                local_solver=LocalSolverConfig(dense_threshold=0),
+                reduction=ReductionStrategy.AtomicScatter,
+            ),
+        ):
+            assert pickle.loads(pickle.dumps(config)) == config
 
     def test_approx_chol_config_defaults(self):
         cfg = ApproxCholConfig()
@@ -88,7 +113,7 @@ class TestAdvancedConfigs:
                 cats,
                 y,
                 options=LsmrOptions(maxiter=2000),
-                preconditioner=AdditiveSchwarz(local_solver=local),
+                preconditioner=PreconditionerConfig.Additive(local_solver=local),
             )
             assert result.converged
 
@@ -98,7 +123,9 @@ class TestAdvancedConfigs:
             as_solver_categories(cats),
             y,
             options=LsmrOptions(),
-            preconditioner=AdditiveSchwarz(local_solver=LocalSolverConfig()),
+            preconditioner=PreconditionerConfig.Additive(
+                local_solver=LocalSolverConfig()
+            ),
         )
         assert result.converged
 
@@ -135,11 +162,11 @@ class TestFePreconditioner:
 
     def test_preconditioner_exposes_default_config(self, solver_and_precond):
         solver, precond, categories, y = solver_and_precond
-        assert precond.config == PreconditionerConfig.Additive
+        assert precond.config == PreconditionerConfig.Additive()
 
     def test_preconditioner_exposes_tuned_config(self, problem):
         cats, _ = problem
-        requested = PreconditionerConfig.additive(
+        requested = PreconditionerConfig.Additive(
             local_solver=LocalSolverConfig(
                 approx_chol=ApproxCholConfig(seed=41, split_merge=3),
                 schur=Schur.approximate(ApproxSchurConfig(seed=17, split=2)),
@@ -169,18 +196,18 @@ class TestFePreconditioner:
         categories = as_solver_categories(
             [np.array([0, 1, 0, 1, 2, 2]), np.array([0, 0, 1, 1, 0, 1])]
         )
-        solver = Solver(categories, preconditioner=PreconditionerConfig.Diagonal)
+        solver = Solver(categories, preconditioner=PreconditionerConfig.Diagonal())
         precond = solver.preconditioner
 
         assert precond is not None
         assert "Diagonal" in repr(precond)
-        assert precond.config == PreconditionerConfig.Diagonal
+        assert precond.config == PreconditionerConfig.Diagonal()
 
     def test_single_factor_diagonal_preconditioner_is_cached(self):
         categories = np.asfortranarray(
             np.array([[0], [1], [0], [2], [1]], dtype=np.uint32)
         )
-        solver = Solver(categories, preconditioner=PreconditionerConfig.Diagonal)
+        solver = Solver(categories, preconditioner=PreconditionerConfig.Diagonal())
         precond = solver.preconditioner
 
         assert precond is not None

--- a/tests/test_preconditioner.py
+++ b/tests/test_preconditioner.py
@@ -49,6 +49,10 @@ class TestAdvancedConfigs:
 
         assert implicit == explicit
         assert implicit != PreconditionerConfig.Diagonal()
+        assert implicit.local_solver == LocalSolverConfig()
+
+        with pytest.raises(TypeError):
+            PreconditionerConfig.Additive(local_solver=None)
 
     def test_preconditioner_config_variant_introspection(self):
         # Each variant is a subclass of PreconditionerConfig (the 3.9-safe
@@ -95,8 +99,10 @@ class TestAdvancedConfigs:
     def test_schur_complement_defaults(self):
         sc = LocalSolverConfig()
         assert sc.dense_threshold == 24
-        # Omitted schur means the library default (approximate), not exact.
-        assert sc.schur is None
+        assert sc.approx_chol.seed == 0
+        assert sc.approx_chol.split_merge == 2
+        assert repr(sc.schur) == "Schur.approximate(seed=0, split=1)"
+        assert sc.scaling.on_failure == "warn"
 
     def test_schur_mode_spellings(self):
         # Omission and Schur.approximate() are the default; Schur.exact() is the
@@ -108,7 +114,8 @@ class TestAdvancedConfigs:
         y = rng.standard_normal(600)
         for schur in (None, Schur.approximate(), Schur.exact()):
             local = LocalSolverConfig(schur=schur)
-            assert local.schur is schur
+            expected = Schur.approximate() if schur is None else schur
+            assert repr(local.schur) == repr(expected)
             result = solve(
                 cats,
                 y,
@@ -179,7 +186,15 @@ class TestFePreconditioner:
         precond = solver.preconditioner
 
         assert precond is not None
-        assert precond.config == requested
+        actual = precond.config
+        assert actual == requested
+        assert isinstance(actual, PreconditionerConfig.Additive)
+        assert actual.reduction == ReductionStrategy.AtomicScatter
+        assert actual.local_solver.approx_chol.seed == 41
+        assert actual.local_solver.approx_chol.split_merge == 3
+        assert repr(actual.local_solver.schur) == "Schur.approximate(seed=17, split=2)"
+        assert actual.local_solver.dense_threshold == 0
+        assert actual.local_solver.scaling.on_failure == "warn"
 
     def test_preconditioner_corrupt_bytes_raises(self):
         with pytest.raises(ValueError):

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -6,8 +6,8 @@ import numpy as np
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-from within import Solver, solve
-from within.config import AdditiveSchwarz, ReductionStrategy
+from within import PreconditionerConfig, Solver, solve
+from within.config import ReductionStrategy
 
 
 @st.composite
@@ -67,10 +67,10 @@ class TestProperties:
 
 
 class TestAdvancedPreconditioners:
-    """Tests for AdditiveSchwarz preconditioner configs."""
+    """Tests for additive Schwarz preconditioner configs."""
 
     def test_additive_schwarz_object_converges(self):
-        """AdditiveSchwarz() as preconditioner object should converge."""
+        """PreconditionerConfig.Additive() as preconditioner object should converge."""
         rng = np.random.default_rng(42)
         categories = np.asfortranarray(
             np.column_stack(
@@ -78,11 +78,11 @@ class TestAdvancedPreconditioners:
             ).astype(np.uint32)
         )
         y = rng.standard_normal(500)
-        result = solve(categories, y, preconditioner=AdditiveSchwarz())
+        result = solve(categories, y, preconditioner=PreconditionerConfig.Additive())
         assert result.converged
 
     def test_reduction_strategy_atomic_scatter_converges(self):
-        """AdditiveSchwarz with AtomicScatter reduction should converge."""
+        """additive Schwarz with AtomicScatter reduction should converge."""
         rng = np.random.default_rng(10)
         categories = np.asfortranarray(
             np.column_stack(
@@ -93,12 +93,14 @@ class TestAdvancedPreconditioners:
         result = solve(
             categories,
             y,
-            preconditioner=AdditiveSchwarz(reduction=ReductionStrategy.AtomicScatter),
+            preconditioner=PreconditionerConfig.Additive(
+                reduction=ReductionStrategy.AtomicScatter
+            ),
         )
         assert result.converged
 
     def test_reduction_strategy_parallel_reduction_converges(self):
-        """AdditiveSchwarz with ParallelReduction strategy should converge."""
+        """additive Schwarz with ParallelReduction strategy should converge."""
         rng = np.random.default_rng(11)
         categories = np.asfortranarray(
             np.column_stack(
@@ -109,7 +111,7 @@ class TestAdvancedPreconditioners:
         result = solve(
             categories,
             y,
-            preconditioner=AdditiveSchwarz(
+            preconditioner=PreconditionerConfig.Additive(
                 reduction=ReductionStrategy.ParallelReduction
             ),
         )
@@ -127,12 +129,14 @@ class TestAdvancedPreconditioners:
         r_atomic = solve(
             categories,
             y,
-            preconditioner=AdditiveSchwarz(reduction=ReductionStrategy.AtomicScatter),
+            preconditioner=PreconditionerConfig.Additive(
+                reduction=ReductionStrategy.AtomicScatter
+            ),
         )
         r_parallel = solve(
             categories,
             y,
-            preconditioner=AdditiveSchwarz(
+            preconditioner=PreconditionerConfig.Additive(
                 reduction=ReductionStrategy.ParallelReduction
             ),
         )

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -15,7 +15,7 @@ from within import (
     Solver,
     solve,
 )
-from within.config import AdditiveSchwarz, LocalSolverConfig, ScalingConfig
+from within.config import LocalSolverConfig, ScalingConfig
 
 from conftest import as_solver_categories, generate_synthetic_data
 
@@ -112,7 +112,7 @@ def test_one_shot_solve_surfaces_build_warnings():
     from within import solve_batch
 
     design = [Effect(f, True, [z]), Effect(g, True)]
-    precond = AdditiveSchwarz(
+    precond = PreconditionerConfig.Additive(
         local_solver=LocalSolverConfig(scaling=ScalingConfig(max_iterations=0))
     )
 
@@ -160,7 +160,7 @@ class TestSolveDefaults:
             as_solver_categories(cats),
             y,
             options=LsmrOptions(),
-            preconditioner=PreconditionerConfig.Off,
+            preconditioner=PreconditionerConfig.Off(),
         )
         assert result.converged
 
@@ -180,18 +180,18 @@ class TestPreconditioners:
             as_solver_categories(cats),
             y,
             options=LsmrOptions(),
-            preconditioner=PreconditionerConfig.Additive,
+            preconditioner=PreconditionerConfig.Additive(),
         )
         assert result.converged
 
     def test_advanced_additive_schwarz(self, problem):
-        """Test advanced config via AdditiveSchwarz."""
+        """Test advanced config via additive Schwarz."""
         cats, y = problem
         result = solve(
             as_solver_categories(cats),
             y,
             options=LsmrOptions(),
-            preconditioner=AdditiveSchwarz(),
+            preconditioner=PreconditionerConfig.Additive(),
         )
         assert result.converged
 
@@ -205,7 +205,7 @@ class TestPreconditioners:
             categories,
             y,
             options=LsmrOptions(maxiter=2000),
-            preconditioner=PreconditionerConfig.Diagonal,
+            preconditioner=PreconditionerConfig.Diagonal(),
         )
         assert result.converged
         assert np.all(np.isfinite(result.x))
@@ -336,10 +336,10 @@ class TestSolver:
         np.testing.assert_array_equal(r1.x, r2.x)
 
     def test_solver_no_preconditioner(self, problem):
-        """Solver with PreconditionerConfig.Off works."""
+        """Solver with PreconditionerConfig.Off() works."""
         cats, y = problem
         solver = Solver(
-            as_solver_categories(cats), preconditioner=PreconditionerConfig.Off
+            as_solver_categories(cats), preconditioner=PreconditionerConfig.Off()
         )
         result = solver.solve(y)
         assert result.converged
@@ -427,7 +427,7 @@ class TestSolverSerde:
     def test_no_preconditioner_returns_none(self, problem):
         cats, y = problem
         solver = Solver(
-            as_solver_categories(cats), preconditioner=PreconditionerConfig.Off
+            as_solver_categories(cats), preconditioner=PreconditionerConfig.Off()
         )
         assert solver.preconditioner is None
 
@@ -439,7 +439,7 @@ class TestSolverSerde:
         )
         y = np.array([1.0, 2.0, 1.5, 2.5, 3.0, 3.5])
 
-        solver1 = Solver(categories, preconditioner=PreconditionerConfig.Diagonal)
+        solver1 = Solver(categories, preconditioner=PreconditionerConfig.Diagonal())
         r1 = solver1.solve(y)
         precond = solver1.preconditioner
 
@@ -465,7 +465,11 @@ class TestSolverSerde:
 class TestAliases:
     def test_additive_alias(self, problem):
         cats, y = problem
-        result = solve(as_solver_categories(cats), y, preconditioner=AdditiveSchwarz())
+        result = solve(
+            as_solver_categories(cats),
+            y,
+            preconditioner=PreconditionerConfig.Additive(),
+        )
         assert result.converged
 
 


### PR DESCRIPTION
Add complex enum for `PreconditionerConfig` as discussed here: https://github.com/py-econometrics/within/pull/274#issuecomment-5325102350

Note that this PR targets the branch `expose-python-preconditioner-config` (not main). Let me know what you think @schroedk 