### PR TITLE
Encapsulate design.frame

### DIFF
--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -145,7 +145,7 @@ fn stable_argsort(key: &[u32], n_levels: usize) -> Vec<u32> {
 #[derive(Clone, Debug)]
 pub struct Design<'a> {
     /// Columns in internal row order (caller's, or an owned locality-sorted copy).
-    pub(crate) frame: ObservationFrame<'a>,
+    frame: ObservationFrame<'a>,
     pub(crate) terms: Vec<TermMeta>,
     pub(crate) n_obs: usize,
     pub(crate) n_dofs: usize,
@@ -320,6 +320,21 @@ impl<'a> Design<'a> {
         self.terms[channel.term].columns[channel.column]
     }
 
+    /// Level codes for one term, in internal observation order.
+    pub(crate) fn level_column(&self, term: usize) -> &[u32] {
+        self.frame.level_column(term)
+    }
+
+    /// Continuous loading column in internal observation order.
+    pub(crate) fn loading_column(&self, column: usize) -> &[f64] {
+        self.frame.loading_column(column)
+    }
+
+    /// Replace one loading column during solver-local preparation.
+    pub(crate) fn replace_loading_column(&mut self, column: usize, values: Vec<f64>) {
+        self.frame.set_loading_column(column, values);
+    }
+
     /// Number of observations (rows of D).
     #[inline]
     pub fn n_obs(&self) -> usize {
@@ -443,8 +458,8 @@ mod tests {
         // Factor 1's permuted column [0,1,1,0] is no longer non-decreasing.
         assert!(!design.terms[1].sorted);
 
-        assert_eq!(design.frame.level_column(0), [0, 0, 1, 2]);
-        assert_eq!(design.frame.level_column(1), [0, 1, 1, 0]);
+        assert_eq!(design.level_column(0), [0, 0, 1, 2]);
+        assert_eq!(design.level_column(1), [0, 1, 1, 0]);
     }
 
     #[test]
@@ -477,8 +492,8 @@ mod tests {
 
         let perm = design.obs_perm.as_ref().expect("permutation applied");
         assert_eq!(perm, &[1, 3, 2, 0]);
-        assert_eq!(design.frame.level_column(0), [0, 0, 1, 2]);
-        assert_eq!(design.frame.loading_column(0), [20.0, 40.0, 30.0, 10.0]);
+        assert_eq!(design.level_column(0), [0, 0, 1, 2]);
+        assert_eq!(design.loading_column(0), [20.0, 40.0, 30.0, 10.0]);
     }
 
     #[test]
@@ -515,7 +530,7 @@ mod tests {
             ]
         );
         assert_eq!(&*design.terms[2].columns, &[Loading::Covariate(2)]);
-        assert_eq!(design.frame.loading_column(0), &z0[..]);
-        assert_eq!(design.frame.loading_column(2), &z1[..]);
+        assert_eq!(design.loading_column(0), &z0[..]);
+        assert_eq!(design.loading_column(2), &z1[..]);
     }
 }

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -70,15 +70,15 @@ fn residual_shares(
         return Vec::new();
     }
     let moments = &moments[term];
-    let levels = design.frame.level_column(term);
+    let levels = design.level_column(term);
     let zs: Vec<&[f64]> = moments
         .covariates()
         .iter()
-        .map(|&c| design.frame.loading_column(c as usize))
+        .map(|&c| design.loading_column(c as usize))
         .collect();
     let columns: Vec<&[f64]> = targets
         .iter()
-        .map(|&(_, c)| design.frame.loading_column(c as usize))
+        .map(|&(_, c)| design.loading_column(c as usize))
         .collect();
     let stride = columns.len() * (zs.len() + 1);
     let n_levels = moments.n_levels();

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -30,7 +30,7 @@ pub(crate) fn find_all_active_levels(design: &Design<'_>) -> Vec<Vec<bool>> {
         .collect();
     // Factor-outer/obs-inner: all writes for a factor land in one `active[f]` buffer.
     for (f, col) in active.iter_mut().enumerate() {
-        for &v in design.frame.level_column(f) {
+        for &v in design.level_column(f) {
             col[v as usize] = true;
         }
     }

--- a/crates/within/src/domain/cross_tab/accumulate.rs
+++ b/crates/within/src/domain/cross_tab/accumulate.rs
@@ -95,12 +95,10 @@ pub(super) fn accumulate_cross_block(
     let sparse_cost = design.n_obs.saturating_mul(12);
     let go_sparse = table_size > DENSE_TABLE_MAX_ENTRIES && sparse_cost < dense_cost;
 
-    let row_levels = design.frame.level_column(pair.rows.term);
-    let col_levels = design.frame.level_column(pair.cols.term);
-    let load = |col: ColumnLoading<u32>| {
-        col.covariate()
-            .map(|&c| design.frame.loading_column(c as usize))
-    };
+    let row_levels = design.level_column(pair.rows.term);
+    let col_levels = design.level_column(pair.cols.term);
+    let load =
+        |col: ColumnLoading<u32>| col.covariate().map(|&c| design.loading_column(c as usize));
     // One arm per loading combination; closures aren't generic, so the literals repeat.
     match (
         load(design.loading(pair.rows)),

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -328,9 +328,9 @@ fn dense_and_sparse_paths_agree_on_signed_data() {
     .expect("both factors have active levels");
 
     let cols = PairColumns {
-        row_levels: design.frame.level_column(0),
-        col_levels: design.frame.level_column(1),
-        row_load: design.frame.loading_column(0),
+        row_levels: design.level_column(0),
+        col_levels: design.level_column(1),
+        row_load: design.loading_column(0),
         col_load: Unit,
         weights: None,
     };

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -78,11 +78,11 @@ impl LevelMoments {
         let zs: Vec<&[f64]> = moments
             .covariates
             .iter()
-            .map(|&c| design.frame.loading_column(c as usize))
+            .map(|&c| design.loading_column(c as usize))
             .collect();
         let mut z_row = vec![0.0; v];
         let mut delta = vec![0.0; v];
-        for (obs, &level) in design.frame.level_column(term).iter().enumerate() {
+        for (obs, &level) in design.level_column(term).iter().enumerate() {
             for (zr, col) in z_row.iter_mut().zip(&zs) {
                 *zr = col[obs];
             }

--- a/crates/within/src/operator/design/gather.rs
+++ b/crates/within/src/operator/design/gather.rs
@@ -19,34 +19,33 @@ pub(crate) fn gather_apply(
 
     dst.fill(0.0);
 
-    let frame = &design.frame;
     for_each_chunk(dst, |chunk, row_start| {
         for (q, t) in design.terms.iter().enumerate() {
             let (offset, n_levels) = (t.offset, t.n_levels);
-            let levels = frame.level_column(q);
+            let levels = design.level_column(q);
             let col = |c: usize| &src[offset + c * n_levels..offset + (c + 1) * n_levels];
             match &*t.columns {
                 [Loading::Constant] => gather_term(chunk, row_start, levels, [col(0)], |_| [1.0]),
                 [Loading::Constant, Loading::Covariate(c0)] => {
-                    let z0 = frame.loading_column(*c0 as usize);
+                    let z0 = design.loading_column(*c0 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1)], |i| [1.0, z0[i]])
                 }
                 [Loading::Constant, Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                    let z0 = frame.loading_column(*c0 as usize);
-                    let z1 = frame.loading_column(*c1 as usize);
+                    let z0 = design.loading_column(*c0 as usize);
+                    let z1 = design.loading_column(*c1 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1), col(2)], |i| {
                         [1.0, z0[i], z1[i]]
                     })
                 }
                 [Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                    let z0 = frame.loading_column(*c0 as usize);
-                    let z1 = frame.loading_column(*c1 as usize);
+                    let z0 = design.loading_column(*c0 as usize);
+                    let z1 = design.loading_column(*c1 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1)], |i| {
                         [z0[i], z1[i]]
                     })
                 }
                 [Loading::Covariate(c0)] => {
-                    let z0 = frame.loading_column(*c0 as usize);
+                    let z0 = design.loading_column(*c0 as usize);
                     gather_term(chunk, row_start, levels, [col(0)], |i| [z0[i]])
                 }
                 columns => {
@@ -60,7 +59,7 @@ pub(crate) fn gather_apply(
                             acc += match loading {
                                 Loading::Constant => coef,
                                 Loading::Covariate(k) => {
-                                    coef * frame.loading_column(*k as usize)[i]
+                                    coef * design.loading_column(*k as usize)[i]
                                 }
                             };
                         }

--- a/crates/within/src/operator/design/scatter.rs
+++ b/crates/within/src/operator/design/scatter.rs
@@ -19,33 +19,32 @@ pub(super) fn scatter_apply(
 ) {
     debug_assert_eq!(dst.len(), design.n_dofs);
     let parallel = design.n_obs > PAR_THRESHOLD;
-    let frame = &design.frame;
 
     for (q, t) in design.terms.iter().enumerate() {
-        let levels = frame.level_column(q);
+        let levels = design.level_column(q);
         let block = &mut dst[t.offset..t.offset + t.n_dofs()];
         match &*t.columns {
             [Loading::Constant] => {
                 scatter_term::<1>(block, t, levels, parallel, scratch, |i| [base(i)])
             }
             [Loading::Constant, Loading::Covariate(c0)] => {
-                let z0 = frame.loading_column(*c0 as usize);
+                let z0 = design.loading_column(*c0 as usize);
                 scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [b, z0[i] * b]
                 })
             }
             [Loading::Constant, Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                let z0 = frame.loading_column(*c0 as usize);
-                let z1 = frame.loading_column(*c1 as usize);
+                let z0 = design.loading_column(*c0 as usize);
+                let z1 = design.loading_column(*c1 as usize);
                 scatter_term::<3>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [b, z0[i] * b, z1[i] * b]
                 })
             }
             [Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                let z0 = frame.loading_column(*c0 as usize);
-                let z1 = frame.loading_column(*c1 as usize);
+                let z0 = design.loading_column(*c0 as usize);
+                let z1 = design.loading_column(*c1 as usize);
                 scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [z0[i] * b, z1[i] * b]
@@ -60,7 +59,7 @@ pub(super) fn scatter_apply(
                             scatter_term::<1>(slot, t, levels, parallel, scratch, |i| [base(i)]);
                         }
                         Loading::Covariate(k) => {
-                            let z = frame.loading_column(*k as usize);
+                            let z = design.loading_column(*k as usize);
                             scatter_term::<1>(slot, t, levels, parallel, scratch, move |i| {
                                 [z[i] * base(i)]
                             });

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -305,13 +305,13 @@ mod slope_design_tests {
     fn dense_matrix(design: &Design<'_>) -> Vec<Vec<f64>> {
         let mut d = vec![vec![0.0; design.n_dofs]; design.n_obs];
         for (q, t) in design.terms.iter().enumerate() {
-            let levels = design.frame.level_column(q);
+            let levels = design.level_column(q);
             for (c, loading) in t.columns.iter().enumerate() {
                 let base = t.offset + c * t.n_levels;
                 for (i, &lev) in levels.iter().enumerate() {
                     d[i][base + lev as usize] = match loading {
                         Loading::Constant => 1.0,
-                        Loading::Covariate(k) => design.frame.loading_column(*k as usize)[i],
+                        Loading::Covariate(k) => design.loading_column(*k as usize)[i],
                     };
                 }
             }

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -217,7 +217,7 @@ fn build_diagonal(
     let mut diag = vec![0.0; design.n_dofs];
 
     for (factor_idx, term) in design.terms.iter().enumerate() {
-        let levels = design.frame.level_column(factor_idx);
+        let levels = design.level_column(factor_idx);
         let w = |uid: usize| weights.map_or(1.0, |ws| ws[uid]);
         for (column, loading) in term.columns.iter().enumerate() {
             let base = term.column_base(column);
@@ -229,7 +229,7 @@ fn build_diagonal(
                     }
                 }
                 Loading::Covariate(z_col) => {
-                    let z = design.frame.loading_column(*z_col as usize);
+                    let z = design.loading_column(*z_col as usize);
                     for (uid, &level) in levels.iter().enumerate() {
                         // Keep `w * z * z` left-to-right: a zero weight kills a huge `z` first.
                         slice[level as usize] += w(uid) * z[uid] * z[uid];

--- a/crates/within/src/solver/reparam.rs
+++ b/crates/within/src/solver/reparam.rs
@@ -93,11 +93,8 @@ impl TermReparam {
         let moments = &moments[term];
         let v = moments.n_slopes();
         let z_cols: Vec<usize> = moments.covariates().iter().map(|&c| c as usize).collect();
-        let levels = design.frame.level_column(term);
-        let zs: Vec<&[f64]> = z_cols
-            .iter()
-            .map(|&c| design.frame.loading_column(c))
-            .collect();
+        let levels = design.level_column(term);
+        let zs: Vec<&[f64]> = z_cols.iter().map(|&c| design.loading_column(c)).collect();
 
         let mut z_row = vec![0.0; v];
         let mut transforms = Vec::with_capacity(n_levels);
@@ -144,7 +141,7 @@ impl TermReparam {
             }
         }
         for (out, &c) in u_cols.into_iter().zip(&z_cols) {
-            design.frame.set_loading_column(c, out);
+            design.replace_loading_column(c, out);
         }
 
         Self {

--- a/crates/within/src/solver/reparam/tests.rs
+++ b/crates/within/src/solver/reparam/tests.rs
@@ -33,12 +33,12 @@ fn build_whitens_each_slope_bearing_term() {
 
     for term in [0, 2] {
         let meta = &design.terms[term];
-        let levels = design.frame.level_column(term);
+        let levels = design.level_column(term);
         let us: Vec<&[f64]> = meta
             .columns
             .iter()
             .filter_map(|c| c.covariate())
-            .map(|&k| design.frame.loading_column(k as usize))
+            .map(|&k| design.loading_column(k as usize))
             .collect();
         for level in 0..meta.n_levels {
             let obs: Vec<usize> = (0..levels.len())


### PR DESCRIPTION
This PR is an intermediate step in preparation for the internal factor encoding #268 and the persistent `Design` API #269.

The only change is that `Design.frame` is made private with public methods for `level_column`, `loading_column`, and `replace_loading_column`. No functionality is changed.