### PR TITLE
Add internal FactorEncoding

### DIFF
--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -15,11 +15,10 @@ pub(crate) use factor_pairs::{
     SddmMatrix,
 };
 
-use std::borrow::Cow;
-
 use crate::channel::Channel;
 use crate::observation::ObservationFrame;
 use crate::BuildError;
+use std::borrow::Cow;
 
 /// A slice that is guaranteed non-empty by construction.
 #[repr(transparent)]
@@ -81,7 +80,8 @@ impl<T> Loading<T> {
 /// Per-term metadata; coefficient `c` of `level` lives at `offset + c · n_levels + level`.
 #[derive(Debug, Clone)]
 pub(crate) struct TermMeta {
-    pub n_levels: usize,
+    /// Caller-visible labels indexed by compact internal level code.
+    pub level_labels: Box<[u32]>,
     pub offset: usize,
     /// Non-decreasing in the design's internal row order (fixed at construction).
     pub sorted: bool,
@@ -90,25 +90,73 @@ pub(crate) struct TermMeta {
 }
 
 impl TermMeta {
+    pub fn n_levels(&self) -> usize {
+        self.level_labels.len()
+    }
+
     pub fn n_columns(&self) -> usize {
         self.columns.len()
     }
 
     pub fn n_dofs(&self) -> usize {
-        self.n_columns() * self.n_levels
+        self.n_columns() * self.n_levels()
     }
 
     /// Global DOF base of coefficient column `column`.
     pub fn column_base(&self, column: usize) -> usize {
-        self.offset + column * self.n_levels
+        self.offset + column * self.n_levels()
+    }
+}
+
+struct FactorEncoding {
+    /// `None` when the caller codes are already contiguous and need no rewrite
+    codes: Option<Vec<u32>>,
+    /// Caller-visible labels in compact-code order.
+    labels: Box<[u32]>,
+}
+
+impl FactorEncoding {
+    fn new(levels: &[u32]) -> Self {
+        let mut labels = levels.to_vec();
+        labels.sort_unstable();
+        labels.dedup();
+
+        // Check whether labels are already compact
+        let is_compact = labels
+            .iter()
+            .enumerate()
+            .all(|(code, &label)| label == code as u32);
+
+        let codes = if is_compact {
+            // Nothing to encode
+            None
+        } else {
+            // Encode
+            let mut codes = Vec::with_capacity(levels.len());
+
+            for label in levels {
+                let code = labels
+                    .binary_search(label)
+                    .expect("labels were collected from this factor");
+                let code = u32::try_from(code)
+                    .expect("a u32-labelled factor cannot have an unrepresentable compact code");
+                codes.push(code);
+            }
+            Some(codes)
+        };
+
+        FactorEncoding {
+            codes,
+            labels: labels.into_boxed_slice(),
+        }
     }
 }
 
 /// Stable argsort of observations by a level column, ascending.
 ///
 /// Dense counting sort in `O(n_obs + n_levels)` or sparse comparison sort — same
-/// permutation either way, gated as in `schur::sort_and_dedup`. Gappy caller codes
-/// can span far more levels than rows, where the bucket array outgrows the output.
+/// permutation either way, gated as in `schur::sort_and_dedup`. Preprocessing can
+/// leave more encoded levels than rows, where the bucket array outgrows the output.
 fn stable_argsort(key: &[u32], n_levels: usize) -> Vec<u32> {
     let n_obs = key.len();
     debug_assert!(
@@ -172,7 +220,8 @@ impl<'a> Design<'a> {
         Self::build(frame, structure, true)
     }
 
-    /// Intercept-only factors, level count `max + 1`; locality-sorts an unsorted dominant factor.
+    /// Intercept-only factors, compacted in ascending label order; locality-sorts
+    /// an unsorted dominant factor.
     pub fn from_frame(frame: ObservationFrame<'a>) -> Result<Self, BuildError> {
         let structure = vec![NonEmpty::of(Loading::Constant); frame.n_factors()];
         Self::build(frame, structure, true)
@@ -196,25 +245,35 @@ impl<'a> Design<'a> {
         }
         debug_assert_eq!(column_structure.len(), frame.n_factors());
 
+        let mut encoded_factors = Vec::with_capacity(frame.n_factors());
+        let mut labels_by_factor = Vec::with_capacity(frame.n_factors());
+
+        for factor in 0..frame.n_factors() {
+            let FactorEncoding { codes, labels } = FactorEncoding::new(frame.level_column(factor));
+
+            encoded_factors.push(codes);
+            labels_by_factor.push(labels);
+        }
+
+        let frame = frame.with_encoded_factors(encoded_factors);
+
         let n_obs = frame.n_obs();
         let mut terms = Vec::with_capacity(frame.n_factors());
         let mut offset = 0;
-        for (q, columns) in column_structure.into_iter().enumerate() {
+        for ((q, columns), level_labels) in column_structure
+            .into_iter()
+            .enumerate()
+            .zip(labels_by_factor)
+        {
             let col = frame.level_column(q);
-            let mut max = 0;
-            let mut sorted = true;
-            let mut prev = 0;
-            for &v in col {
-                max = max.max(v);
-                sorted &= v >= prev;
-                prev = v;
-            }
+
             let meta = TermMeta {
-                n_levels: max as usize + 1,
+                level_labels,
                 offset,
-                sorted,
+                sorted: col.is_sorted(),
                 columns,
             };
+
             offset += meta.n_dofs();
             terms.push(meta);
         }
@@ -228,7 +287,7 @@ impl<'a> Design<'a> {
         let dominant = (0..terms.len()).max_by_key(|&q| terms[q].n_dofs());
         let (frame, obs_perm) = match dominant {
             Some(d) if locality_sort && !terms[d].sorted && u32::try_from(n_obs).is_ok() => {
-                let perm = stable_argsort(frame.level_column(d), terms[d].n_levels);
+                let perm = stable_argsort(frame.level_column(d), terms[d].n_levels());
                 let sorted_frame = frame.permuted(&perm);
                 // Factors nested in the dominant one come out sorted, keeping coalesced scatter.
                 for (q, meta) in terms.iter_mut().enumerate() {
@@ -409,13 +468,28 @@ mod tests {
     }
 
     #[test]
-    fn build_rejects_dof_space_exceeding_u32() {
-        // A single code of u32::MAX implies one level past the CSR column-index width.
-        let err = Design::from_frame(frame(vec![vec![u32::MAX]], vec![])).unwrap_err();
-        assert!(matches!(
-            err,
-            BuildError::DofSpaceExceedsU32 { n_dofs } if n_dofs == u32::MAX as usize + 1
-        ));
+    fn gappy_codes_are_compacted_in_numeric_label_order() {
+        // Caller labels [10, 20, 30] map to compact codes [0, 1, 2].
+        // The raw observation codes are therefore [2, 0, 1, 0].
+        let design = Design::from_frame(frame(vec![vec![30, 10, 20, 10]], vec![])).unwrap();
+
+        assert_eq!(design.terms[0].n_levels(), 3);
+        assert_eq!(&*design.terms[0].level_labels, &[10, 20, 30]);
+        assert_eq!(design.n_dofs(), 3);
+
+        // Locality sorting by the compact codes uses original rows [1, 3, 2, 0].
+        assert_eq!(design.obs_perm.as_deref(), Some(&[1u32, 3, 2, 0][..]));
+        assert_eq!(design.level_column(0), [0, 0, 1, 2]);
+    }
+
+    #[test]
+    fn maximum_u32_is_a_valid_factor_label() {
+        let design = Design::from_frame(frame(vec![vec![u32::MAX, u32::MAX]], vec![])).unwrap();
+
+        assert_eq!(design.terms[0].n_levels(), 1);
+        assert_eq!(&*design.terms[0].level_labels, &[u32::MAX]);
+        assert_eq!(design.n_dofs(), 1);
+        assert_eq!(design.level_column(0), [0, 0]);
     }
 
     #[test]

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -330,28 +330,3 @@ fn level_blocks_cover_every_row_exactly_once() {
     }
     assert!(seen.iter().all(|&n| n == 1), "{seen:?}");
 }
-
-/// Gaps leave empty levels inside a block; the row order must group only codes that occur.
-#[test]
-fn gappy_level_codes_screen_the_same_at_any_budget() {
-    let n = 4000;
-    let a: Vec<u32> = (0..n).map(|i| (i % 40) as u32 * 2).collect();
-    let b: Vec<u32> = (0..n).map(|i| ((i / 40) % 25) as u32 * 3).collect();
-    let z1 = pseudo_noise(n, 7);
-    let z2 = pseudo_noise(n, 11);
-    let design = Design::new(vec![
-        Effect::new(&a, true, [&z1[..]]).unwrap(),
-        Effect::new(&b, true, [&z2[..]]).unwrap(),
-    ])
-    .unwrap();
-    assert!(!design.terms[1].sorted);
-    for (split, whole) in shares(&design, 1, 1)
-        .into_iter()
-        .zip(shares(&design, 1, FULL_TABLE))
-    {
-        assert!(
-            (split - whole).abs() <= 1e-12 * split.max(whole),
-            "{split:e} vs {whole:e}"
-        );
-    }
-}

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -26,7 +26,7 @@ pub(crate) fn find_all_active_levels(design: &Design<'_>) -> Vec<Vec<bool>> {
     let mut active: Vec<Vec<bool>> = design
         .terms
         .iter()
-        .map(|f| vec![false; f.n_levels])
+        .map(|f| vec![false; f.n_levels()])
         .collect();
     // Factor-outer/obs-inner: all writes for a factor land in one `active[f]` buffer.
     for (f, col) in active.iter_mut().enumerate() {

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -278,29 +278,19 @@ proptest! {
 }
 
 #[test]
-fn test_find_all_active_levels_with_gaps() {
-    // Factor 0 has 5 levels but only 0, 2, 4 appear; factor 1 uses all 3.
+fn caller_label_gaps_do_not_create_inactive_internal_levels() {
     let fa = vec![0u32, 2, 4, 0, 2, 4];
     let fb = vec![0u32, 1, 2, 0, 1, 2];
     let design = design_of(vec![fa, fb]);
 
     let active = find_all_active_levels(&design);
 
-    // Factor 0: 5 levels, only 0, 2, 4 active.
-    assert_eq!(active[0].len(), 5, "factor 0 should have 5 levels");
-    assert_eq!(
-        active[0],
-        vec![true, false, true, false, true],
-        "factor 0 active pattern: [true, false, true, false, true]"
-    );
+    // Caller labels are retained in compact-code order.
+    assert_eq!(&*design.terms[0].level_labels, &[0, 2, 4]);
 
-    // Factor 1: all 3 levels active.
-    assert_eq!(active[1].len(), 3, "factor 1 should have 3 levels");
-    assert_eq!(
-        active[1],
-        vec![true, true, true],
-        "factor 1 active pattern: all true"
-    );
+    // Internal codes are 0, 1, 2, and every internal level occurs.
+    assert_eq!(active[0], vec![true, true, true]);
+    assert_eq!(active[1], vec![true, true, true]);
 }
 
 #[test]

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -70,9 +70,9 @@ impl LevelMoments {
         let v = covariates.len();
         let mut moments = Self {
             intercept: v < meta.columns.len(),
-            w_sum: vec![0.0; meta.n_levels],
-            mean: vec![0.0; meta.n_levels * v],
-            comoment: vec![0.0; meta.n_levels * tri_len(v)],
+            w_sum: vec![0.0; meta.n_levels()],
+            mean: vec![0.0; meta.n_levels() * v],
+            comoment: vec![0.0; meta.n_levels() * tri_len(v)],
             covariates,
         };
         let zs: Vec<&[f64]> = moments

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -99,7 +99,7 @@ pub enum BuildError {
         /// The offending value.
         value: f64,
     },
-    /// Usually raw entity IDs passed as factor codes, inflating `n_levels = max code + 1`.
+    /// The compact coefficient space does not fit the internal `u32` column indices.
     #[error("design has {n_dofs} degrees of freedom, exceeding the u32 column-index limit")]
     DofSpaceExceedsU32 {
         /// Total degrees of freedom implied by the design.

--- a/crates/within/src/observation.rs
+++ b/crates/within/src/observation.rs
@@ -47,6 +47,34 @@ impl<'a> ObservationFrame<'a> {
         })
     }
 
+    pub(crate) fn with_encoded_factors(self, encoded: Vec<Option<Vec<u32>>>) -> Self {
+        debug_assert_eq!(encoded.len(), self.categorical.len());
+
+        let Self {
+            categorical,
+            continuous,
+            n_obs,
+        } = self;
+
+        let categorical = categorical
+            .into_iter()
+            .zip(encoded)
+            .map(|(original, encoded)| match encoded {
+                Some(encoded) => {
+                    debug_assert_eq!(encoded.len(), n_obs);
+                    Cow::Owned(encoded)
+                }
+                None => original,
+            })
+            .collect();
+
+        Self {
+            categorical,
+            continuous,
+            n_obs,
+        }
+    }
+
     /// Number of observations (rows).
     #[inline]
     pub fn n_obs(&self) -> usize {

--- a/crates/within/src/operator/design/gather.rs
+++ b/crates/within/src/operator/design/gather.rs
@@ -21,7 +21,7 @@ pub(crate) fn gather_apply(
 
     for_each_chunk(dst, |chunk, row_start| {
         for (q, t) in design.terms.iter().enumerate() {
-            let (offset, n_levels) = (t.offset, t.n_levels);
+            let (offset, n_levels) = (t.offset, t.n_levels());
             let levels = design.level_column(q);
             let col = |c: usize| &src[offset + c * n_levels..offset + (c + 1) * n_levels];
             match &*t.columns {

--- a/crates/within/src/operator/design/scatter.rs
+++ b/crates/within/src/operator/design/scatter.rs
@@ -52,8 +52,8 @@ pub(super) fn scatter_apply(
             }
             columns => {
                 for (c, loading) in columns.iter().enumerate() {
-                    let start = c * t.n_levels;
-                    let slot = &mut block[start..start + t.n_levels];
+                    let start = c * t.n_levels();
+                    let slot = &mut block[start..start + t.n_levels()];
                     match loading {
                         Loading::Constant => {
                             scatter_term::<1>(slot, t, levels, parallel, scratch, |i| [base(i)]);
@@ -80,7 +80,7 @@ fn scatter_term<const C: usize>(
     scratch: &[AtomicF64],
     values: impl Fn(usize) -> [f64; C] + Sync,
 ) {
-    let n_levels = meta.n_levels;
+    let n_levels = meta.n_levels();
     debug_assert_eq!(block.len(), C * n_levels);
     match ScatterStrategy::pick(parallel, C * n_levels, meta.sorted) {
         ScatterStrategy::Sequential => scatter_sequential::<C>(block, n_levels, levels, &values),

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -307,7 +307,7 @@ mod slope_design_tests {
         for (q, t) in design.terms.iter().enumerate() {
             let levels = design.level_column(q);
             for (c, loading) in t.columns.iter().enumerate() {
-                let base = t.offset + c * t.n_levels;
+                let base = t.offset + c * t.n_levels();
                 for (i, &lev) in levels.iter().enumerate() {
                     d[i][base + lev as usize] = match loading {
                         Loading::Constant => 1.0,

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -221,7 +221,7 @@ fn build_diagonal(
         let w = |uid: usize| weights.map_or(1.0, |ws| ws[uid]);
         for (column, loading) in term.columns.iter().enumerate() {
             let base = term.column_base(column);
-            let slice = &mut diag[base..base + term.n_levels];
+            let slice = &mut diag[base..base + term.n_levels()];
             match loading {
                 Loading::Constant => {
                     for (uid, &level) in levels.iter().enumerate() {

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -143,7 +143,7 @@ impl CoefficientLayout {
             .iter()
             .map(|t| TermLayout {
                 offset: t.offset,
-                n_levels: t.n_levels,
+                n_levels: t.n_levels(),
                 n_columns: t.n_columns(),
             })
             .collect();
@@ -606,8 +606,8 @@ impl<'a> Solver<'a> {
 /// Solve fixed-effects least squares for a design input.
 ///
 /// `design` is anything implementing [`IntoDesign`]: an observation-major
-/// `(n_obs, n_factors)` categories array (levels `0..max_level` per factor,
-/// count inferred) or a list of [`Effect`] terms.
+/// `(n_obs, n_factors)` categories array (observed `u32` labels are compacted in
+/// ascending numeric order within each factor) or a list of [`Effect`] terms.
 /// `y` is the response vector (length = n_obs).
 ///
 /// Zero-copy for F-order category arrays whose dominant factor is already

--- a/crates/within/src/solver/reparam.rs
+++ b/crates/within/src/solver/reparam.rs
@@ -80,7 +80,7 @@ impl TermReparam {
         unidentified: &mut Vec<CoefficientAddress>,
     ) -> Self {
         let meta = &design.terms[term];
-        let (offset, n_levels) = (meta.offset, meta.n_levels);
+        let (offset, n_levels) = (meta.offset, meta.n_levels());
         let mut intercept_column = None;
         let mut slope_columns = Vec::new();
         for (column, loading) in meta.columns.iter().enumerate() {

--- a/crates/within/src/solver/reparam/tests.rs
+++ b/crates/within/src/solver/reparam/tests.rs
@@ -40,7 +40,7 @@ fn build_whitens_each_slope_bearing_term() {
             .filter_map(|c| c.covariate())
             .map(|&k| design.loading_column(k as usize))
             .collect();
-        for level in 0..meta.n_levels {
+        for level in 0..meta.n_levels() {
             let obs: Vec<usize> = (0..levels.len())
                 .filter(|&i| levels[i] as usize == level)
                 .collect();

--- a/crates/within/tests/common/property_strategies.rs
+++ b/crates/within/tests/common/property_strategies.rs
@@ -59,6 +59,15 @@ pub struct SlopesProblem {
     pub y: Vec<f64>,
 }
 
+fn populated_level_column(n_levels: u32, n_obs: usize) -> impl Strategy<Value = Vec<u32>> {
+    proptest::collection::vec(0u32..n_levels, n_obs - n_levels as usize)
+        .prop_map(move |mut levels| {
+            levels.extend(0..n_levels);
+            levels
+        })
+        .prop_shuffle()
+}
+
 pub fn random_slopes_problem_strategy() -> impl Strategy<Value = SlopesProblem> {
     (60usize..=300, 1usize..=3).prop_flat_map(|(n_obs, n_factors)| {
         // Per factor: level count, intercept flag, slope count. An effect with
@@ -71,7 +80,7 @@ pub fn random_slopes_problem_strategy() -> impl Strategy<Value = SlopesProblem> 
                     .map(|(n_levels, intercept, n_slopes)| {
                         let intercept = intercept || n_slopes == 0;
                         (
-                            proptest::collection::vec(0u32..n_levels, n_obs),
+                            populated_level_column(n_levels, n_obs),
                             proptest::collection::vec(-3.0f64..3.0, n_obs),
                             proptest::collection::vec(
                                 proptest::collection::vec(-0.5f64..0.5, n_obs),

--- a/crates/within/tests/edge_cases.rs
+++ b/crates/within/tests/edge_cases.rs
@@ -179,15 +179,11 @@ fn test_diagonal_matches_unpreconditioned_solution() {
     common::assert_solutions_close(&diagonal.x, &unpreconditioned.x, 1e-6);
 }
 
-/// A factor whose observed levels leave interior gaps (`n_levels = max + 1`)
-/// produces structural zero columns of `D` — unidentified DOFs whose diagonal
-/// is zero. The unpreconditioned and additive paths both pin those coefficients
-/// to 0 and solve fine; with the pseudo-inverse of a zero diagonal, the diagonal
-/// preconditioner now matches rather than failing with `SingularDiagonal`.
+/// Gaps between caller labels do not create structural zero columns because the
+/// design compacts its observed labels before solving.
 #[test]
-fn test_diagonal_matches_unpreconditioned_on_gap_design() {
-    // Single factor observed only at levels {0, 2, 4} => n_levels = 5, so global
-    // DOFs 1 and 3 have no observations.
+fn test_diagonal_matches_unpreconditioned_on_compacted_gap_design() {
+    // Caller labels {0, 2, 4} become internal codes {0, 1, 2}.
     let cats = array![[0u32], [2], [4]];
     let y = vec![1.0, 2.0, 3.0];
     let params = LsmrOptions::default();
@@ -199,15 +195,14 @@ fn test_diagonal_matches_unpreconditioned_on_gap_design() {
         &params,
         &PreconditionerConfig::Diagonal,
     )
-    .expect("diagonal solve must succeed on a gap design (pseudo-inverse of zero diagonal)");
+    .expect("diagonal solve must succeed on a compacted gap design");
     let unpreconditioned = solve(cats.view(), &y, None, &params, &PreconditionerConfig::Off)
         .expect("unpreconditioned solve");
 
     assert!(diagonal.converged, "diagonal solve must converge");
+    assert_eq!(diagonal.layout.n_levels(0), Some(3));
+    assert_eq!(diagonal.x.len(), 3);
     common::assert_solutions_close(&diagonal.x, &unpreconditioned.x, 1e-6);
-    // The unobserved DOFs are unidentified and must be pinned to exactly 0.
-    assert_eq!(diagonal.x[1], 0.0, "unobserved DOF 1 must be 0");
-    assert_eq!(diagonal.x[3], 0.0, "unobserved DOF 3 must be 0");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/within/tests/property_gaps.rs
+++ b/crates/within/tests/property_gaps.rs
@@ -6,6 +6,13 @@ use within::{solve, LsmrOptions, Solver};
 mod strategies;
 use strategies::{additive_precond, random_fe_problem_strategy};
 
+fn factor_labels(cats: &Array2<u32>, factor: usize) -> Vec<u32> {
+    let mut labels: Vec<u32> = cats.column(factor).iter().copied().collect();
+    labels.sort_unstable();
+    labels.dedup();
+    labels
+}
+
 /// 4-factor problem: 2–10 levels each, 100–500 observations.
 fn random_4_factor_problem_strategy() -> impl Strategy<Value = (Array2<u32>, Vec<f64>)> {
     proptest::collection::vec(2..=10u32, 4usize).prop_flat_map(|n_levels| {
@@ -129,18 +136,22 @@ proptest! {
         let n_obs = y.len();
         let n_factors = cats.ncols();
 
-        // Compute factor offsets (same ordering as Design)
+        // Reproduce Design's numeric-label encoding and term offsets.
+        let labels_by_factor: Vec<Vec<u32>> = (0..n_factors)
+            .map(|factor| factor_labels(&cats, factor))
+            .collect();
         let mut offsets = vec![0usize; n_factors];
         for f in 1..n_factors {
-            let n_levels_prev = *cats.column(f - 1).iter().max().unwrap() as usize + 1;
-            offsets[f] = offsets[f - 1] + n_levels_prev;
+            offsets[f] = offsets[f - 1] + labels_by_factor[f - 1].len();
         }
 
         for i in 0..n_obs {
             let dx_i: f64 = (0..n_factors)
                 .map(|f| {
-                    let level = cats[[i, f]] as usize;
-                    result.x[offsets[f] + level]
+                    let code = labels_by_factor[f]
+                        .binary_search(&cats[[i, f]])
+                        .expect("factor label was collected from this column");
+                    result.x[offsets[f] + code]
                 })
                 .sum();
             let expected_demeaned = y[i] - dx_i;
@@ -157,7 +168,7 @@ proptest! {
     /// distinct singular value); in practice far fewer are needed.
     #[test]
     fn prop_single_factor_converges((cats, y) in single_factor_strategy()) {
-        let n_levels = *cats.column(0).iter().max().unwrap() as usize + 1;
+        let n_levels = factor_labels(&cats, 0).len();
         let params = LsmrOptions {
             tol: 1e-8,
             maxiter: n_levels + 10,

--- a/crates/within/tests/slopes.rs
+++ b/crates/within/tests/slopes.rs
@@ -156,7 +156,8 @@ fn slope_only_term_recovers_per_level_projection() {
 
 #[test]
 fn rank_drops_report_deterministically_with_exact_zeros() {
-    // Level 1 never occurs; level 2's slope is constant, so only its slope drops.
+    // Caller label 1 never occurs; labels {0, 2, 3} compact to codes {0, 1, 2}.
+    // Label 2's slope is constant, so only the slope for compact code 1 drops.
     let levels: Vec<u32> = vec![0, 0, 0, 2, 2, 2, 3, 3, 3];
     let z: Vec<f64> = vec![1.0, 2.0, -1.5, 2.5, 2.5, 2.5, -2.0, 0.7, 1.3];
     let y = synthetic_y(levels.len());
@@ -164,25 +165,22 @@ fn rank_drops_report_deterministically_with_exact_zeros() {
 
     let r = run(&PreconditionerConfig::default());
     assert!(r.converged);
-    // Ascending (level, column) order.
-    assert_eq!(drops(&r), [(0, 1, 0), (0, 1, 1), (0, 2, 1)]);
+    assert_eq!(drops(&r), [(0, 1, 1)]);
 
     // Minimal-norm 0 at exactly the dropped slots; everything else finite.
-    for slot in [1, 4 + 1, 4 + 2] {
-        assert_eq!(r.x[slot], 0.0);
-    }
+    assert_eq!(r.x[3 + 1], 0.0);
     assert!(r.x.iter().all(|v| v.is_finite()));
 
     // The constant level degrades to intercept-only: a = mean(y within level).
     assert_close(
-        r.x[2],
+        r.x[1],
         (y[3] + y[4] + y[5]) / 3.0,
         "constant level intercept",
     );
     let (a, b) = per_level_intercept_slope(&levels, &z, &y, None, 4);
-    for l in [0usize, 3] {
-        assert_close(r.x[l], a[l], &format!("intercept of level {l}"));
-        assert_close(r.x[4 + l], b[l], &format!("slope of level {l}"));
+    for (code, label) in [(0usize, 0usize), (2, 3)] {
+        assert_close(r.x[code], a[label], &format!("intercept of label {label}"));
+        assert_close(r.x[3 + code], b[label], &format!("slope of label {label}"));
     }
 
     // The explicit diagonal preconditioner agrees with the default path.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,25 @@ import numpy as np
 from numpy.typing import NDArray
 
 
+def populated_level_column(
+    rng: np.random.Generator,
+    n_levels: int,
+    n_rows: int,
+) -> NDArray[np.int64]:
+    """Random level column in which every label ``0..n_levels`` occurs."""
+    if not 0 < n_levels <= n_rows:
+        raise ValueError("n_levels must be positive and no greater than n_rows")
+
+    levels = np.concatenate(
+        [
+            np.arange(n_levels, dtype=np.int64),
+            rng.integers(0, n_levels, size=n_rows - n_levels, dtype=np.int64),
+        ]
+    )
+    rng.shuffle(levels)
+    return levels
+
+
 def generate_synthetic_data(
     n_levels: list[int],
     n_rows: int,
@@ -11,7 +30,7 @@ def generate_synthetic_data(
 ) -> tuple[list[NDArray[np.int64]], NDArray[np.float64], NDArray[np.float64]]:
     """Generate synthetic fixed-effects data: y = D @ x_true (no noise)."""
     rng = np.random.default_rng(seed)
-    cats = [rng.integers(0, nl, size=n_rows) for nl in n_levels]
+    cats = [populated_level_column(rng, nl, n_rows) for nl in n_levels]
     x_true = rng.standard_normal(sum(n_levels))
     y = np.zeros(n_rows)
     offset = 0

--- a/tests/test_preconditioner.py
+++ b/tests/test_preconditioner.py
@@ -4,7 +4,7 @@ import pickle
 
 import numpy as np
 import pytest
-from conftest import as_solver_categories
+from conftest import as_solver_categories, populated_level_column
 from within import LsmrOptions, Preconditioner, PreconditionerConfig, Solver, solve
 from within._within import (
     ApproxCholConfig,
@@ -18,12 +18,9 @@ from within._within import (
 @pytest.fixture()
 def problem():
     """Two-factor problem with 50 levels each, 10k observations."""
-    np.random.seed(42)
-    cats = [
-        np.random.randint(0, 50, size=10_000),
-        np.random.randint(0, 50, size=10_000),
-    ]
-    y = np.random.randn(10_000)
+    rng = np.random.default_rng(42)
+    cats = [populated_level_column(rng, 50, 10_000) for _ in range(2)]
+    y = rng.standard_normal(10_000)
     return cats, y
 
 

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -17,7 +17,11 @@ from within import (
 )
 from within.config import LocalSolverConfig, ScalingConfig
 
-from conftest import as_solver_categories, generate_synthetic_data
+from conftest import (
+    as_solver_categories,
+    generate_synthetic_data,
+    populated_level_column,
+)
 
 
 def assert_normal_equations_satisfied(cats, y, result, tol, weights=None):
@@ -136,12 +140,9 @@ def test_one_shot_solve_surfaces_build_warnings():
 @pytest.fixture()
 def problem():
     """Two-factor problem with 50 levels each, 10k observations."""
-    np.random.seed(42)
-    cats = [
-        np.random.randint(0, 50, size=10_000),
-        np.random.randint(0, 50, size=10_000),
-    ]
-    y = np.random.randn(10_000)
+    rng = np.random.default_rng(42)
+    cats = [populated_level_column(rng, 50, 10_000) for _ in range(2)]
+    y = rng.standard_normal(10_000)
     return cats, y
 
 
@@ -233,10 +234,10 @@ class TestDemean:
 
     def test_residual_is_orthogonal_to_design(self):
         """The residual y - D x should be orthogonal to every column of D."""
-        np.random.seed(99)
+        rng = np.random.default_rng(99)
         n_obs, n_levels = 5_000, [30, 40]
-        cats = [np.random.randint(0, nl, size=n_obs) for nl in n_levels]
-        y = np.random.randn(n_obs)
+        cats = [populated_level_column(rng, nl, n_obs) for nl in n_levels]
+        y = rng.standard_normal(n_obs)
         result = solve(as_solver_categories(cats), y)
         residual = y.copy()
         offset = 0


### PR DESCRIPTION
Adds internal compact encoding of factor labels. The current encoding still expects `u32` caller labels but doesn't provide functionality to encode arbitrary input labels (e.g., strings).

Closes #228.