### PR TITLE
bench: AKM sorting/mobility ladder with shared slope covariates

### DIFF
--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -23,6 +23,7 @@ from ._framework import (
 from .suites import (  # noqa: F401
     ac_comparison,
     akm_panel,
+    akm_slopes,
     fixest_comparison,
     high_fe,
     many_components,

--- a/benchmarks/_framework.py
+++ b/benchmarks/_framework.py
@@ -21,7 +21,7 @@ from typing import Any, Callable, Literal, TypeVar
 import numpy as np
 from numpy.typing import NDArray
 
-from within import LsmrOptions, solve
+from within import Effect, LsmrOptions, solve
 from within._within import (
     AdditiveSchwarz,
     ApproxCholConfig,
@@ -75,6 +75,17 @@ class BenchmarkResult:
     demeaning_error: float = 0.0
     converged: bool = False
     passed: bool | None = None  # For correctness suites
+
+
+@dataclass(frozen=True)
+class SlopeCase:
+    """A varying-slopes benchmark problem: the ``Effect`` design to solve, the response,
+    and the bare factor codes the group-mean demean check needs."""
+
+    effects: list[Effect]
+    y: NDArray[np.float64]
+    categories: list[NDArray[np.uint32]]
+    n_levels: list[int]
 
 
 def max_abs_group_mean(

--- a/benchmarks/_problems.py
+++ b/benchmarks/_problems.py
@@ -7,6 +7,7 @@ Register new generators with ``@register_generator("key")``.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Callable
 
 import numpy as np
@@ -537,6 +538,114 @@ def simulate_mobility(
         assignments[:, t] = new_firms
 
     return assignments
+
+
+@dataclass(frozen=True)
+class AssortativeMobility:
+    """AKM assignment process: Pareto firm sizes rank-coupled to firm effects, assortative
+    worker-firm matching at strength ``sorting``, and job transitions at rate ``mobility``.
+
+    Adapted from bipartitepandas by Thibaut Lamadon, under the MIT License.
+    """
+
+    n_workers: int = 100_000
+    n_firms: int = 50_000
+    n_years: int = 10
+    n_industries: int = 5
+    var_alpha: float = 1.0
+    var_psi: float = 0.5
+    size_tail: float = 1.0
+    size_correlation: float = 0.6
+    sorting: float = 1.0
+    mobility: float = 0.1
+    own_industry_share: float = 0.8
+    # The match table is n_industries x n_match_bins x n_firms floats; 2048 bins is 2 GB.
+    n_match_bins: int = 64
+
+    def simulate(self, rng: np.random.Generator) -> NDArray[np.intp]:
+        """Firm id per worker-year, shape ``(n_workers, n_years)``."""
+        draws = np.clip(rng.random(self.n_firms), 1e-12, 1 - 1e-12)
+        sizes = np.exp(-np.log(draws) / self.size_tail)
+        psi = rng.normal(scale=np.sqrt(self.var_psi), size=self.n_firms)
+
+        rank = rng.standard_normal(self.n_firms)
+        size_rank = self.size_correlation * rank + np.sqrt(
+            max(0.0, 1 - self.size_correlation**2)
+        ) * rng.standard_normal(self.n_firms)
+        psi[np.argsort(rank)] = np.sort(psi)
+        firm_weights = np.empty(self.n_firms)
+        firm_weights[np.argsort(size_rank)] = np.sort(sizes)
+        firm_weights /= firm_weights.sum()
+
+        firm_industries = rng.permutation(np.arange(self.n_firms) % self.n_industries)
+        industry_weights = np.full(
+            (self.n_industries, self.n_firms),
+            (1 - self.own_industry_share) / (self.n_industries - 1),
+        )
+        for industry in range(self.n_industries):
+            industry_weights[industry, firm_industries == industry] = (
+                self.own_industry_share
+            )
+
+        alpha = rng.normal(scale=np.sqrt(self.var_alpha), size=self.n_workers)
+        n_bins = min(self.n_match_bins, self.n_workers)
+        match_bin = np.empty(self.n_workers, dtype=np.intp)
+        match_bin[np.argsort(alpha, kind="mergesort")] = (
+            np.arange(self.n_workers) * n_bins // self.n_workers
+        )
+        centers = np.array([alpha[match_bin == b].mean() for b in range(n_bins)])
+
+        tau2 = max(self.var_alpha + self.var_psi, 1e-12)
+        log_sizes = np.log(firm_weights)
+        cdfs = np.empty((self.n_industries, n_bins, self.n_firms), dtype=np.float32)
+        for industry in range(self.n_industries):
+            log_weights = log_sizes + np.log(industry_weights[industry])
+            for b, center in enumerate(centers):
+                log_scores = (
+                    -0.5 * self.sorting * (center - psi) ** 2 / tau2 + log_weights
+                )
+                # Strong sorting underflows every score, so shift before exponentiating.
+                scores = np.exp(log_scores - log_scores.max())
+                cdf = np.cumsum(scores / scores.sum(), dtype=np.float64)
+                cdf[-1] = 1.0
+                cdfs[industry, b] = cdf
+
+        worker_industries = rng.integers(0, self.n_industries, size=self.n_workers)
+        groups = {
+            (industry, b): np.flatnonzero(
+                (worker_industries == industry) & (match_bin == b)
+            )
+            for industry in range(self.n_industries)
+            for b in range(n_bins)
+        }
+
+        paths = np.empty((self.n_workers, self.n_years), dtype=np.intp)
+        for (industry, b), workers in groups.items():
+            paths[workers, 0] = np.searchsorted(
+                cdfs[industry, b], rng.random(len(workers)), side="right"
+            )
+        moves = rng.random((self.n_workers, self.n_years - 1)) < self.mobility
+        for year in range(1, self.n_years):
+            paths[:, year] = paths[:, year - 1]
+            for (industry, b), workers in groups.items():
+                movers = workers[moves[workers, year - 1]]
+                if not movers.size:
+                    continue
+                cdf = cdfs[industry, b]
+                current = paths[movers, year - 1]
+                drawn = np.searchsorted(cdf, rng.random(len(movers)), side="right")
+                for _ in range(8):
+                    stayed = drawn == current
+                    if not stayed.any():
+                        break
+                    drawn[stayed] = np.searchsorted(
+                        cdf, rng.random(int(stayed.sum())), side="right"
+                    )
+                # A transition must change firm; after eight rejections take the neighbour.
+                stayed = drawn == current
+                drawn[stayed] = (current[stayed] + 1) % self.n_firms
+                paths[movers, year] = drawn
+        return paths
 
 
 def find_largest_component(

--- a/benchmarks/suites/akm_slopes.py
+++ b/benchmarks/suites/akm_slopes.py
@@ -1,12 +1,13 @@
-"""AKM sorting/mobility ladder crossed with how two factors share a slope covariate.
+"""AKM sorting/mobility ladder crossed with how two factors' slope covariates relate.
 
 The worker-firm mover graph is swept along the two axes the AKM literature parameterizes —
 assortative sorting strength at full mobility, and the per-year move rate — and each panel is
-solved under four slope specifications: none, independent covariates, one covariate shared by
-both large factors, and that same covariate perturbed by 1e-3 on one side. A shared covariate
-puts a null direction across both terms' intercept and slope channels, so no factor-pair
-subdomain contains it; perturbing it trades that exact kernel for a tiny singular value, which
-is the harder regime.
+solved under five slope specifications: none, independent covariates, one covariate shared by
+both large factors, that covariate perturbed on one side, and the experience/tenure pair.
+Sharing a covariate puts a null direction across both terms' intercept and slope channels, so
+no factor-pair subdomain contains it. The last two arms sit just off that exact kernel by
+different routes: an injected epsilon fixes the offset directly, while experience minus tenure
+is constant within a job spell and differs only on movers, so mobility sets the offset.
 """
 
 from __future__ import annotations
@@ -32,7 +33,7 @@ from .._problems import AssortativeMobility, _make_response, _reindex
 from .._table import print_pivot, print_table
 
 SlopeColumns = Callable[
-    [NDArray[np.float64], np.random.Generator],
+    ["_MoverPanel", np.random.Generator],
     tuple[list[NDArray[np.float64]] | None, list[NDArray[np.float64]] | None],
 ]
 
@@ -43,30 +44,34 @@ CONDITIONING_TOL = 1e-12
 
 @dataclass(frozen=True)
 class _MoverPanel:
-    """One connected worker/firm/year panel, plus the year column used as a slope."""
+    """One worker/firm/year panel and the covariates the slope specifications draw on:
+    calendar year, experience (entry cohort + year), and tenure (years since the last move)."""
 
     codes: list[NDArray[np.uint32]]
     n_levels: list[int]
     year: NDArray[np.float64]
+    experience: NDArray[np.float64]
+    tenure: NDArray[np.float64]
 
 
 _SPECS: list[tuple[str, SlopeColumns]] = [
-    ("intercepts", lambda year, rng: (None, None)),
+    ("intercepts", lambda panel, rng: (None, None)),
     (
         "independent",
-        lambda year, rng: (
-            [rng.standard_normal(len(year))],
-            [rng.standard_normal(len(year))],
+        lambda panel, rng: (
+            [rng.standard_normal(len(panel.year))],
+            [rng.standard_normal(len(panel.year))],
         ),
     ),
-    ("shared_year", lambda year, rng: ([year], [year])),
+    ("shared_year", lambda panel, rng: ([panel.year], [panel.year])),
     (
         "near_shared_year",
-        lambda year, rng: (
-            [year],
-            [year + NEAR_SHARED_EPS * rng.standard_normal(len(year))],
+        lambda panel, rng: (
+            [panel.year],
+            [panel.year + NEAR_SHARED_EPS * rng.standard_normal(len(panel.year))],
         ),
     ),
+    ("experience_tenure", lambda panel, rng: ([panel.experience], [panel.tenure])),
 ]
 
 _LADDER: dict[str, AssortativeMobility] = {
@@ -81,7 +86,14 @@ def _mover_panel(n_obs: int, design: AssortativeMobility, seed: int) -> _MoverPa
     """Simulate *design* at roughly *n_obs* rows, keeping every component as the paper does."""
     n_workers = max(1, n_obs // design.n_years)
     sized = replace(design, n_workers=n_workers, n_firms=max(2, n_workers // 2))
-    assignments = sized.simulate(np.random.default_rng(seed))
+    rng = np.random.default_rng(seed)
+    assignments = sized.simulate(rng)
+
+    tenure = np.zeros((n_workers, sized.n_years))
+    for year in range(1, sized.n_years):
+        stayed = assignments[:, year] == assignments[:, year - 1]
+        tenure[:, year] = (tenure[:, year - 1] + 1.0) * stayed
+    entry_cohort = rng.integers(0, 30, size=n_workers)
 
     worker_ids = np.repeat(np.arange(n_workers, dtype=np.intp), sized.n_years)
     year_ids = np.tile(np.arange(sized.n_years, dtype=np.intp), n_workers)
@@ -89,10 +101,13 @@ def _mover_panel(n_obs: int, design: AssortativeMobility, seed: int) -> _MoverPa
         _reindex(ids).astype(np.uint32)
         for ids in (worker_ids, assignments.ravel(), year_ids)
     ]
+    year = year_ids.astype(np.float64)
     return _MoverPanel(
         codes,
         [int(c.max()) + 1 for c in codes],
-        year_ids.astype(np.float64),
+        year,
+        entry_cohort[worker_ids] + year,
+        tenure.ravel(),
     )
 
 
@@ -100,7 +115,7 @@ def _slope_case(panel: _MoverPanel, columns: SlopeColumns, seed: int) -> SlopeCa
     """Apply one slope specification to *panel*, generating a matching response."""
     rng = np.random.default_rng(seed)
     y = _make_response(panel.codes, panel.n_levels, rng)
-    worker_slopes, firm_slopes = columns(panel.year, rng)
+    worker_slopes, firm_slopes = columns(panel, rng)
     for factor, slopes in ((0, worker_slopes), (1, firm_slopes)):
         for z in slopes or ():
             gamma = 0.5 * rng.standard_normal(panel.n_levels[factor])

--- a/benchmarks/suites/akm_slopes.py
+++ b/benchmarks/suites/akm_slopes.py
@@ -1,0 +1,182 @@
+"""AKM sorting/mobility ladder crossed with how two factors share a slope covariate.
+
+The worker-firm mover graph is swept along the two axes the AKM literature parameterizes —
+assortative sorting strength at full mobility, and the per-year move rate — and each panel is
+solved under four slope specifications: none, independent covariates, one covariate shared by
+both large factors, and that same covariate perturbed by 1e-3 on one side. A shared covariate
+puts a null direction across both terms' intercept and slope channels, so no factor-pair
+subdomain contains it; perturbing it trades that exact kernel for a tiny singular value, which
+is the harder regime.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Callable
+
+import numpy as np
+from numpy.typing import NDArray
+
+from within import Effect, LsmrOptions, solve
+
+from .._framework import (
+    BenchmarkResult,
+    SlopeCase,
+    SolverConfig,
+    SuiteOptions,
+    make_additive_schwarz,
+    max_abs_group_mean,
+    suite,
+)
+from .._problems import AssortativeMobility, _make_response, _reindex
+from .._table import print_pivot, print_table
+
+SlopeColumns = Callable[
+    [NDArray[np.float64], np.random.Generator],
+    tuple[list[NDArray[np.float64]] | None, list[NDArray[np.float64]] | None],
+]
+
+NEAR_SHARED_EPS = 1e-3
+# benchmark_lsmr's 1e-7 floor hides the penalty: shared_year is 23 iters there, 261 at 1e-12.
+CONDITIONING_TOL = 1e-12
+
+
+@dataclass(frozen=True)
+class _MoverPanel:
+    """One connected worker/firm/year panel, plus the year column used as a slope."""
+
+    codes: list[NDArray[np.uint32]]
+    n_levels: list[int]
+    year: NDArray[np.float64]
+
+
+_SPECS: list[tuple[str, SlopeColumns]] = [
+    ("intercepts", lambda year, rng: (None, None)),
+    (
+        "independent",
+        lambda year, rng: (
+            [rng.standard_normal(len(year))],
+            [rng.standard_normal(len(year))],
+        ),
+    ),
+    ("shared_year", lambda year, rng: ([year], [year])),
+    (
+        "near_shared_year",
+        lambda year, rng: (
+            [year],
+            [year + NEAR_SHARED_EPS * rng.standard_normal(len(year))],
+        ),
+    ),
+]
+
+_LADDER: dict[str, AssortativeMobility] = {
+    "mobility=1.0": AssortativeMobility(mobility=1.0),
+    "mobility=0.05": AssortativeMobility(mobility=0.05),
+    "mobility=0.001": AssortativeMobility(mobility=0.001),
+    "sorting=1e4": AssortativeMobility(mobility=1.0, sorting=10_000.0),
+}
+
+
+def _mover_panel(n_obs: int, design: AssortativeMobility, seed: int) -> _MoverPanel:
+    """Simulate *design* at roughly *n_obs* rows, keeping every component as the paper does."""
+    n_workers = max(1, n_obs // design.n_years)
+    sized = replace(design, n_workers=n_workers, n_firms=max(2, n_workers // 2))
+    assignments = sized.simulate(np.random.default_rng(seed))
+
+    worker_ids = np.repeat(np.arange(n_workers, dtype=np.intp), sized.n_years)
+    year_ids = np.tile(np.arange(sized.n_years, dtype=np.intp), n_workers)
+    codes = [
+        _reindex(ids).astype(np.uint32)
+        for ids in (worker_ids, assignments.ravel(), year_ids)
+    ]
+    return _MoverPanel(
+        codes,
+        [int(c.max()) + 1 for c in codes],
+        year_ids.astype(np.float64),
+    )
+
+
+def _slope_case(panel: _MoverPanel, columns: SlopeColumns, seed: int) -> SlopeCase:
+    """Apply one slope specification to *panel*, generating a matching response."""
+    rng = np.random.default_rng(seed)
+    y = _make_response(panel.codes, panel.n_levels, rng)
+    worker_slopes, firm_slopes = columns(panel.year, rng)
+    for factor, slopes in ((0, worker_slopes), (1, firm_slopes)):
+        for z in slopes or ():
+            gamma = 0.5 * rng.standard_normal(panel.n_levels[factor])
+            y += z * gamma[panel.codes[factor]]
+
+    effects = [
+        Effect(panel.codes[0], True, worker_slopes),
+        Effect(panel.codes[1], True, firm_slopes),
+        Effect(panel.codes[2], True, None),
+    ]
+    return SlopeCase(effects, y, panel.codes, panel.n_levels)
+
+
+@suite(
+    "akm_slopes",
+    description="AKM sorting/mobility ladder x shared vs independent slope covariates",
+    tags=("slopes", "akm", "3fe", "conditioning"),
+)
+def run_akm_slopes(opts: SuiteOptions) -> list[BenchmarkResult]:
+    n_obs_list = opts.select(
+        smoke=[100_000], iterate=[100_000], full=[100_000, 1_000_000]
+    )
+    designs = opts.select(
+        smoke=["mobility=1.0", "mobility=0.05"],
+        iterate=["mobility=1.0", "mobility=0.05", "mobility=0.001"],
+        full=list(_LADDER),
+    )
+    cfg = SolverConfig(
+        "LSMR(Schwarz)",
+        LsmrOptions(
+            tol=min(opts.tol, CONDITIONING_TOL), maxiter=max(opts.maxiter, 20_000)
+        ),
+        preconditioner=make_additive_schwarz(local_solver=None),
+    )
+
+    results: list[BenchmarkResult] = []
+    for n_obs in n_obs_list:
+        for design_name in designs:
+            panel = _mover_panel(n_obs, _LADDER[design_name], opts.seed)
+            for spec_name, columns in _SPECS:
+                case = _slope_case(panel, columns, opts.seed)
+                name = f"n={n_obs:,} {design_name} {spec_name}"
+                print(f"\n  {name}: Rows={len(case.y):,}")
+                try:
+                    r = solve(
+                        case.effects,
+                        case.y,
+                        options=cfg.config,
+                        preconditioner=cfg.preconditioner,
+                    )
+                except Exception as e:  # noqa: BLE001 - report and continue the sweep
+                    print(f"    WARNING: {cfg.label} failed: {e}")
+                    continue
+                results.append(
+                    BenchmarkResult(
+                        problem=name,
+                        config=cfg.label,
+                        n_dofs=len(r.x),
+                        n_rows=len(case.y),
+                        setup_time=r.time_setup,
+                        solve_time=r.time_solve,
+                        iterations=r.iterations,
+                        final_residual=r.residual,
+                        demeaning_error=max_abs_group_mean(
+                            case.categories, case.n_levels, r.demeaned
+                        ),
+                        converged=r.converged,
+                    )
+                )
+
+    print_table(results)
+    print_table(
+        results,
+        columns=["config", "setup_time", "solve_time", "iterations", "ms_per_iter"],
+        title="Per-iteration cost",
+    )
+    print("\n")
+    print_pivot(results)
+    return results

--- a/benchmarks/suites/slopes.py
+++ b/benchmarks/suites/slopes.py
@@ -10,7 +10,6 @@ varying-slopes conditioning is known to bite.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Callable
 
 import numpy as np
@@ -20,6 +19,7 @@ from within import Effect, solve
 
 from .._framework import (
     BenchmarkResult,
+    SlopeCase,
     SolverConfig,
     SuiteOptions,
     benchmark_lsmr,
@@ -38,18 +38,7 @@ from .._problems import (
 from .._table import print_pivot, print_table
 
 
-@dataclass(frozen=True)
-class _SlopeCase:
-    """A varying-slopes benchmark problem: the ``Effect`` design to solve, the
-    response, and the bare factor codes the group-mean demean check needs."""
-
-    effects: list[Effect]
-    y: NDArray[np.float64]
-    categories: list[NDArray[np.uint32]]
-    n_levels: list[int]
-
-
-def _fixest_slopes(n_obs: int, dgp_type: str, n_slopes: int, seed: int) -> _SlopeCase:
+def _fixest_slopes(n_obs: int, dgp_type: str, n_slopes: int, seed: int) -> SlopeCase:
     """Worker×year×firm panel; the worker factor carries ``n_slopes`` slopes.
 
     ``dgp_type`` is ``"simple"`` (i.i.d. firms, well-connected) or
@@ -70,10 +59,10 @@ def _fixest_slopes(n_obs: int, dgp_type: str, n_slopes: int, seed: int) -> _Slop
         Effect(codes[1], True, None),
         Effect(codes[2], True, None),
     ]
-    return _SlopeCase(effects, y, codes, n_levels)
+    return SlopeCase(effects, y, codes, n_levels)
 
 
-def _akm_slopes(n_obs: int, slope_vars: str, seed: int) -> _SlopeCase:
+def _akm_slopes(n_obs: int, slope_vars: str, seed: int) -> SlopeCase:
     """AKM mobility panel (Zipf firms, clustered low mobility, largest component)
     with structured slopes derived from the mobility process:
 
@@ -146,10 +135,10 @@ def _akm_slopes(n_obs: int, slope_vars: str, seed: int) -> _SlopeCase:
         Effect(codes[1], True, [ten_obs] if with_ten else None),
         Effect(codes[2], True, None),
     ]
-    return _SlopeCase(effects, y, codes, n_levels)
+    return SlopeCase(effects, y, codes, n_levels)
 
 
-_CASES: list[tuple[str, Callable[[int, int], _SlopeCase]]] = [
+_CASES: list[tuple[str, Callable[[int, int], SlopeCase]]] = [
     ("fixest_simple_v1", lambda n, s: _fixest_slopes(n, "simple", 1, s)),
     ("fixest_simple_v3", lambda n, s: _fixest_slopes(n, "simple", 3, s)),
     ("fixest_difficult_v1", lambda n, s: _fixest_slopes(n, "difficult", 1, s)),


### PR DESCRIPTION
Ports the AKM data-generating process from the `within-paper` repo into the benchmark suite: Pareto firm sizes rank-coupled to firm effects, match-bin assortative assignment, industry preference, and year-by-year moves. Both ladders the AKM literature sweeps — sorting strength and move rate — are single-field variations of one frozen `AssortativeMobility` description.

The new `akm_slopes` suite crosses that ladder with four slope specifications: none, independent covariates, one covariate shared by both large factors (`indiv_id[year] + firm_id[year] + year`), and that covariate perturbed on one side. The existing `slopes` suite only carries independent per-factor slopes, so the shared-direction regime was previously unreachable.

Three choices worth review:

- Match scores accumulate in log space with a max-shift — at high sorting strength every score underflows to zero.
- `n_match_bins` defaults to 64, not the paper's 2048: the match table is `n_industries x n_match_bins x n_firms`, which is 2 GB at 2048.
- The suite floors its tolerance at 1e-12 rather than going through `benchmark_lsmr`. At the framework's `BENCHMARK_SOLVER_TOL_MIN` of 1e-7 the shared arm costs fewer iterations than the independent one, inverting the comparison the suite exists to make.

Every rung keeps all components, as the paper does; pruning to the largest component collapsed the low-mobility rung to 8 firms.

`SlopeCase` moves to `_framework` so both slope suites share one carrier; `slopes` is otherwise unchanged.