### PR TITLE
fix(schur): mirror the exact Schur complement's upper triangle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - **BREAKING:** `LsmrStopReason` gains `Escalated` and `WarmStartExact`, breaking exhaustive `match`es.
 - A warm start that already solves the system reports `WarmStartExact` instead of `ZeroRhs`.
 - **BREAKING:** The serialized `Preconditioner` wire format changed (v12 → v13) with the `approx-chol` 0.4 → 0.5 bump; 0.3.0 bytes no longer decode.
+- The exact Schur complement computes one triangle and mirrors it, so the local factorization's symmetric-ingest contract holds by construction instead of by matched rounding (#282).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - **BREAKING:** `LsmrStopReason` gains `Escalated` and `WarmStartExact`, breaking exhaustive `match`es.
 - A warm start that already solves the system reports `WarmStartExact` instead of `ZeroRhs`.
 - **BREAKING:** The serialized `Preconditioner` wire format changed (v12 → v13) with the `approx-chol` 0.4 → 0.5 bump; 0.3.0 bytes no longer decode.
-- The exact Schur complement computes one triangle and mirrors it, so the local factorization's symmetric-ingest contract holds by construction instead of by matched rounding (#282).
 
 ### Added
 

--- a/crates/within/src/block_elim/schur.rs
+++ b/crates/within/src/block_elim/schur.rs
@@ -78,7 +78,8 @@ pub(crate) fn exact_for_factor(matrix: &SddmMatrix, inv_diagonal_eliminated: &[f
     build_explicit_laplacian(&principal, &surplus, matrix.grounding)
 }
 
-/// Multiply-adds [`exact`] performs: `Σ_k nnz(k)²`, quadratic in a width `n_kept` cannot see.
+/// Multiply-adds [`exact`] performs: `Σ_k nnz(k)(nnz(k)+1)/2` for the upper triangles,
+/// quadratic in a width `n_kept` cannot see.
 fn exact_flops(matrix: &SddmMatrix) -> usize {
     matrix
         .cross_tab
@@ -87,12 +88,12 @@ fn exact_flops(matrix: &SddmMatrix) -> usize {
         .windows(2)
         .map(|bounds| {
             let width = (bounds[1] - bounds[0]) as usize;
-            width * width
+            width * (width + 1) / 2
         })
         .sum()
 }
 
-/// Scatter Schur row `i` into a dense workspace, recording touched columns.
+/// Scatter the diagonal-and-upper part of Schur row `i`, recording touched columns.
 fn compute_schur_row_dense(
     matrix: &SddmMatrix,
     inv_diagonal_eliminated: &[f64],
@@ -103,14 +104,22 @@ fn compute_schur_row_dense(
     work[i] = matrix.diagonal_kept()[i];
     touched.push(i);
 
+    let elim_to_keep = &matrix.cross_tab.c;
     for (k, w) in matrix.cross_tab.ct.row(i) {
         let inv = inv_diagonal_eliminated[k];
-        for (j, v) in matrix.cross_tab.c.row(k) {
+        let start = elim_to_keep.indptr[k] as usize;
+        let end = elim_to_keep.indptr[k + 1] as usize;
+        let columns = &elim_to_keep.indices[start..end];
+        let split = columns.partition_point(|&j| (j as usize) < i);
+        for (&j, &v) in columns[split..]
+            .iter()
+            .zip(&elim_to_keep.data[start + split..end])
+        {
+            let j = j as usize;
             if work[j] == 0.0 && j != i {
                 touched.push(j);
             }
-            // Pairing the loadings before the reciprocal makes (i, j) and (j, i) bitwise equal.
-            work[j] -= (w * v) * inv;
+            work[j] -= w * v * inv;
         }
     }
 }
@@ -131,16 +140,38 @@ fn extract_sparse_row(i: usize, work: &mut [f64], touched: &mut [usize]) -> (Vec
     (row_indices, row_data)
 }
 
-/// Assemble a CSR matrix from per-row sparse results.
+/// Assemble full rows from diagonal-and-upper parts; the strict upper mirrors into the lower.
 fn assemble_schur_csr(rows: Vec<(Vec<u32>, Vec<f64>)>, n_keep: usize) -> CsrMatrix {
     let mut s_indptr = vec![0u32; n_keep + 1];
-    let total_nnz: usize = rows.iter().map(|(ri, _)| ri.len()).sum();
-    let mut s_indices = Vec::with_capacity(total_nnz);
-    let mut s_data = Vec::with_capacity(total_nnz);
+    for (i, (ri, _)) in rows.iter().enumerate() {
+        s_indptr[i + 1] += to_u32(ri.len());
+        for &j in ri {
+            if j as usize != i {
+                s_indptr[j as usize + 1] += 1;
+            }
+        }
+    }
+    for i in 0..n_keep {
+        s_indptr[i + 1] += s_indptr[i];
+    }
+    let total_nnz = s_indptr[n_keep] as usize;
+    let mut s_indices = vec![0u32; total_nnz];
+    let mut s_data = vec![0.0f64; total_nnz];
+
+    // Row layout: [mirrored lower | diagonal and upper]; ascending source rows keep it sorted.
+    let mut lower_cursor: Vec<u32> = s_indptr[..n_keep].to_vec();
     for (i, (ri, rd)) in rows.into_iter().enumerate() {
-        s_indices.extend_from_slice(&ri);
-        s_data.extend_from_slice(&rd);
-        s_indptr[i + 1] = to_u32(s_indices.len());
+        let own = s_indptr[i + 1] as usize - ri.len();
+        s_indices[own..own + ri.len()].copy_from_slice(&ri);
+        s_data[own..own + rd.len()].copy_from_slice(&rd);
+        for (&j, &v) in ri.iter().zip(&rd) {
+            if j as usize != i {
+                let pos = lower_cursor[j as usize] as usize;
+                s_indices[pos] = to_u32(i);
+                s_data[pos] = v;
+                lower_cursor[j as usize] += 1;
+            }
+        }
     }
     CsrMatrix::new(s_indptr, s_indices, s_data, n_keep)
 }

--- a/crates/within/src/block_elim/schur.rs
+++ b/crates/within/src/block_elim/schur.rs
@@ -22,6 +22,11 @@ pub(crate) enum RowSplit {
     Parallel,
 }
 
+struct UpperSchurRow {
+    columns: Vec<u32>,
+    values: Vec<f64>,
+}
+
 /// Multiply-adds below which splitting the kept rows costs more than it saves.
 const PAR_ROW_SPLIT_THRESHOLD: usize = 100_000;
 
@@ -40,7 +45,7 @@ pub(crate) fn exact(
         result
     };
 
-    let rows: Vec<(Vec<u32>, Vec<f64>)> = match split {
+    let rows: Vec<UpperSchurRow> = match split {
         RowSplit::Parallel => (0..n_keep)
             .into_par_iter()
             .map_init(
@@ -78,8 +83,7 @@ pub(crate) fn exact_for_factor(matrix: &SddmMatrix, inv_diagonal_eliminated: &[f
     build_explicit_laplacian(&principal, &surplus, matrix.grounding)
 }
 
-/// Multiply-adds [`exact`] performs: `Σ_k nnz(k)(nnz(k)+1)/2` for the upper triangles,
-/// quadratic in a width `n_kept` cannot see.
+/// Upper-triangle multiply-adds: `Σ_k nnz(k)(nnz(k)+1)/2`.
 fn exact_flops(matrix: &SddmMatrix) -> usize {
     matrix
         .cross_tab
@@ -110,12 +114,10 @@ fn compute_schur_row_dense(
         let start = elim_to_keep.indptr[k] as usize;
         let end = elim_to_keep.indptr[k + 1] as usize;
         let columns = &elim_to_keep.indices[start..end];
-        let split = columns.partition_point(|&j| (j as usize) < i);
-        for (&j, &v) in columns[split..]
-            .iter()
-            .zip(&elim_to_keep.data[start + split..end])
-        {
-            let j = j as usize;
+        let upper_start = columns.partition_point(|&j| (j as usize) < i);
+        for position in start + upper_start..end {
+            let j = elim_to_keep.indices[position] as usize;
+            let v = elim_to_keep.data[position];
             if work[j] == 0.0 && j != i {
                 touched.push(j);
             }
@@ -125,55 +127,55 @@ fn compute_schur_row_dense(
 }
 
 /// Extract non-zeros, keeping a numerically-zero diagonal so SDDM structure survives.
-fn extract_sparse_row(i: usize, work: &mut [f64], touched: &mut [usize]) -> (Vec<u32>, Vec<f64>) {
+fn extract_sparse_row(i: usize, work: &mut [f64], touched: &mut [usize]) -> UpperSchurRow {
     touched.sort_unstable();
-    let mut row_indices = Vec::with_capacity(touched.len());
-    let mut row_data = Vec::with_capacity(touched.len());
+    let mut columns = Vec::with_capacity(touched.len());
+    let mut values = Vec::with_capacity(touched.len());
     for &j in touched.iter() {
         let v = work[j];
         if v != 0.0 || j == i {
-            row_indices.push(to_u32(j));
-            row_data.push(v);
+            columns.push(to_u32(j));
+            values.push(v);
         }
         work[j] = 0.0;
     }
-    (row_indices, row_data)
+    UpperSchurRow { columns, values }
 }
 
 /// Assemble full rows from diagonal-and-upper parts; the strict upper mirrors into the lower.
-fn assemble_schur_csr(rows: Vec<(Vec<u32>, Vec<f64>)>, n_keep: usize) -> CsrMatrix {
-    let mut s_indptr = vec![0u32; n_keep + 1];
-    for (i, (ri, _)) in rows.iter().enumerate() {
-        s_indptr[i + 1] += to_u32(ri.len());
-        for &j in ri {
+fn assemble_schur_csr(rows: Vec<UpperSchurRow>, n_keep: usize) -> CsrMatrix {
+    let mut row_offsets = vec![0u32; n_keep + 1];
+    for (i, row) in rows.iter().enumerate() {
+        row_offsets[i + 1] += to_u32(row.columns.len());
+        for &j in &row.columns {
             if j as usize != i {
-                s_indptr[j as usize + 1] += 1;
+                row_offsets[j as usize + 1] += 1;
             }
         }
     }
     for i in 0..n_keep {
-        s_indptr[i + 1] += s_indptr[i];
+        row_offsets[i + 1] += row_offsets[i];
     }
-    let total_nnz = s_indptr[n_keep] as usize;
-    let mut s_indices = vec![0u32; total_nnz];
-    let mut s_data = vec![0.0f64; total_nnz];
+    let total_nnz = row_offsets[n_keep] as usize;
+    let mut column_indices = vec![0u32; total_nnz];
+    let mut values = vec![0.0f64; total_nnz];
 
     // Row layout: [mirrored lower | diagonal and upper]; ascending source rows keep it sorted.
-    let mut lower_cursor: Vec<u32> = s_indptr[..n_keep].to_vec();
-    for (i, (ri, rd)) in rows.into_iter().enumerate() {
-        let own = s_indptr[i + 1] as usize - ri.len();
-        s_indices[own..own + ri.len()].copy_from_slice(&ri);
-        s_data[own..own + rd.len()].copy_from_slice(&rd);
-        for (&j, &v) in ri.iter().zip(&rd) {
+    let mut lower_write_positions = row_offsets[..n_keep].to_vec();
+    for (i, row) in rows.into_iter().enumerate() {
+        let upper_start = row_offsets[i + 1] as usize - row.columns.len();
+        column_indices[upper_start..upper_start + row.columns.len()].copy_from_slice(&row.columns);
+        values[upper_start..upper_start + row.values.len()].copy_from_slice(&row.values);
+        for (&j, &v) in row.columns.iter().zip(&row.values) {
             if j as usize != i {
-                let pos = lower_cursor[j as usize] as usize;
-                s_indices[pos] = to_u32(i);
-                s_data[pos] = v;
-                lower_cursor[j as usize] += 1;
+                let position = lower_write_positions[j as usize] as usize;
+                column_indices[position] = to_u32(i);
+                values[position] = v;
+                lower_write_positions[j as usize] += 1;
             }
         }
     }
-    CsrMatrix::new(s_indptr, s_indices, s_data, n_keep)
+    CsrMatrix::new(row_offsets, column_indices, values, n_keep)
 }
 
 /// Edges sorted by `(lo, hi)` land both triangles in column order without per-row sorting.

--- a/crates/within/src/block_elim/schur/tests.rs
+++ b/crates/within/src/block_elim/schur/tests.rs
@@ -186,65 +186,26 @@ fn sampled_schur_carries_surplus_exactly_on_low_degree_stars() {
     }
 }
 
-/// Mirrored-lower CSR (#229, #282): every stored entry has a stored mirror with identical bits.
 #[test]
-fn exact_schur_csr_is_structurally_symmetric() {
-    let cancelling_signed_loadings = (
-        vec![
-            0.3, -1.7, 0.0, //
-            2.9, 0.7, 1.3, //
-            -0.11, 3.3, 5.1, //
-            1.9, 0.0, -2.3, //
-        ],
-        4,
-        3,
-        vec![3.0, 7.0, 0.9, 11.0, 13.7, 2.3, 19.1],
-    );
-    let ragged_with_zero_column_overlap = (
-        vec![
-            0.3, -1.7, 0.0, 0.9, //
-            2.9, 0.7, 1.3, 0.0, //
-            -0.11, 3.3, 5.1, -0.7, //
-            1.9, 0.0, -2.3, 0.4, //
-            0.0, 1.1, 0.0, -1.3, //
-        ],
-        5,
-        4,
-        vec![3.0, 7.0, 0.9, 11.0, 4.2, 13.7, 2.3, 19.1, 6.6],
-    );
+fn assemble_schur_csr_mirrors_upper_rows() {
+    let rows = vec![
+        UpperSchurRow {
+            columns: vec![0, 2],
+            values: vec![4.0, -1.25],
+        },
+        UpperSchurRow {
+            columns: vec![1, 2],
+            values: vec![5.0, -2.5],
+        },
+        UpperSchurRow {
+            columns: vec![2],
+            values: vec![6.0],
+        },
+    ];
 
-    for (c_dense, n_rows, n_cols, diagonal) in
-        [cancelling_signed_loadings, ragged_with_zero_column_overlap]
-    {
-        let (row_diag, _) = diagonal.split_at(n_rows);
-        let inv_diagonal: Vec<f64> = row_diag.iter().map(|d| 1.0 / d).collect();
-        for grounding in [Grounding::Grounded, Grounding::Floating] {
-            let operator = SddmMatrix::from_dense_for_test(
-                &c_dense,
-                n_rows,
-                n_cols,
-                diagonal.clone(),
-                grounding,
-            );
-            let complement = exact_for_factor(&operator, &inv_diagonal);
-            for i in 0..complement.n() {
-                let start = complement.indptr()[i] as usize;
-                let end = complement.indptr()[i + 1] as usize;
-                let row = &complement.indices()[start..end];
-                for (&j, &value) in row.iter().zip(&complement.data()[start..end]) {
-                    let j = j as usize;
-                    let js = complement.indptr()[j] as usize;
-                    let je = complement.indptr()[j + 1] as usize;
-                    let mirror_at = complement.indices()[js..je]
-                        .binary_search(&(i as u32))
-                        .unwrap_or_else(|_| panic!("{grounding:?}: ({i}, {j}) has no mirror"));
-                    assert_eq!(
-                        value.to_bits(),
-                        complement.data()[js + mirror_at].to_bits(),
-                        "{grounding:?}: mirror of ({i}, {j}) differs"
-                    );
-                }
-            }
-        }
-    }
+    let matrix = assemble_schur_csr(rows, 3);
+
+    assert_eq!(matrix.indptr(), &[0, 2, 4, 7]);
+    assert_eq!(matrix.indices(), &[0, 2, 1, 2, 0, 1, 2]);
+    assert_eq!(matrix.data(), &[4.0, -1.25, 5.0, -2.5, -1.25, -2.5, 6.0]);
 }

--- a/crates/within/src/block_elim/schur/tests.rs
+++ b/crates/within/src/block_elim/schur/tests.rs
@@ -186,25 +186,64 @@ fn sampled_schur_carries_surplus_exactly_on_low_degree_stars() {
     }
 }
 
-/// Signed loadings cancel past approx-chol's 8-ulp ingest tolerance, so this must be bitwise.
+/// Mirrored-lower CSR (#229, #282): every stored entry has a stored mirror with identical bits.
 #[test]
-fn exact_schur_triangles_agree_bitwise_on_signed_loadings() {
-    let c_dense = vec![
-        0.3, -1.7, 0.0, //
-        2.9, 0.7, 1.3, //
-        -0.11, 3.3, 5.1, //
-        1.9, 0.0, -2.3, //
-    ];
-    let diagonal = vec![3.0, 7.0, 0.9, 11.0, 13.7, 2.3, 19.1];
-    let (row_diag, _) = diagonal.split_at(4);
-    let inv_diagonal: Vec<f64> = row_diag.iter().map(|d| 1.0 / d).collect();
+fn exact_schur_csr_is_structurally_symmetric() {
+    let cancelling_signed_loadings = (
+        vec![
+            0.3, -1.7, 0.0, //
+            2.9, 0.7, 1.3, //
+            -0.11, 3.3, 5.1, //
+            1.9, 0.0, -2.3, //
+        ],
+        4,
+        3,
+        vec![3.0, 7.0, 0.9, 11.0, 13.7, 2.3, 19.1],
+    );
+    let ragged_with_zero_column_overlap = (
+        vec![
+            0.3, -1.7, 0.0, 0.9, //
+            2.9, 0.7, 1.3, 0.0, //
+            -0.11, 3.3, 5.1, -0.7, //
+            1.9, 0.0, -2.3, 0.4, //
+            0.0, 1.1, 0.0, -1.3, //
+        ],
+        5,
+        4,
+        vec![3.0, 7.0, 0.9, 11.0, 4.2, 13.7, 2.3, 19.1, 6.6],
+    );
 
-    for grounding in [Grounding::Grounded, Grounding::Floating] {
-        let operator = SddmMatrix::from_dense_for_test(&c_dense, 4, 3, diagonal.clone(), grounding);
-        let dense = sparse_to_dense(&exact_for_factor(&operator, &inv_diagonal));
-        for (i, row) in dense.iter().enumerate() {
-            for (j, &value) in row.iter().enumerate() {
-                assert_eq!(value, dense[j][i], "{grounding:?} asymmetric at ({i}, {j})");
+    for (c_dense, n_rows, n_cols, diagonal) in
+        [cancelling_signed_loadings, ragged_with_zero_column_overlap]
+    {
+        let (row_diag, _) = diagonal.split_at(n_rows);
+        let inv_diagonal: Vec<f64> = row_diag.iter().map(|d| 1.0 / d).collect();
+        for grounding in [Grounding::Grounded, Grounding::Floating] {
+            let operator = SddmMatrix::from_dense_for_test(
+                &c_dense,
+                n_rows,
+                n_cols,
+                diagonal.clone(),
+                grounding,
+            );
+            let complement = exact_for_factor(&operator, &inv_diagonal);
+            for i in 0..complement.n() {
+                let start = complement.indptr()[i] as usize;
+                let end = complement.indptr()[i + 1] as usize;
+                let row = &complement.indices()[start..end];
+                for (&j, &value) in row.iter().zip(&complement.data()[start..end]) {
+                    let j = j as usize;
+                    let js = complement.indptr()[j] as usize;
+                    let je = complement.indptr()[j + 1] as usize;
+                    let mirror_at = complement.indices()[js..je]
+                        .binary_search(&(i as u32))
+                        .unwrap_or_else(|_| panic!("{grounding:?}: ({i}, {j}) has no mirror"));
+                    assert_eq!(
+                        value.to_bits(),
+                        complement.data()[js + mirror_at].to_bits(),
+                        "{grounding:?}: mirror of ({i}, {j}) differs"
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
The dense exact Schur path now computes only the diagonal-and-upper part of each row and mirrors it at assembly, so approx-chol's symmetric-ingest contract holds by construction instead of by matched rounding. Bitwise-inert on current main and slightly cheaper (the scatter skips the strict lower triangle); a structural test pins the mirrored CSR.

The #282 reproduction does not fail on current main (48-run seed sweep clean); this removes the failure class regardless.

Rung 1 of 3 (#280–#282 ladder).

Closes #282