### PR TITLE
fix(bench): repair the akm_slopes suite against the PreconditionerConfig union

### DIFF
--- a/benchmarks/suites/akm_slopes.py
+++ b/benchmarks/suites/akm_slopes.py
@@ -18,14 +18,13 @@ from typing import Callable
 import numpy as np
 from numpy.typing import NDArray
 
-from within import Effect, LsmrOptions, solve
+from within import Effect, LsmrOptions, PreconditionerConfig, solve
 
 from .._framework import (
     BenchmarkResult,
     SlopeCase,
     SolverConfig,
     SuiteOptions,
-    make_additive_schwarz,
     max_abs_group_mean,
     suite,
 )
@@ -148,7 +147,7 @@ def run_akm_slopes(opts: SuiteOptions) -> list[BenchmarkResult]:
         LsmrOptions(
             tol=min(opts.tol, CONDITIONING_TOL), maxiter=max(opts.maxiter, 20_000)
         ),
-        preconditioner=make_additive_schwarz(local_solver=None),
+        preconditioner=PreconditionerConfig.Additive(),
     )
 
     results: list[BenchmarkResult] = []


### PR DESCRIPTION
`make_additive_schwarz(local_solver=None)` has raised `TypeError` since #274's tagged union landed, so the `akm_slopes` suite has not run since. #289 added the suite and #274 converted the API independently, and it was the last `None` caller — every other call site passes a real config.

Split out of #291, where it was committed but missed the merge.