### PR TITLE
Constrain certified cross-term gauge directions out of the solve space (#297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project follows [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Python `Preconditioner.build_duration_seconds` and Rust `Preconditioner::build_duration()` expose the original preconditioner build duration, preserved across serialization and reuse.
-- `BuildWarning::CollinearSlopeCovariate` reports a slope covariate that is (nearly) a per-level combination of another term's columns — a cross-term near-null direction that per-term whitening cannot see and that can inflate iteration counts by orders of magnitude (#281).
+- `BuildWarning::CollinearSlopeCovariate` reports a slope covariate that is (nearly) a per-level combination of another term's columns — a cross-term near-null direction that per-term whitening cannot see (#281). It carries the slope channel, the reproducing term, the covariate's relative residual outside that term's span, and an `AliasVerdict` saying whether the direction was constrained out of the solve space or kept.
+- A cross-term aliasing direction is constrained out of the solve space when it certifies as null against the design — `‖A n‖ ≤ 1e-11 · ‖ |A| |n| ‖` on each row of the orthonormal basis — so no local block is left inverting a roundoff-scale null. A direction that fails the certificate stays in the solve space and is only warned about (#297).
 - `schwarz_precond::EscalationPolicy` builds a per-run `EscalationHandler` that ends a solve with `LsmrStopReason::Escalated` and an iterate that warm-starts the next preconditioner; `Staleness` implements it from the trailing contraction window.
 - `schwarz_precond::MlsmrOptions::warm_start` carries an initial iterate through a change of preconditioner.
 - `LocalSolverConfig::ridge` (Python `LocalSolverConfig(ridge=...)`) floors the local spectrum of grounded slope-pair components at a fraction of their largest diagonal; `0` disables it (#290).
@@ -31,6 +32,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - A design carrying varying slopes on two distinct factors could fail preconditioner construction with `matrix is not symmetric`, when rounding left the two triangles of the exact Schur complement unequal (#229).
 - A `design` that is neither a 2-D `uint32` array nor a list of `Effect` raised `ValueError` where the documented type is `TypeError`, and `AdditiveSchwarz` accepted a wrong-type `local_solver` at construction, deferring the `TypeError` to solve time (#248).
 - A slope covariate collinear with another term could make LSMR report convergence on a solve that had not demeaned the response; tolerance stops are now audited against the true residual and a failed check reports `LsmrStopReason::FalseConvergence` with `converged = false` (#290).
+- That audit measured `Aᵀr` in the preconditioner's own metric, so a component the preconditioner annihilates stayed invisible to it and a solve missing that direction still reported `converged = true`. The audit now also requires the plain `‖Aᵀr‖` to have dropped against its initial value (#297).
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +1479,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.119",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,6 +1571,7 @@ version = "0.4.0"
 dependencies = [
  "faer",
  "rayon",
+ "rstest",
  "serde",
  "thiserror 2.0.19",
  "thread_local",
@@ -2055,6 +2094,7 @@ dependencies = [
  "proptest",
  "rand 0.10.2",
  "rayon",
+ "rstest",
  "schwarz-precond",
  "serde",
  "thiserror 2.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rayon = "1.12"
 serde = { version = "1", features = ["derive"] }
 postcard = { version = "1", features = ["use-std"] }
 thiserror = "2"
+rstest = { version = "0.26.1", default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -217,8 +217,9 @@ let r2 = solver.solve(&another_y, &LsmrOptions::default())?;  // reuses precondi
 | `SchurMode` | `Approximate(ApproxSchurConfig)` \| `Exact` |
 | `Preconditioner` | Opaque built handle — reuse via `Solver::new(.., precond)` (owned or `&`) |
 | `Effect` | `Effect::new(levels: &[u32], intercept: bool, slopes: impl IntoIterator<Item = &[f64]>) -> Result<Self, BuildError>` |
-| `CoefficientAddress` | `{ channel: Channel { term, column }, level: usize }` |
-| `CoefficientLayout` | `index(CoefficientAddress) -> Option<usize>`, `address(usize) -> Option<CoefficientAddress>`, `n_dofs()`, `n_terms()`, `n_levels(term)`, `n_columns(term)` |
+| `FactorLabel` | Opaque caller-visible label; currently constructible from `u32` and readable with `try_as_u32()` |
+| `CoefficientAddress` | `{ channel: Channel { term, column }, level: FactorLabel }` |
+| `CoefficientLayout` | `index(&CoefficientAddress) -> Option<usize>`, `address(usize) -> Option<CoefficientAddress>`, `n_dofs()`, `n_terms()`, `n_levels(term)`, `n_columns(term)` |
 
 ### Varying slopes
 
@@ -240,8 +241,8 @@ let terms = vec![
 let r = solve(terms, &y, None, None, None)?;
 
 // Read firm level 3's x-slope via the layout map (column 0 = intercept, 1 = first slope):
-let at = CoefficientAddress { channel: Channel { term: 0, column: 1 }, level: 3 };
-println!("{}", r.x[r.layout.index(at).unwrap()]);
+let at = CoefficientAddress { channel: Channel { term: 0, column: 1 }, level: 3.into() };
+println!("{}", r.x[r.layout.index(&at).unwrap()]);
 ```
 
 `Solver::new` takes the same `Vec<Effect>`, so a slope design can be reused

--- a/crates/schwarz-precond/Cargo.toml
+++ b/crates/schwarz-precond/Cargo.toml
@@ -21,6 +21,7 @@ thread_local = "1.1"
 
 [dev-dependencies]
 faer.workspace = true
+rstest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/schwarz-precond/src/lsmr/bidiag.rs
+++ b/crates/schwarz-precond/src/lsmr/bidiag.rs
@@ -246,6 +246,10 @@ pub(super) struct Certificate {
     pub(super) normr: f64,
     /// `‖Âᵀ(rhs − A x)‖` in the stream's metric (`√(zᵀM⁻¹z)` when preconditioned).
     pub(super) normar: f64,
+    /// The same residual in the plain metric, which a singular `M⁻¹` cannot hide a component in,
+    /// and its reference `‖Aᵀ rhs‖`.
+    pub(super) normar_raw: f64,
+    pub(super) normar_raw0: f64,
 }
 
 /// Stream feeding LSMR `(α, β)` pairs and the matching normalized `v_k`.
@@ -300,9 +304,12 @@ impl<A: Operator + ?Sized> Bidiagonalization for GolubKahan<'_, A> {
 
     fn certify(&mut self, x: &[f64], rhs: &[f64]) -> Result<Certificate, SolveError> {
         let normr = true_residual(self.operator, x, rhs, &mut self.bufs.av, &mut self.bufs.atu)?;
+        let normar = super::vec_norm(&self.bufs.atu);
         Ok(Certificate {
             normr,
-            normar: super::vec_norm(&self.bufs.atu),
+            normar,
+            normar_raw: normar,
+            normar_raw0: self.normar_raw0,
         })
     }
 }
@@ -344,11 +351,15 @@ impl<A: Operator + ?Sized, M: Operator + ?Sized> Bidiagonalization
 
     fn certify(&mut self, x: &[f64], rhs: &[f64]) -> Result<Certificate, SolveError> {
         let normr = true_residual(self.operator, x, rhs, &mut self.bufs.av, &mut self.bufs.atu)?;
+        // Read before `M⁻¹`, whose null space is exactly what the metric norm cannot see.
+        let normar_raw = super::vec_norm(&self.bufs.atu);
         self.preconditioner
             .apply(&self.bufs.atu, &mut self.bufs.v)?;
         Ok(Certificate {
             normr,
             normar: alpha_from_vp(&self.bufs.v, &self.bufs.atu)?,
+            normar_raw,
+            normar_raw0: self.normar_raw0,
         })
     }
 }
@@ -385,6 +396,7 @@ pub(super) struct GolubKahan<'a, A: Operator + ?Sized> {
     bufs: GolubKahanBuffers,
     /// Last `α` emitted; needed by the next step's u-update.
     alpha: f64,
+    normar_raw0: f64,
 }
 
 impl<'a, A: Operator + ?Sized> GolubKahan<'a, A> {
@@ -422,6 +434,7 @@ impl<'a, A: Operator + ?Sized> GolubKahan<'a, A> {
                 operator,
                 bufs,
                 alpha,
+                normar_raw0: beta * alpha,
             },
             BidiagStep { alpha, beta },
         ))
@@ -466,6 +479,7 @@ pub(super) struct ModifiedGolubKahan<'a, A: Operator + ?Sized, M: Operator + ?Si
     alpha: f64,
     /// `1/β_k`; cancels the unnormalization of `u` in the next step.
     beta_prev_inv: f64,
+    normar_raw0: f64,
 }
 
 impl<'a, A: Operator + ?Sized, M: Operator + ?Sized> ModifiedGolubKahan<'a, A, M> {
@@ -490,6 +504,7 @@ impl<'a, A: Operator + ?Sized, M: Operator + ?Sized> ModifiedGolubKahan<'a, A, M
         }
 
         operator.apply_adjoint(&bufs.u, &mut bufs.p_tilde)?;
+        let normar_raw0 = beta * super::vec_norm(&bufs.p_tilde);
 
         preconditioner.apply(&bufs.p_tilde, &mut bufs.v)?;
 
@@ -511,6 +526,7 @@ impl<'a, A: Operator + ?Sized, M: Operator + ?Sized> ModifiedGolubKahan<'a, A, M
                 bufs,
                 alpha,
                 beta_prev_inv: 1.0, // u was normalized by init
+                normar_raw0,
             },
             BidiagStep { alpha, beta },
         ))

--- a/crates/schwarz-precond/src/lsmr/recurrence.rs
+++ b/crates/schwarz-precond/src/lsmr/recurrence.rs
@@ -262,10 +262,12 @@ impl ConvergenceState {
     /// True-residual audit of a tolerance stop (cf. van der Vorst & Ye, SISC 22(3), 2000).
     pub(super) fn certified(&self, cert: &Certificate, zeta0: f64) -> bool {
         let rel = CERTIFICATION_SLACK * self.criteria.rel_tol;
-        cert.normr <= CERTIFICATION_SLACK * self.criteria.abs_tol
+        let in_metric = cert.normr <= CERTIFICATION_SLACK * self.criteria.abs_tol
             // `normr → 0` degenerates the ratio test; the drop of `‖Âᵀr‖` vs its start certifies.
             || cert.normar <= rel * zeta0
-            || self.ne_ratio(cert.normr, cert.normar) <= rel
+            || self.ne_ratio(cert.normr, cert.normar) <= rel;
+        // A metric that annihilates a direction cannot audit it, so the plain norm must also drop.
+        in_metric && cert.normar_raw <= rel * cert.normar_raw0.max(f64::MIN_POSITIVE)
     }
 }
 

--- a/crates/schwarz-precond/src/lsmr/tests/audit.rs
+++ b/crates/schwarz-precond/src/lsmr/tests/audit.rs
@@ -10,6 +10,7 @@ struct ScriptedStream {
     v: Vec<f64>,
     normr: f64,
     normar: f64,
+    normar_raw: f64,
 }
 
 impl Bidiagonalization for ScriptedStream {
@@ -27,15 +28,18 @@ impl Bidiagonalization for ScriptedStream {
         Ok(Certificate {
             normr: self.normr,
             normar: self.normar,
+            normar_raw: self.normar_raw,
+            normar_raw0: 1.0,
         })
     }
 }
 
-fn scripted_run(normr: f64, normar: f64) -> super::super::LsmrResult {
+fn scripted_run(normr: f64, normar: f64, normar_raw: f64) -> super::super::LsmrResult {
     let stream = ScriptedStream {
         v: vec![0.0; 2],
         normr,
         normar,
+        normar_raw,
     };
     let step1 = BidiagStep {
         alpha: 1.0,
@@ -47,7 +51,7 @@ fn scripted_run(normr: f64, normar: f64) -> super::super::LsmrResult {
 
 #[test]
 fn collapsed_stop_is_refused_by_the_audit() {
-    let r = scripted_run(1.0, 1.0);
+    let r = scripted_run(1.0, 1.0, 1.0);
     assert!(!r.converged);
     assert_eq!(r.stop_reason, LsmrStopReason::FalseConvergence);
     assert_eq!(r.residual_norm, 1.0);
@@ -56,7 +60,7 @@ fn collapsed_stop_is_refused_by_the_audit() {
 
 #[test]
 fn honest_stop_passes_the_audit() {
-    let r = scripted_run(1e-12, 1e-12);
+    let r = scripted_run(1e-12, 1e-12, 1e-12);
     assert!(r.converged);
     assert_eq!(r.stop_reason, LsmrStopReason::ResidualTolerance);
 }
@@ -64,7 +68,15 @@ fn honest_stop_passes_the_audit() {
 #[test]
 fn near_consistent_stop_certifies_via_the_initial_ne_drop() {
     // Ratio leg would refuse (1e-12/1e-6 ≫ 100·tol); the drop vs ζ̄₀ = 1 certifies.
-    let r = scripted_run(1e-6, 1e-12);
+    let r = scripted_run(1e-6, 1e-12, 1e-12);
     assert!(r.converged);
     assert_eq!(r.stop_reason, LsmrStopReason::ResidualTolerance);
+}
+
+/// A metric that annihilates part of `Aᵀr` reports it as zero, so the plain norm has to refuse.
+#[test]
+fn a_stop_the_metric_cannot_see_is_refused() {
+    let r = scripted_run(1e-6, 1e-12, 1e-6);
+    assert!(!r.converged);
+    assert_eq!(r.stop_reason, LsmrStopReason::FalseConvergence);
 }

--- a/crates/schwarz-precond/src/lsmr/tests/solve.rs
+++ b/crates/schwarz-precond/src/lsmr/tests/solve.rs
@@ -3,6 +3,7 @@
 use super::super::*;
 use crate::lsmr::fixtures::*;
 use crate::{Operator, SolveError};
+use rstest::rstest;
 
 #[test]
 fn vec_norm_is_overflow_safe_and_propagates_nan() {
@@ -195,29 +196,50 @@ fn test_mlsmr_maxiter_exhaustion() {
     assert_eq!(result.stop_reason, LsmrStopReason::MaxIterations);
 }
 
-/// `lsmr` (GolubKahan path) and `mlsmr` with `M = I`
-/// (ModifiedGolubKahan with the identity) are mathematically the same
-/// algorithm.
-/// They should produce numerically equivalent solutions and iteration
-/// counts; this guards against future drift between the two
-/// bidiagonalization implementations.
-#[test]
-fn test_mlsmr_none_matches_identity_precond() {
-    let b = vec![1.0, 2.0, 3.0, 3.0];
-    let id = IdentityOp { n: 3 };
+/// `lsmr` (GolubKahan path) and `mlsmr` with `M = I` (ModifiedGolubKahan with
+/// the identity) are the same algorithm and must not drift apart. The windowed
+/// case also covers the M-weighted MGS path, which dots against `p̃ = M v` and
+/// scales by `1/α`; with `M = I` that must reduce to the Euclidean MGS the
+/// unpreconditioned path uses, guarding `WindowRing<2>::push` against drift.
+#[rstest]
+#[case::unwindowed(Box::new(OverdeterminedOp), vec![1.0, 2.0, 3.0, 3.0], 100, None, 1e-10)]
+// 30x12 Vandermonde, cond(A) ~ 1e10, stresses the windowed reorth path; its agreement bound
+// is set by what that path converges to (its normal-equation residual assertion is 1e-6).
+#[case::windowed(
+    Box::new(DenseOp::vandermonde(30, 12)),
+    (0..30).map(|i| (1.0 + i as f64 / 29.0).ln()).collect(),
+    50,
+    Some(10),
+    1e-7
+)]
+fn mlsmr_with_identity_matches_unpreconditioned_lsmr(
+    #[case] op: Box<dyn Operator>,
+    #[case] b: Vec<f64>,
+    #[case] maxiter: usize,
+    #[case] local: Option<usize>,
+    #[case] agreement: f64,
+) {
+    let id = IdentityOp { n: op.ncols() };
 
-    let none_result = lsmr(&OverdeterminedOp, &b, 1e-12, 100, None).expect("lsmr solve");
+    // Tight tol with headroom in maxiter drives both paths to the same minimum, so the
+    // comparison is not governed by rounding noise in the convergence test.
+    let none_result = lsmr(op.as_ref(), &b, 1e-12, maxiter, local).expect("lsmr solve");
     let id_result = mlsmr(
-        &OverdeterminedOp,
+        op.as_ref(),
         &b,
         &id,
         1e-12,
-        100,
-        MlsmrOptions::default(),
+        maxiter,
+        MlsmrOptions {
+            local_size: local,
+            ..Default::default()
+        },
     )
     .expect("preconditioned Identity solve");
 
     assert!(none_result.converged && id_result.converged);
+    // The two paths do the same algebra in a different order, so rounding can shift the
+    // convergence test by one step; the solve must still land on the same answer.
     assert!(
         (none_result.iterations as isize - id_result.iterations as isize).abs() <= 1,
         "iteration counts disagree: {} vs {}",
@@ -233,76 +255,12 @@ fn test_mlsmr_none_matches_identity_precond() {
         .sum::<f64>()
         .sqrt();
     assert!(
-        diff < 1e-10,
+        diff < agreement,
         "GolubKahan vs ModifiedGolubKahan-with-identity solutions disagree: {diff}"
     );
     assert!(
-        (none_result.residual_norm - id_result.residual_norm).abs() < 1e-10,
+        (none_result.residual_norm - id_result.residual_norm).abs() < agreement,
         "residual norm estimates disagree: {} vs {}",
-        none_result.residual_norm,
-        id_result.residual_norm
-    );
-}
-
-/// Same equivalence guarantee as above but with windowed reorthogonalization
-/// active. The M-weighted MGS path uses dot products against `p̃ = M v` and
-/// scales `p̃` by `1/α`; with `M = I` this must reduce to the Euclidean
-/// MGS used by the unpreconditioned path. Guards the windowed scaling
-/// logic in `WindowRing<2>::push` against drift.
-#[test]
-fn test_mlsmr_none_matches_identity_precond_windowed() {
-    // 30×12 Vandermonde, cond(A) ≈ 1e10 — chosen to stress the windowed reorth
-    // path (see test_mlsmr_local_reorth_unpreconditioned for rationale).
-    let op = DenseOp::vandermonde(30, 12);
-    let b: Vec<f64> = (0..op.rows)
-        .map(|i| {
-            let x = i as f64 / (op.rows - 1) as f64;
-            (1.0 + x).ln()
-        })
-        .collect();
-    let id = IdentityOp { n: op.cols };
-    let local = Some(10);
-
-    // Tight tolerance with headroom in maxiter: drives both paths to the
-    // same minimum so the comparison isn't governed by rounding noise in
-    // the convergence test.
-    let none_result = lsmr(&op, &b, 1e-12, 50, local).expect("lsmr windowed solve");
-    let opts = MlsmrOptions {
-        local_size: local,
-        ..Default::default()
-    };
-    let id_result =
-        mlsmr(&op, &b, &id, 1e-12, 50, opts).expect("preconditioned Identity windowed solve");
-
-    assert!(none_result.converged && id_result.converged);
-    // The two paths do the same algebra differently (par_dot on `v` vs on
-    // `p̃ = M v`), so rounding can shift the convergence test by one step.
-    // The solve must still land on the same answer.
-    assert!(
-        (none_result.iterations as isize - id_result.iterations as isize).abs() <= 1,
-        "iteration counts disagree: {} vs {}",
-        none_result.iterations,
-        id_result.iterations,
-    );
-
-    // Agreement bound is governed by what each path is converging to —
-    // the windowed Vandermonde test asserts a normal-equation residual of
-    // 1e-6, so 1e-7 here cleanly catches scaling drift in the M-weighted
-    // reorth without flagging algebra-order rounding.
-    let diff: f64 = none_result
-        .x
-        .iter()
-        .zip(id_result.x.iter())
-        .map(|(a, b)| (a - b).powi(2))
-        .sum::<f64>()
-        .sqrt();
-    assert!(
-        diff < 1e-7,
-        "windowed GolubKahan vs ModifiedGolubKahan-with-identity disagree: {diff}"
-    );
-    assert!(
-        (none_result.residual_norm - id_result.residual_norm).abs() < 1e-7,
-        "windowed residual norm estimates disagree: {} vs {}",
         none_result.residual_norm,
         id_result.residual_norm
     );

--- a/crates/within-py/src/results.rs
+++ b/crates/within-py/src/results.rs
@@ -71,7 +71,7 @@ pub struct PyUnidentifiedDirection {
     #[pyo3(get)]
     pub term: usize,
     #[pyo3(get)]
-    pub level: usize,
+    pub level: u32,
     #[pyo3(get)]
     pub column: usize,
 }
@@ -114,22 +114,28 @@ impl PyCoefficientLayout {
             .ok_or_else(|| self.term_oob(term))
     }
 
-    fn index(&self, term: usize, level: usize, column: usize) -> PyResult<usize> {
+    fn index(&self, term: usize, level: u32, column: usize) -> PyResult<usize> {
         let at = CoefficientAddress {
             channel: Channel { term, column },
-            level,
+            level: level.into(),
         };
-        self.inner.index(at).ok_or_else(|| {
+        self.inner.index(&at).ok_or_else(|| {
             PyIndexError::new_err(format!(
                 "coefficient address (term={term}, level={level}, column={column}) out of range"
             ))
         })
     }
 
-    fn address(&self, index: usize) -> PyResult<(usize, usize, usize)> {
+    fn address(&self, index: usize) -> PyResult<(usize, u32, usize)> {
         self.inner
             .address(index)
-            .map(|at| (at.channel.term, at.level, at.channel.column))
+            .map(|at| {
+                (
+                    at.channel.term,
+                    at.level.try_as_u32().expect("u32 factor label"),
+                    at.channel.column,
+                )
+            })
             .ok_or_else(|| {
                 PyIndexError::new_err(format!(
                     "x index {index} out of range (n_dofs={})",
@@ -164,7 +170,7 @@ pub(crate) fn into_py_result(py: Python<'_>, result: SolveResult) -> PySolveResu
             .iter()
             .map(|u| PyUnidentifiedDirection {
                 term: u.channel.term,
-                level: u.level,
+                level: u.level.try_as_u32().expect("u32 factor label"),
                 column: u.channel.column,
             })
             .collect(),
@@ -199,7 +205,7 @@ pub(crate) fn into_py_batch_result(
             .iter()
             .map(|u| PyUnidentifiedDirection {
                 term: u.channel.term,
-                level: u.level,
+                level: u.level.try_as_u32().expect("u32 factor label"),
                 column: u.channel.column,
             })
             .collect(),

--- a/crates/within/Cargo.toml
+++ b/crates/within/Cargo.toml
@@ -24,6 +24,7 @@ thiserror.workspace = true
 criterion = { version = "0.7", features = ["html_reports"] }
 rand = "0.10"
 proptest = "1"
+rstest.workspace = true
 
 [[bench]]
 name = "fixest"

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -167,6 +167,11 @@ impl TermMeta {
     pub fn column_base(&self, column: usize) -> usize {
         self.offset + column * self.n_levels()
     }
+
+    /// The constant's coefficient column, if the term carries one.
+    pub fn intercept_column(&self) -> Option<usize> {
+        self.columns.iter().position(|c| c.covariate().is_none())
+    }
 }
 
 /// Stable argsort of observations by a level column, ascending.

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -78,11 +78,41 @@ impl<T> Loading<T> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum FactorLabelValue {
+    U32(u32),
+}
+
+/// A caller-visible factor label.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FactorLabel(FactorLabelValue);
+
+impl FactorLabel {
+    /// Return the label as `u32`, or `None` when it has another representation.
+    pub fn try_as_u32(&self) -> Option<u32> {
+        match self.0 {
+            FactorLabelValue::U32(value) => Some(value),
+        }
+    }
+}
+
+impl From<u32> for FactorLabel {
+    fn from(value: u32) -> Self {
+        Self(FactorLabelValue::U32(value))
+    }
+}
+
+impl From<&FactorLabel> for FactorLabel {
+    fn from(value: &FactorLabel) -> Self {
+        value.clone()
+    }
+}
+
 /// Mapping between caller-visible factor labels and numerical level positions.
 ///
 /// This is an identity mapping for the existing dense `u32` API. Later
 /// encodings can store an explicit mapping without changing `TermMeta`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct FactorEncoding {
     n_levels: usize,
 }
@@ -94,6 +124,18 @@ impl FactorEncoding {
 
     pub(crate) fn n_levels(&self) -> usize {
         self.n_levels
+    }
+
+    pub(crate) fn position(&self, label: &FactorLabel) -> Option<usize> {
+        let position = label.try_as_u32()? as usize;
+        (position < self.n_levels).then_some(position)
+    }
+
+    pub(crate) fn label(&self, position: usize) -> Option<FactorLabel> {
+        if position >= self.n_levels {
+            return None;
+        }
+        u32::try_from(position).ok().map(FactorLabel::from)
     }
 }
 
@@ -440,6 +482,14 @@ mod tests {
             err,
             BuildError::DofSpaceExceedsU32 { n_dofs } if n_dofs == u32::MAX as usize + 1
         ));
+    }
+
+    #[test]
+    fn u32_factor_label_round_trips() {
+        let label = FactorLabel::from(u32::MAX);
+
+        assert_eq!(label.try_as_u32(), Some(u32::MAX));
+        assert_eq!(FactorLabel::from(&label), label);
     }
 
     #[test]

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -145,7 +145,7 @@ fn stable_argsort(key: &[u32], n_levels: usize) -> Vec<u32> {
 #[derive(Clone, Debug)]
 pub struct Design<'a> {
     /// Columns in internal row order (caller's, or an owned locality-sorted copy).
-    pub(crate) frame: ObservationFrame<'a>,
+    frame: ObservationFrame<'a>,
     pub(crate) terms: Vec<TermMeta>,
     pub(crate) n_obs: usize,
     pub(crate) n_dofs: usize,
@@ -320,6 +320,21 @@ impl<'a> Design<'a> {
         self.terms[channel.term].columns[channel.column]
     }
 
+    /// Level codes for one term, in internal observation order.
+    pub(crate) fn level_column(&self, term: usize) -> &[u32] {
+        self.frame.level_column(term)
+    }
+
+    /// Continuous loading column in internal observation order.
+    pub(crate) fn loading_column(&self, column: usize) -> &[f64] {
+        self.frame.loading_column(column)
+    }
+
+    /// Replace one loading column during solver-local preparation.
+    pub(crate) fn replace_loading_column(&mut self, column: usize, values: Vec<f64>) {
+        self.frame.set_loading_column(column, values);
+    }
+
     /// Number of observations (rows of D).
     #[inline]
     pub fn n_obs(&self) -> usize {
@@ -443,8 +458,8 @@ mod tests {
         // Factor 1's permuted column [0,1,1,0] is no longer non-decreasing.
         assert!(!design.terms[1].sorted);
 
-        assert_eq!(design.frame.level_column(0), [0, 0, 1, 2]);
-        assert_eq!(design.frame.level_column(1), [0, 1, 1, 0]);
+        assert_eq!(design.level_column(0), [0, 0, 1, 2]);
+        assert_eq!(design.level_column(1), [0, 1, 1, 0]);
     }
 
     #[test]
@@ -477,8 +492,8 @@ mod tests {
 
         let perm = design.obs_perm.as_ref().expect("permutation applied");
         assert_eq!(perm, &[1, 3, 2, 0]);
-        assert_eq!(design.frame.level_column(0), [0, 0, 1, 2]);
-        assert_eq!(design.frame.loading_column(0), [20.0, 40.0, 30.0, 10.0]);
+        assert_eq!(design.level_column(0), [0, 0, 1, 2]);
+        assert_eq!(design.loading_column(0), [20.0, 40.0, 30.0, 10.0]);
     }
 
     #[test]
@@ -515,7 +530,7 @@ mod tests {
             ]
         );
         assert_eq!(&*design.terms[2].columns, &[Loading::Covariate(2)]);
-        assert_eq!(design.frame.loading_column(0), &z0[..]);
-        assert_eq!(design.frame.loading_column(2), &z1[..]);
+        assert_eq!(design.loading_column(0), &z0[..]);
+        assert_eq!(design.loading_column(2), &z1[..]);
     }
 }

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -78,10 +78,29 @@ impl<T> Loading<T> {
     }
 }
 
+/// Mapping between caller-visible factor labels and numerical level positions.
+///
+/// This is an identity mapping for the existing dense `u32` API. Later
+/// encodings can store an explicit mapping without changing `TermMeta`.
+#[derive(Debug, Clone)]
+pub(crate) struct FactorEncoding {
+    n_levels: usize,
+}
+
+impl FactorEncoding {
+    fn identity(n_levels: usize) -> Self {
+        Self { n_levels }
+    }
+
+    pub(crate) fn n_levels(&self) -> usize {
+        self.n_levels
+    }
+}
+
 /// Per-term metadata; coefficient `c` of `level` lives at `offset + c · n_levels + level`.
 #[derive(Debug, Clone)]
 pub(crate) struct TermMeta {
-    pub n_levels: usize,
+    pub(crate) encoding: FactorEncoding,
     pub offset: usize,
     /// Non-decreasing in the design's internal row order (fixed at construction).
     pub sorted: bool,
@@ -90,17 +109,21 @@ pub(crate) struct TermMeta {
 }
 
 impl TermMeta {
+    pub fn n_levels(&self) -> usize {
+        self.encoding.n_levels()
+    }
+
     pub fn n_columns(&self) -> usize {
         self.columns.len()
     }
 
     pub fn n_dofs(&self) -> usize {
-        self.n_columns() * self.n_levels
+        self.n_columns() * self.n_levels()
     }
 
     /// Global DOF base of coefficient column `column`.
     pub fn column_base(&self, column: usize) -> usize {
-        self.offset + column * self.n_levels
+        self.offset + column * self.n_levels()
     }
 }
 
@@ -209,8 +232,9 @@ impl<'a> Design<'a> {
                 sorted &= v >= prev;
                 prev = v;
             }
+            let encoding = FactorEncoding::identity(max as usize + 1);
             let meta = TermMeta {
-                n_levels: max as usize + 1,
+                encoding,
                 offset,
                 sorted,
                 columns,
@@ -228,7 +252,7 @@ impl<'a> Design<'a> {
         let dominant = (0..terms.len()).max_by_key(|&q| terms[q].n_dofs());
         let (frame, obs_perm) = match dominant {
             Some(d) if locality_sort && !terms[d].sorted && u32::try_from(n_obs).is_ok() => {
-                let perm = stable_argsort(frame.level_column(d), terms[d].n_levels);
+                let perm = stable_argsort(frame.level_column(d), terms[d].n_levels());
                 let sorted_frame = frame.permuted(&perm);
                 // Factors nested in the dominant one come out sorted, keeping coalesced scatter.
                 for (q, meta) in terms.iter_mut().enumerate() {

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -70,15 +70,15 @@ fn residual_shares(
         return Vec::new();
     }
     let moments = &moments[term];
-    let levels = design.frame.level_column(term);
+    let levels = design.level_column(term);
     let zs: Vec<&[f64]> = moments
         .covariates()
         .iter()
-        .map(|&c| design.frame.loading_column(c as usize))
+        .map(|&c| design.loading_column(c as usize))
         .collect();
     let columns: Vec<&[f64]> = targets
         .iter()
-        .map(|&(_, c)| design.frame.loading_column(c as usize))
+        .map(|&(_, c)| design.loading_column(c as usize))
         .collect();
     let stride = columns.len() * (zs.len() + 1);
     let n_levels = moments.n_levels();

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -8,7 +8,7 @@ use rayon::prelude::*;
 use super::level_moments::{BasisScratch, LevelMoments, TermMoments};
 use super::Design;
 use crate::channel::Channel;
-use crate::BuildWarning;
+use crate::{AliasVerdict, BuildWarning};
 
 /// Residual share below which a covariate counts as reproduced by the other term.
 const COLLINEARITY_TOL: f64 = 1e-3;
@@ -41,6 +41,7 @@ pub(crate) fn detect_collinear_slopes(
                         slope,
                         term,
                         relative_residual,
+                        verdict: AliasVerdict::Kept,
                     },
                 )
         })
@@ -88,7 +89,6 @@ fn residual_shares(
         weights,
         zs,
         columns,
-        zeros: vec![0.0; moments.n_slopes()],
         moments,
         stride,
         // Grouping gathers every column, so it must buy back more than the one block.
@@ -135,7 +135,6 @@ struct Screen<'a> {
     weights: Option<&'a [f64]>,
     zs: Vec<&'a [f64]>,
     columns: Vec<&'a [f64]>,
-    zeros: Vec<f64>,
     moments: &'a LevelMoments,
     order: RowOrder,
     /// One level's row of the table: `[Σw·c, Σw·z·c]` per target.
@@ -154,14 +153,6 @@ impl Screen<'_> {
             let w = self.weights.map_or(1.0, |w| w[obs]);
             (w > 0.0).then(|| (obs, w, self.levels[obs] as usize - first))
         })
-    }
-
-    /// Without an intercept the level's span holds no constant, so `z` enters uncentered.
-    fn center(&self, level: usize) -> &[f64] {
-        match self.moments.intercept() {
-            true => self.moments.mean(level),
-            false => &self.zeros,
-        }
     }
 
     /// Each target's total variation rides this pass, since the rows are already loaded.
@@ -213,7 +204,7 @@ impl Screen<'_> {
                     if v > 0 {
                         self.moments.basis(level, scratch);
                     }
-                    let center = self.center(level);
+                    let center = self.moments.center(level);
                     for slot in row.chunks_exact_mut(v + 1) {
                         let sum_wc = slot[0];
                         for ((dj, &xj), &cj) in d.iter_mut().zip(&slot[1..]).zip(center) {
@@ -259,7 +250,7 @@ impl Screen<'_> {
                     for (obs, w, row) in self.active_rows(first, rows) {
                         for (dzj, (z, &cj)) in dz
                             .iter_mut()
-                            .zip(self.zs.iter().zip(self.center(first + row)))
+                            .zip(self.zs.iter().zip(self.moments.center(first + row)))
                         {
                             *dzj = z[obs] - cj;
                         }

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -26,7 +26,7 @@ pub(crate) fn find_all_active_levels(design: &Design<'_>) -> Vec<Vec<bool>> {
     let mut active: Vec<Vec<bool>> = design
         .terms
         .iter()
-        .map(|f| vec![false; f.n_levels])
+        .map(|f| vec![false; f.n_levels()])
         .collect();
     // Factor-outer/obs-inner: all writes for a factor land in one `active[f]` buffer.
     for (f, col) in active.iter_mut().enumerate() {

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -30,7 +30,7 @@ pub(crate) fn find_all_active_levels(design: &Design<'_>) -> Vec<Vec<bool>> {
         .collect();
     // Factor-outer/obs-inner: all writes for a factor land in one `active[f]` buffer.
     for (f, col) in active.iter_mut().enumerate() {
-        for &v in design.frame.level_column(f) {
+        for &v in design.level_column(f) {
             col[v as usize] = true;
         }
     }

--- a/crates/within/src/domain/cross_tab/accumulate.rs
+++ b/crates/within/src/domain/cross_tab/accumulate.rs
@@ -95,12 +95,10 @@ pub(super) fn accumulate_cross_block(
     let sparse_cost = design.n_obs.saturating_mul(12);
     let go_sparse = table_size > DENSE_TABLE_MAX_ENTRIES && sparse_cost < dense_cost;
 
-    let row_levels = design.frame.level_column(pair.rows.term);
-    let col_levels = design.frame.level_column(pair.cols.term);
-    let load = |col: ColumnLoading<u32>| {
-        col.covariate()
-            .map(|&c| design.frame.loading_column(c as usize))
-    };
+    let row_levels = design.level_column(pair.rows.term);
+    let col_levels = design.level_column(pair.cols.term);
+    let load =
+        |col: ColumnLoading<u32>| col.covariate().map(|&c| design.loading_column(c as usize));
     // One arm per loading combination; closures aren't generic, so the literals repeat.
     match (
         load(design.loading(pair.rows)),

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -328,9 +328,9 @@ fn dense_and_sparse_paths_agree_on_signed_data() {
     .expect("both factors have active levels");
 
     let cols = PairColumns {
-        row_levels: design.frame.level_column(0),
-        col_levels: design.frame.level_column(1),
-        row_load: design.frame.loading_column(0),
+        row_levels: design.level_column(0),
+        col_levels: design.level_column(1),
+        row_load: design.loading_column(0),
         col_load: Unit,
         weights: None,
     };

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -70,9 +70,9 @@ impl LevelMoments {
         let v = covariates.len();
         let mut moments = Self {
             intercept: v < meta.columns.len(),
-            w_sum: vec![0.0; meta.n_levels],
-            mean: vec![0.0; meta.n_levels * v],
-            comoment: vec![0.0; meta.n_levels * tri_len(v)],
+            w_sum: vec![0.0; meta.n_levels()],
+            mean: vec![0.0; meta.n_levels() * v],
+            comoment: vec![0.0; meta.n_levels() * tri_len(v)],
             covariates,
         };
         let zs: Vec<&[f64]> = moments

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -7,7 +7,7 @@ use super::Design;
 
 /// Relative rank tolerance: a slope direction drops once its remaining
 /// within-level variance falls to `RANK_TOL` × its own initial variance.
-pub(crate) const RANK_TOL: f64 = 1e-10;
+const RANK_TOL: f64 = 1e-10;
 
 /// Every term's [`LevelMoments`], indexed by term.
 pub(crate) struct TermMoments(Vec<LevelMoments>);
@@ -48,6 +48,8 @@ pub(crate) struct LevelMoments {
     mean: Vec<f64>,
     /// Per level, `Σ w (z−μ)(z−μ)ᵀ` packed as a row-major lower triangle.
     comoment: Vec<f64>,
+    /// Returned by [`Self::center`] for an intercept-free term.
+    zeros: Box<[f64]>,
 }
 
 /// Index of `(j, k)`, `k ≤ j`, in a packed row-major lower triangle.
@@ -73,6 +75,7 @@ impl LevelMoments {
             w_sum: vec![0.0; meta.n_levels()],
             mean: vec![0.0; meta.n_levels() * v],
             comoment: vec![0.0; meta.n_levels() * tri_len(v)],
+            zeros: vec![0.0; v].into(),
             covariates,
         };
         let zs: Vec<&[f64]> = moments
@@ -134,9 +137,17 @@ impl LevelMoments {
         self.w_sum[level]
     }
 
-    pub(crate) fn mean(&self, level: usize) -> &[f64] {
+    fn mean(&self, level: usize) -> &[f64] {
         let v = self.n_slopes();
         &self.mean[level * v..][..v]
+    }
+
+    /// What a fit on the level's span centers against; no intercept, no constant to remove.
+    pub(crate) fn center(&self, level: usize) -> &[f64] {
+        match self.intercept {
+            true => self.mean(level),
+            false => &self.zeros,
+        }
     }
 
     /// The level's orthonormal rows `w` (`w·G·wᵀ = I`) and kept-column mask,

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -78,11 +78,11 @@ impl LevelMoments {
         let zs: Vec<&[f64]> = moments
             .covariates
             .iter()
-            .map(|&c| design.frame.loading_column(c as usize))
+            .map(|&c| design.loading_column(c as usize))
             .collect();
         let mut z_row = vec![0.0; v];
         let mut delta = vec![0.0; v];
-        for (obs, &level) in design.frame.level_column(term).iter().enumerate() {
+        for (obs, &level) in design.level_column(term).iter().enumerate() {
             for (zr, col) in z_row.iter_mut().zip(&zs) {
                 *zr = col[obs];
             }

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -129,7 +129,27 @@ pub enum BuildWarning {
         term: usize,
         /// Share of the covariate's weighted variation outside that term's span.
         relative_residual: f64,
+        /// Whether the direction spanning both terms left the solve space.
+        verdict: AliasVerdict,
     },
+}
+
+/// What became of a warned cross-term direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AliasVerdict {
+    /// Certified null against the design and removed from the solve space.
+    Constrained,
+    /// Carries information the data can still resolve, so the iteration keeps it.
+    Kept,
+}
+
+impl std::fmt::Display for AliasVerdict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Constrained => "was removed from the solve space",
+            Self::Kept => "stays in the solve space, where iteration counts can inflate by orders of magnitude",
+        })
+    }
 }
 
 impl std::fmt::Display for BuildWarning {
@@ -149,11 +169,12 @@ impl std::fmt::Display for BuildWarning {
                 slope,
                 term,
                 relative_residual,
+                verdict,
             } => write!(
                 f,
                 "slope covariate of {slope} is nearly collinear with the columns of term \
-                 {term} (relative residual {relative_residual:.2e}); the near-null direction \
-                 spanning both terms can inflate iteration counts by orders of magnitude"
+                 {term} (relative residual {relative_residual:.2e}); the direction spanning \
+                 both terms {verdict}"
             ),
         }
     }

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -43,7 +43,7 @@ pub use config::{
     ReductionStrategy, ScalingConfig, ScalingFailure, SchurMode,
 };
 pub use domain::{Design, Effect, FactorLabel};
-pub use error::{BuildError, BuildWarning, SolveError, WithinError};
+pub use error::{AliasVerdict, BuildError, BuildWarning, SolveError, WithinError};
 pub use operator::schwarz::Preconditioner;
 pub use solver::{
     solve, solve_batch, BatchSolveResult, CoefficientAddress, CoefficientLayout, IntoDesign,

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -42,7 +42,7 @@ pub use config::{
     ApproxCholConfig, ApproxSchurConfig, LocalSolverConfig, LsmrOptions, PreconditionerConfig,
     ReductionStrategy, ScalingConfig, ScalingFailure, SchurMode,
 };
-pub use domain::{Design, Effect};
+pub use domain::{Design, Effect, FactorLabel};
 pub use error::{BuildError, BuildWarning, SolveError, WithinError};
 pub use operator::schwarz::Preconditioner;
 pub use solver::{

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -52,6 +52,27 @@ impl<'a> DesignOperator<'a> {
         }
     }
 
+    /// Squared column norms `diag(AᵀA)`: the operator's own scale for a coefficient direction,
+    /// which a whitened parameterization makes weight-dependent in a way `‖x‖` is not.
+    pub(crate) fn column_norms_squared(&self) -> Vec<f64> {
+        let mut diag = vec![0.0; self.design.n_dofs];
+        for (index, term) in self.design.terms.iter().enumerate() {
+            let levels = self.design.level_column(index);
+            let w = |obs: usize| self.sqrt_weights.map_or(1.0, |sw| sw[obs] * sw[obs]);
+            for (column, loading) in term.columns.iter().enumerate() {
+                let base = term.column_base(column);
+                let slice = &mut diag[base..base + term.n_levels()];
+                let z = loading
+                    .covariate()
+                    .map(|&c| self.design.loading_column(c as usize));
+                for (obs, &level) in levels.iter().enumerate() {
+                    slice[level as usize] += w(obs) * z.map_or(1.0, |z| z[obs] * z[obs]);
+                }
+            }
+        }
+        diag
+    }
+
     /// Observation-space RHS `b = W^{1/2} y`; borrows unweighted, owns weighted.
     pub(crate) fn weighted_rhs<'y>(&self, y: &'y [f64]) -> Cow<'y, [f64]> {
         match self.sqrt_weights {

--- a/crates/within/src/operator/design/gather.rs
+++ b/crates/within/src/operator/design/gather.rs
@@ -19,34 +19,33 @@ pub(crate) fn gather_apply(
 
     dst.fill(0.0);
 
-    let frame = &design.frame;
     for_each_chunk(dst, |chunk, row_start| {
         for (q, t) in design.terms.iter().enumerate() {
             let (offset, n_levels) = (t.offset, t.n_levels);
-            let levels = frame.level_column(q);
+            let levels = design.level_column(q);
             let col = |c: usize| &src[offset + c * n_levels..offset + (c + 1) * n_levels];
             match &*t.columns {
                 [Loading::Constant] => gather_term(chunk, row_start, levels, [col(0)], |_| [1.0]),
                 [Loading::Constant, Loading::Covariate(c0)] => {
-                    let z0 = frame.loading_column(*c0 as usize);
+                    let z0 = design.loading_column(*c0 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1)], |i| [1.0, z0[i]])
                 }
                 [Loading::Constant, Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                    let z0 = frame.loading_column(*c0 as usize);
-                    let z1 = frame.loading_column(*c1 as usize);
+                    let z0 = design.loading_column(*c0 as usize);
+                    let z1 = design.loading_column(*c1 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1), col(2)], |i| {
                         [1.0, z0[i], z1[i]]
                     })
                 }
                 [Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                    let z0 = frame.loading_column(*c0 as usize);
-                    let z1 = frame.loading_column(*c1 as usize);
+                    let z0 = design.loading_column(*c0 as usize);
+                    let z1 = design.loading_column(*c1 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1)], |i| {
                         [z0[i], z1[i]]
                     })
                 }
                 [Loading::Covariate(c0)] => {
-                    let z0 = frame.loading_column(*c0 as usize);
+                    let z0 = design.loading_column(*c0 as usize);
                     gather_term(chunk, row_start, levels, [col(0)], |i| [z0[i]])
                 }
                 columns => {
@@ -60,7 +59,7 @@ pub(crate) fn gather_apply(
                             acc += match loading {
                                 Loading::Constant => coef,
                                 Loading::Covariate(k) => {
-                                    coef * frame.loading_column(*k as usize)[i]
+                                    coef * design.loading_column(*k as usize)[i]
                                 }
                             };
                         }

--- a/crates/within/src/operator/design/gather.rs
+++ b/crates/within/src/operator/design/gather.rs
@@ -21,7 +21,7 @@ pub(crate) fn gather_apply(
 
     for_each_chunk(dst, |chunk, row_start| {
         for (q, t) in design.terms.iter().enumerate() {
-            let (offset, n_levels) = (t.offset, t.n_levels);
+            let (offset, n_levels) = (t.offset, t.n_levels());
             let levels = design.level_column(q);
             let col = |c: usize| &src[offset + c * n_levels..offset + (c + 1) * n_levels];
             match &*t.columns {

--- a/crates/within/src/operator/design/scatter.rs
+++ b/crates/within/src/operator/design/scatter.rs
@@ -52,8 +52,8 @@ pub(super) fn scatter_apply(
             }
             columns => {
                 for (c, loading) in columns.iter().enumerate() {
-                    let start = c * t.n_levels;
-                    let slot = &mut block[start..start + t.n_levels];
+                    let start = c * t.n_levels();
+                    let slot = &mut block[start..start + t.n_levels()];
                     match loading {
                         Loading::Constant => {
                             scatter_term::<1>(slot, t, levels, parallel, scratch, |i| [base(i)]);
@@ -80,7 +80,7 @@ fn scatter_term<const C: usize>(
     scratch: &[AtomicF64],
     values: impl Fn(usize) -> [f64; C] + Sync,
 ) {
-    let n_levels = meta.n_levels;
+    let n_levels = meta.n_levels();
     debug_assert_eq!(block.len(), C * n_levels);
     match ScatterStrategy::pick(parallel, C * n_levels, meta.sorted) {
         ScatterStrategy::Sequential => scatter_sequential::<C>(block, n_levels, levels, &values),

--- a/crates/within/src/operator/design/scatter.rs
+++ b/crates/within/src/operator/design/scatter.rs
@@ -19,33 +19,32 @@ pub(super) fn scatter_apply(
 ) {
     debug_assert_eq!(dst.len(), design.n_dofs);
     let parallel = design.n_obs > PAR_THRESHOLD;
-    let frame = &design.frame;
 
     for (q, t) in design.terms.iter().enumerate() {
-        let levels = frame.level_column(q);
+        let levels = design.level_column(q);
         let block = &mut dst[t.offset..t.offset + t.n_dofs()];
         match &*t.columns {
             [Loading::Constant] => {
                 scatter_term::<1>(block, t, levels, parallel, scratch, |i| [base(i)])
             }
             [Loading::Constant, Loading::Covariate(c0)] => {
-                let z0 = frame.loading_column(*c0 as usize);
+                let z0 = design.loading_column(*c0 as usize);
                 scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [b, z0[i] * b]
                 })
             }
             [Loading::Constant, Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                let z0 = frame.loading_column(*c0 as usize);
-                let z1 = frame.loading_column(*c1 as usize);
+                let z0 = design.loading_column(*c0 as usize);
+                let z1 = design.loading_column(*c1 as usize);
                 scatter_term::<3>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [b, z0[i] * b, z1[i] * b]
                 })
             }
             [Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                let z0 = frame.loading_column(*c0 as usize);
-                let z1 = frame.loading_column(*c1 as usize);
+                let z0 = design.loading_column(*c0 as usize);
+                let z1 = design.loading_column(*c1 as usize);
                 scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [z0[i] * b, z1[i] * b]
@@ -60,7 +59,7 @@ pub(super) fn scatter_apply(
                             scatter_term::<1>(slot, t, levels, parallel, scratch, |i| [base(i)]);
                         }
                         Loading::Covariate(k) => {
-                            let z = frame.loading_column(*k as usize);
+                            let z = design.loading_column(*k as usize);
                             scatter_term::<1>(slot, t, levels, parallel, scratch, move |i| {
                                 [z[i] * base(i)]
                             });

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -307,7 +307,7 @@ mod slope_design_tests {
         for (q, t) in design.terms.iter().enumerate() {
             let levels = design.level_column(q);
             for (c, loading) in t.columns.iter().enumerate() {
-                let base = t.offset + c * t.n_levels;
+                let base = t.offset + c * t.n_levels();
                 for (i, &lev) in levels.iter().enumerate() {
                     d[i][base + lev as usize] = match loading {
                         Loading::Constant => 1.0,

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -305,13 +305,13 @@ mod slope_design_tests {
     fn dense_matrix(design: &Design<'_>) -> Vec<Vec<f64>> {
         let mut d = vec![vec![0.0; design.n_dofs]; design.n_obs];
         for (q, t) in design.terms.iter().enumerate() {
-            let levels = design.frame.level_column(q);
+            let levels = design.level_column(q);
             for (c, loading) in t.columns.iter().enumerate() {
                 let base = t.offset + c * t.n_levels;
                 for (i, &lev) in levels.iter().enumerate() {
                     d[i][base + lev as usize] = match loading {
                         Loading::Constant => 1.0,
-                        Loading::Covariate(k) => design.frame.loading_column(*k as usize)[i],
+                        Loading::Covariate(k) => design.loading_column(*k as usize)[i],
                     };
                 }
             }

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -221,7 +221,7 @@ fn build_diagonal(
         let w = |uid: usize| weights.map_or(1.0, |ws| ws[uid]);
         for (column, loading) in term.columns.iter().enumerate() {
             let base = term.column_base(column);
-            let slice = &mut diag[base..base + term.n_levels];
+            let slice = &mut diag[base..base + term.n_levels()];
             match loading {
                 Loading::Constant => {
                     for (uid, &level) in levels.iter().enumerate() {

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -217,7 +217,7 @@ fn build_diagonal(
     let mut diag = vec![0.0; design.n_dofs];
 
     for (factor_idx, term) in design.terms.iter().enumerate() {
-        let levels = design.frame.level_column(factor_idx);
+        let levels = design.level_column(factor_idx);
         let w = |uid: usize| weights.map_or(1.0, |ws| ws[uid]);
         for (column, loading) in term.columns.iter().enumerate() {
             let base = term.column_base(column);
@@ -229,7 +229,7 @@ fn build_diagonal(
                     }
                 }
                 Loading::Covariate(z_col) => {
-                    let z = design.frame.loading_column(*z_col as usize);
+                    let z = design.loading_column(*z_col as usize);
                     for (uid, &level) in levels.iter().enumerate() {
                         // Keep `w * z * z` left-to-right: a zero weight kills a huge `z` first.
                         slice[level as usize] += w(uid) * z[uid] * z[uid];

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -13,12 +13,12 @@ use crate::channel::Channel;
 use crate::config::{LsmrOptions, PreconditionerConfig};
 use crate::domain::collinearity::detect_collinear_slopes;
 use crate::domain::level_moments::TermMoments;
-use crate::domain::{Design, Effect};
+use crate::domain::{Design, Effect, FactorEncoding};
 use crate::observation::ObservationFrame;
 use crate::operator::design::gather_apply;
 use crate::operator::schwarz::{build_preconditioner, Preconditioner};
 use crate::operator::DesignOperator;
-use crate::{BuildError, BuildWarning, SolveError, WithinError};
+use crate::{BuildError, BuildWarning, FactorLabel, SolveError, WithinError};
 
 mod reparam;
 #[cfg(test)]
@@ -112,27 +112,47 @@ impl From<&Preconditioner> for PreconditionerInput {
 }
 
 /// One coefficient of the design: a [`Channel`] at one level of its term.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CoefficientAddress {
     /// The coefficient column this address sits in.
     pub channel: Channel,
-    /// Level index within the term (`0..n_levels`).
-    pub level: usize,
+    /// Caller-visible factor label.
+    pub level: FactorLabel,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CoefficientPosition {
+    channel: Channel,
+    level: usize,
+}
+
+impl CoefficientPosition {
+    fn to_caller_address(self, design: &Design) -> CoefficientAddress {
+        let level = design.terms[self.channel.term]
+            .encoding
+            .label(self.level)
+            .expect("coefficient position belongs to its term");
+
+        CoefficientAddress {
+            channel: self.channel,
+            level,
+        }
+    }
 }
 
 /// Translates a [`CoefficientAddress`] to its flat index in [`SolveResult::x`]
-/// and back, so callers need not reconstruct the term-major offset formula
-/// (`offset + column * n_levels + level`) by hand.
+/// and back, including the translation between caller-visible labels and
+/// internal compact level positions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CoefficientLayout {
     terms: Vec<TermLayout>,
     n_dofs: usize,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct TermLayout {
     offset: usize,
-    n_levels: usize,
+    encoding: FactorEncoding,
     n_columns: usize,
 }
 
@@ -143,7 +163,7 @@ impl CoefficientLayout {
             .iter()
             .map(|t| TermLayout {
                 offset: t.offset,
-                n_levels: t.n_levels(),
+                encoding: t.encoding.clone(),
                 n_columns: t.n_columns(),
             })
             .collect();
@@ -165,7 +185,7 @@ impl CoefficientLayout {
 
     /// Level count of `term`, or `None` if `term` is out of range.
     pub fn n_levels(&self, term: usize) -> Option<usize> {
-        self.terms.get(term).map(|t| t.n_levels)
+        self.terms.get(term).map(|t| t.encoding.n_levels())
     }
 
     /// Coefficient-column count of `term` (`intercept? + slopes`, ordered
@@ -174,12 +194,18 @@ impl CoefficientLayout {
         self.terms.get(term).map(|t| t.n_columns)
     }
 
-    /// Flat [`SolveResult::x`] index of `at`, or `None` if any coordinate is
-    /// out of range.
-    pub fn index(&self, at: CoefficientAddress) -> Option<usize> {
-        let t = self.terms.get(at.channel.term)?;
-        (at.level < t.n_levels && at.channel.column < t.n_columns)
-            .then(|| t.offset + at.channel.column * t.n_levels + at.level)
+    /// Flat [`SolveResult::x`] index of `at`, or `None` if its term,
+    /// column, or caller-visible level label is out of range.
+    pub fn index(&self, at: &CoefficientAddress) -> Option<usize> {
+        let term = self.terms.get(at.channel.term)?;
+
+        if at.channel.column >= term.n_columns {
+            return None;
+        }
+
+        let position = term.encoding.position(&at.level)?;
+
+        Some(term.offset + at.channel.column * term.encoding.n_levels() + position)
     }
 
     /// The address of flat index `i`, or `None` if `i >= n_dofs`.
@@ -191,12 +217,18 @@ impl CoefficientLayout {
         let term = self.terms.partition_point(|t| t.offset <= i) - 1;
         let t = &self.terms[term];
         let within = i - t.offset;
+        let n_levels = t.encoding.n_levels();
+        let level = t
+            .encoding
+            .label(within % n_levels)
+            .expect("coefficient position belongs to the term encoding");
+
         Some(CoefficientAddress {
             channel: Channel {
                 term,
-                column: within / t.n_levels,
+                column: within / n_levels,
             },
-            level: within % t.n_levels,
+            level,
         })
     }
 }
@@ -207,9 +239,10 @@ impl CoefficientLayout {
 pub struct SolveResult {
     /// Fixed-effect coefficients (length = total DOFs across all factors).
     ///
-    /// Term-major: coefficient column `c` of level `level` sits at
-    /// `term_offset + c * n_levels + level`, columns ordered
-    /// `[intercept?, slopes…]`. Slots for unidentified directions hold the
+    /// Term-major by compact level position `p`: coefficient column `c` sits at
+    /// `term_offset + c * n_levels + p`, with columns ordered
+    /// `[intercept?, slopes…]`. Use [`SolveResult::layout`] to translate caller
+    /// labels to these slots. Slots for unidentified directions hold the
     /// minimal-norm value `0`, never NaN; see [`SolveResult::unidentified`].
     pub x: Vec<f64>,
     /// Per-level directions the data cannot identify.
@@ -504,10 +537,15 @@ impl<'a> Solver<'a> {
     /// Per-level directions the data cannot identify, shared across all RHS:
     /// identification depends only on the design and weights, never on `y`.
     fn unidentified(&self) -> Vec<CoefficientAddress> {
-        self.reparam
-            .as_ref()
-            .map(|rp| rp.unidentified.clone())
-            .unwrap_or_default()
+        let Some(reparam) = &self.reparam else {
+            return Vec::new();
+        };
+        reparam
+            .unidentified
+            .iter()
+            .copied()
+            .map(|position| position.to_caller_address(&self.design))
+            .collect()
     }
 
     /// Solve for a single RHS vector with the given LSMR tuning.

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -143,7 +143,7 @@ impl CoefficientLayout {
             .iter()
             .map(|t| TermLayout {
                 offset: t.offset,
-                n_levels: t.n_levels,
+                n_levels: t.n_levels(),
                 n_columns: t.n_columns(),
             })
             .collect();

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 
 use ndarray::{ArrayView2, Axis};
 use rayon::prelude::*;
-use schwarz_precond::{lsmr as lsmr_solve, mlsmr, MlsmrOptions};
+use schwarz_precond::{lsmr as lsmr_solve, mlsmr, MlsmrOptions, Operator};
 
 use crate::channel::Channel;
 use crate::config::{LsmrOptions, PreconditionerConfig};
@@ -20,9 +20,11 @@ use crate::operator::schwarz::{build_preconditioner, Preconditioner};
 use crate::operator::DesignOperator;
 use crate::{BuildError, BuildWarning, FactorLabel, SolveError, WithinError};
 
+mod null_space;
 mod reparam;
 #[cfg(test)]
 mod tests;
+use null_space::ProjectedPreconditioner;
 use reparam::SlopeReparam;
 
 /// Fallible conversion into a [`Design`] for [`Solver::new`]: a categories
@@ -415,7 +417,7 @@ impl<'a> Solver<'a> {
         // Reparametrize the slope columns (if any) before the preconditioner reads the frame.
         let reparam = moments
             .as_ref()
-            .and_then(|m| SlopeReparam::build(&mut design, m));
+            .and_then(|m| SlopeReparam::build(&mut design, m, weights.as_deref(), &mut warnings));
 
         let (preconditioner, build_warnings) = match preconditioner.into() {
             PreconditionerInput::Default => {
@@ -502,7 +504,16 @@ impl<'a> Solver<'a> {
                     local_size: lsmr.local_size,
                     ..Default::default()
                 };
-                mlsmr(&rect_op, b, p, lsmr.tol, lsmr.maxiter, options)?
+                let projected = self
+                    .reparam
+                    .as_ref()
+                    .filter(|rp| rp.null.rank() > 0)
+                    .map(|rp| ProjectedPreconditioner::new(p, &rp.null));
+                let m: &dyn Operator = match &projected {
+                    Some(g) => g,
+                    None => p,
+                };
+                mlsmr(&rect_op, b, m, lsmr.tol, lsmr.maxiter, options)?
             }
             None => lsmr_solve(&rect_op, b, lsmr.tol, lsmr.maxiter, lsmr.local_size)?,
         };
@@ -541,7 +552,8 @@ impl<'a> Solver<'a> {
             return Vec::new();
         };
         reparam
-            .unidentified
+            .null
+            .dropped
             .iter()
             .copied()
             .map(|position| position.to_caller_address(&self.design))

--- a/crates/within/src/solver/null_space.rs
+++ b/crates/within/src/solver/null_space.rs
@@ -1,0 +1,258 @@
+//! The solve space's known null directions (#297): whitening's dropped columns, and cross-term
+//! aliasing the collinearity screen proposes and a backward-error test certifies.
+
+use std::sync::Mutex;
+
+use schwarz_precond::Operator;
+
+use super::CoefficientPosition;
+use crate::domain::Design;
+use crate::linalg::dot;
+use crate::operator::schwarz::Preconditioner;
+use crate::operator::DesignOperator;
+use crate::{AliasVerdict, BuildWarning};
+
+/// Share of a unit-norm candidate that must survive the rows already taken to become one.
+/// Below it the candidate is a rescaled duplicate, and normalizing would amplify its image.
+const RANK_SHARE_TOL: f64 = 1e-6;
+
+/// `‖A n‖ ≤ NULL_TOL · ‖ |A| |n| ‖` certifies a row as null: a backward error, so a uniform
+/// weight change cannot move the verdict. An alias lands at roundoff, a real direction far above.
+const NULL_TOL: f64 = 1e-11;
+
+/// Every direction the solve excludes; the operator, the preconditioner and the result read this.
+pub(crate) struct NullSpace {
+    /// Exact-zero whitened columns, ascending in `(term, level, column)`.
+    pub(super) dropped: Vec<CoefficientPosition>,
+    /// Certified cross-term directions, orthonormal; `k × n_dofs`, row-major.
+    pub(super) rows: Vec<f64>,
+    pub(super) n_dofs: usize,
+}
+
+/// One warned covariate, centered so the two per-level fits differ by the aliasing alone and
+/// weighted so the design's adjoint reads it directly.
+pub(super) struct AliasCandidate {
+    /// Index of the warning this came from, which names both terms and takes the verdict.
+    warning: usize,
+    weighted: Vec<f64>,
+}
+
+impl AliasCandidate {
+    /// Must run before whitening, which overwrites the covariate's column.
+    pub(super) fn capture(
+        design: &Design<'_>,
+        weights: Option<&[f64]>,
+        warnings: &[BuildWarning],
+    ) -> Vec<Self> {
+        warnings
+            .iter()
+            .enumerate()
+            .filter_map(|(warning, w)| {
+                let BuildWarning::CollinearSlopeCovariate { slope, term, .. } = w else {
+                    return None;
+                };
+                let covariate = *design.loading(*slope).covariate()?;
+                let c = design.loading_column(covariate as usize);
+                let (mut sum, mut total) = (0.0, 0.0);
+                for (obs, &ci) in c.iter().enumerate() {
+                    let w = weights.map_or(1.0, |ws| ws[obs]);
+                    sum += w * ci;
+                    total += w;
+                }
+                // Two intercepts alias through the ordinary FE gauge, not the covariate.
+                let intercepts = [slope.term, *term]
+                    .iter()
+                    .all(|&t| design.terms[t].intercept_column().is_some());
+                let origin = match intercepts && total > 0.0 {
+                    true => sum / total,
+                    false => 0.0,
+                };
+                Some(Self {
+                    warning,
+                    weighted: c
+                        .iter()
+                        .enumerate()
+                        .map(|(obs, &ci)| (ci - origin) * weights.map_or(1.0, |ws| ws[obs].sqrt()))
+                        .collect(),
+                })
+            })
+            .collect()
+    }
+}
+
+impl NullSpace {
+    pub(crate) fn rank(&self) -> usize {
+        self.rows.len() / self.n_dofs
+    }
+
+    /// Certify the proposals against the whitened design and record each verdict on its warning.
+    pub(super) fn constrain(
+        &mut self,
+        candidates: Vec<AliasCandidate>,
+        design: &Design<'_>,
+        weights: Option<&[f64]>,
+        warnings: &mut [BuildWarning],
+    ) {
+        if candidates.is_empty() {
+            return;
+        }
+        let n_dofs = self.n_dofs;
+        let sqrt_weights: Option<Vec<f64>> =
+            weights.map(|w| w.iter().map(|&wi| wi.sqrt()).collect());
+        let design_op = DesignOperator::new(design, sqrt_weights.as_deref());
+        // Whitening leaves a level's columns orthogonal, so `Aᵀc / diag(AᵀA)` is its per-level fit.
+        let scale = design_op.column_norms_squared();
+        let mut fit = vec![0.0f64; n_dofs];
+        let mut proposed: Vec<(usize, Vec<f64>)> = Vec::new();
+        for candidate in candidates {
+            let BuildWarning::CollinearSlopeCovariate { slope, term, .. } =
+                warnings[candidate.warning]
+            else {
+                continue;
+            };
+            design_op
+                .apply_adjoint(&candidate.weighted, &mut fit)
+                .expect("the design operator cannot fail");
+            let mut values = vec![0.0f64; n_dofs];
+            for (term, sign) in [(slope.term, 1.0), (term, -1.0)] {
+                let meta = &design.terms[term];
+                let block = meta.offset..meta.offset + meta.n_dofs();
+                for ((v, &f), &s) in values[block.clone()]
+                    .iter_mut()
+                    .zip(&fit[block.clone()])
+                    .zip(&scale[block])
+                {
+                    *v = match s > 0.0 {
+                        true => sign * f / s,
+                        false => 0.0,
+                    };
+                }
+            }
+            let norm = dot(&values, &values).sqrt();
+            if norm <= 0.0 || !norm.is_finite() {
+                continue;
+            }
+            for value in &mut values {
+                *value /= norm;
+            }
+            proposed.push((candidate.warning, values));
+        }
+
+        // Pivoted, so a near-duplicate is spent against the row it duplicates, never rescaled.
+        let mut directions: Vec<Vec<f64>> = proposed.iter().map(|(_, d)| d.clone()).collect();
+        let mut rows: Vec<f64> = Vec::new();
+        while let Some((next, share)) = directions
+            .iter()
+            .map(|d| dot(d, d).sqrt())
+            .enumerate()
+            .max_by(|left, right| left.1.total_cmp(&right.1))
+        {
+            if share.is_nan() || share <= RANK_SHARE_TOL {
+                break;
+            }
+            let mut row = directions.swap_remove(next);
+            for value in &mut row {
+                *value /= share;
+            }
+            for other in &mut directions {
+                // Twice, because one pass loses orthogonality exactly where the shares are small.
+                for _ in 0..2 {
+                    let overlap = dot(&row, other);
+                    for (o, &r) in other.iter_mut().zip(&row) {
+                        *o -= overlap * r;
+                    }
+                }
+            }
+            rows.extend_from_slice(&row);
+        }
+        let k = rows.len() / n_dofs;
+        if k == 0 {
+            return;
+        }
+
+        // Per row against the share of the Frobenius budget it may spend, so `‖A N‖_F` holds.
+        let budget = NULL_TOL / (k as f64).sqrt();
+        let mut obs = vec![0.0f64; design_op.nrows()];
+        for row in rows.chunks_exact(n_dofs) {
+            design_op
+                .apply(row, &mut obs)
+                .expect("the design operator cannot fail");
+            let reference: f64 = row.iter().zip(&scale).map(|(&r, &s)| r * r * s).sum();
+            if dot(&obs, &obs).sqrt() <= budget * reference.sqrt() {
+                self.rows.extend_from_slice(row);
+            }
+        }
+
+        // A proposal is removed exactly when the certified rows span it.
+        let mut residual = vec![0.0f64; n_dofs];
+        for (warning, direction) in &proposed {
+            residual.copy_from_slice(direction);
+            self.project(&mut residual);
+            let verdict = match dot(&residual, &residual).sqrt() <= RANK_SHARE_TOL {
+                true => AliasVerdict::Constrained,
+                false => AliasVerdict::Kept,
+            };
+            if let BuildWarning::CollinearSlopeCovariate { verdict: slot, .. } =
+                &mut warnings[*warning]
+            {
+                *slot = verdict;
+            }
+        }
+    }
+
+    /// `x ← (I − VVᵀ) x`.
+    pub(crate) fn project(&self, x: &mut [f64]) {
+        for row in self.rows.chunks_exact(self.n_dofs) {
+            let share = dot(row, x);
+            for (xi, &ri) in x.iter_mut().zip(row) {
+                *xi -= share * ri;
+            }
+        }
+    }
+}
+
+/// The base preconditioner restricted to the constrained solve space: `P M⁻¹ P`.
+pub(crate) struct ProjectedPreconditioner<'a> {
+    base: &'a Preconditioner,
+    null: &'a NullSpace,
+    /// The projected input; the preconditioner needs distinct in and out buffers.
+    scratch: Mutex<Vec<f64>>,
+}
+
+impl<'a> ProjectedPreconditioner<'a> {
+    pub(crate) fn new(base: &'a Preconditioner, null: &'a NullSpace) -> Self {
+        Self {
+            base,
+            null,
+            scratch: Mutex::new(vec![0.0; base.ncols()]),
+        }
+    }
+}
+
+impl Operator for ProjectedPreconditioner<'_> {
+    fn nrows(&self) -> usize {
+        self.base.nrows()
+    }
+
+    fn ncols(&self) -> usize {
+        self.base.ncols()
+    }
+
+    fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
+        let mut projected = self.scratch.lock().unwrap();
+        projected.copy_from_slice(x);
+        self.null.project(&mut projected);
+        self.base.apply(&projected, y)?;
+        self.null.project(y);
+        Ok(())
+    }
+
+    fn apply_adjoint(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
+        let mut projected = self.scratch.lock().unwrap();
+        projected.copy_from_slice(x);
+        self.null.project(&mut projected);
+        <Preconditioner as Operator>::apply_adjoint(self.base, &projected, y)?;
+        self.null.project(y);
+        Ok(())
+    }
+}

--- a/crates/within/src/solver/reparam.rs
+++ b/crates/within/src/solver/reparam.rs
@@ -3,9 +3,11 @@
 use crate::domain::level_moments::{BasisScratch, TermMoments};
 use crate::domain::Design;
 
+use super::null_space::{AliasCandidate, NullSpace};
 use super::CoefficientPosition;
 use crate::channel::Channel;
 use crate::linalg::dot;
+use crate::BuildWarning;
 
 #[cfg(test)]
 mod tests;
@@ -15,8 +17,8 @@ mod tests;
 /// parametrization.
 pub(crate) struct SlopeReparam {
     terms: Vec<TermReparam>,
-    /// Directions the data cannot identify, ascending in `(term, level, column)`.
-    pub(super) unidentified: Vec<CoefficientPosition>,
+    /// Every direction the solve space excludes.
+    pub(super) null: NullSpace,
 }
 
 /// One slope-bearing term's whitening state.
@@ -39,11 +41,17 @@ struct LevelTransform {
 }
 
 impl SlopeReparam {
-    /// Orthonormalize every slope-bearing term's loading columns in place;
-    /// `None` for slope-free designs. Unidentified directions become
-    /// exact-zero columns, so the minimal-norm solve leaves exact-`0`
-    /// coefficients.
-    pub(crate) fn build(design: &mut Design<'_>, moments: &TermMoments) -> Option<Self> {
+    /// Orthonormalize every slope-bearing term's loading columns in place and certify the
+    /// screen's aliasing proposals against the result; `None` for slope-free designs.
+    /// Unidentified directions become exact-zero columns, so the minimal-norm solve leaves
+    /// exact-`0` coefficients.
+    pub(crate) fn build(
+        design: &mut Design<'_>,
+        moments: &TermMoments,
+        weights: Option<&[f64]>,
+        warnings: &mut [BuildWarning],
+    ) -> Option<Self> {
+        let candidates = AliasCandidate::capture(design, weights, warnings);
         let mut terms = Vec::new();
         let mut unidentified = Vec::new();
         for term in 0..design.terms.len() {
@@ -56,10 +64,16 @@ impl SlopeReparam {
             }
             terms.push(TermReparam::build(design, term, moments, &mut unidentified));
         }
-        (!terms.is_empty()).then_some(Self {
-            terms,
-            unidentified,
-        })
+        if terms.is_empty() {
+            return None;
+        }
+        let mut null = NullSpace {
+            dropped: unidentified,
+            rows: Vec::new(),
+            n_dofs: design.n_dofs,
+        };
+        null.constrain(candidates, design, weights, warnings);
+        Some(Self { terms, null })
     }
 
     /// Map solve-basis coefficients back to the user's parametrization.
@@ -81,14 +95,13 @@ impl TermReparam {
     ) -> Self {
         let meta = &design.terms[term];
         let (offset, n_levels) = (meta.offset, meta.n_levels());
-        let mut intercept_column = None;
-        let mut slope_columns = Vec::new();
-        for (column, loading) in meta.columns.iter().enumerate() {
-            match loading.covariate() {
-                Some(_) => slope_columns.push(column),
-                None => intercept_column = Some(column),
-            }
-        }
+        let intercept_column = meta.intercept_column();
+        let slope_columns: Vec<usize> = meta
+            .columns
+            .iter()
+            .enumerate()
+            .filter_map(|(column, loading)| loading.covariate().map(|_| column))
+            .collect();
         let intercept = intercept_column.is_some();
         let moments = &moments[term];
         let v = moments.n_slopes();
@@ -119,14 +132,9 @@ impl TermReparam {
                     });
                 }
             }
-            let center = if intercept {
-                moments.mean(level).into()
-            } else {
-                vec![0.0; v].into()
-            };
             transforms.push(LevelTransform {
                 w: w.clone().into(),
-                center,
+                center: moments.center(level).into(),
             });
         }
 

--- a/crates/within/src/solver/reparam.rs
+++ b/crates/within/src/solver/reparam.rs
@@ -80,7 +80,7 @@ impl TermReparam {
         unidentified: &mut Vec<CoefficientAddress>,
     ) -> Self {
         let meta = &design.terms[term];
-        let (offset, n_levels) = (meta.offset, meta.n_levels);
+        let (offset, n_levels) = (meta.offset, meta.n_levels());
         let mut intercept_column = None;
         let mut slope_columns = Vec::new();
         for (column, loading) in meta.columns.iter().enumerate() {

--- a/crates/within/src/solver/reparam.rs
+++ b/crates/within/src/solver/reparam.rs
@@ -3,7 +3,7 @@
 use crate::domain::level_moments::{BasisScratch, TermMoments};
 use crate::domain::Design;
 
-use super::CoefficientAddress;
+use super::CoefficientPosition;
 use crate::channel::Channel;
 use crate::linalg::dot;
 
@@ -16,7 +16,7 @@ mod tests;
 pub(crate) struct SlopeReparam {
     terms: Vec<TermReparam>,
     /// Directions the data cannot identify, ascending in `(term, level, column)`.
-    pub(crate) unidentified: Vec<CoefficientAddress>,
+    pub(super) unidentified: Vec<CoefficientPosition>,
 }
 
 /// One slope-bearing term's whitening state.
@@ -77,7 +77,7 @@ impl TermReparam {
         design: &mut Design<'_>,
         term: usize,
         moments: &TermMoments,
-        unidentified: &mut Vec<CoefficientAddress>,
+        unidentified: &mut Vec<CoefficientPosition>,
     ) -> Self {
         let meta = &design.terms[term];
         let (offset, n_levels) = (meta.offset, meta.n_levels());
@@ -103,14 +103,14 @@ impl TermReparam {
             moments.basis(level, &mut scratch);
             let (w, kept) = (&scratch.basis, &scratch.kept);
             if intercept && moments.w_sum(level) == 0.0 {
-                unidentified.push(CoefficientAddress {
+                unidentified.push(CoefficientPosition {
                     channel: Channel { term, column: 0 },
                     level,
                 });
             }
             for (j, &kept_j) in kept.iter().enumerate() {
                 if !kept_j {
-                    unidentified.push(CoefficientAddress {
+                    unidentified.push(CoefficientPosition {
                         channel: Channel {
                             term,
                             column: slope_columns[j],

--- a/crates/within/src/solver/reparam.rs
+++ b/crates/within/src/solver/reparam.rs
@@ -93,11 +93,8 @@ impl TermReparam {
         let moments = &moments[term];
         let v = moments.n_slopes();
         let z_cols: Vec<usize> = moments.covariates().iter().map(|&c| c as usize).collect();
-        let levels = design.frame.level_column(term);
-        let zs: Vec<&[f64]> = z_cols
-            .iter()
-            .map(|&c| design.frame.loading_column(c))
-            .collect();
+        let levels = design.level_column(term);
+        let zs: Vec<&[f64]> = z_cols.iter().map(|&c| design.loading_column(c)).collect();
 
         let mut z_row = vec![0.0; v];
         let mut transforms = Vec::with_capacity(n_levels);
@@ -144,7 +141,7 @@ impl TermReparam {
             }
         }
         for (out, &c) in u_cols.into_iter().zip(&z_cols) {
-            design.frame.set_loading_column(c, out);
+            design.replace_loading_column(c, out);
         }
 
         Self {

--- a/crates/within/src/solver/reparam/tests.rs
+++ b/crates/within/src/solver/reparam/tests.rs
@@ -77,11 +77,11 @@ fn unidentified_directions_ascend_across_terms() {
     assert_eq!(
         rp.unidentified,
         vec![
-            CoefficientAddress {
+            CoefficientPosition {
                 channel: Channel { term: 0, column: 1 },
                 level: 1,
             },
-            CoefficientAddress {
+            CoefficientPosition {
                 channel: Channel { term: 1, column: 1 },
                 level: 0,
             },

--- a/crates/within/src/solver/reparam/tests.rs
+++ b/crates/within/src/solver/reparam/tests.rs
@@ -40,7 +40,7 @@ fn build_whitens_each_slope_bearing_term() {
             .filter_map(|c| c.covariate())
             .map(|&k| design.loading_column(k as usize))
             .collect();
-        for level in 0..meta.n_levels {
+        for level in 0..meta.n_levels() {
             let obs: Vec<usize> = (0..levels.len())
                 .filter(|&i| levels[i] as usize == level)
                 .collect();

--- a/crates/within/src/solver/reparam/tests.rs
+++ b/crates/within/src/solver/reparam/tests.rs
@@ -33,12 +33,12 @@ fn build_whitens_each_slope_bearing_term() {
 
     for term in [0, 2] {
         let meta = &design.terms[term];
-        let levels = design.frame.level_column(term);
+        let levels = design.level_column(term);
         let us: Vec<&[f64]> = meta
             .columns
             .iter()
             .filter_map(|c| c.covariate())
-            .map(|&k| design.frame.loading_column(k as usize))
+            .map(|&k| design.loading_column(k as usize))
             .collect();
         for level in 0..meta.n_levels {
             let obs: Vec<usize> = (0..levels.len())

--- a/crates/within/src/solver/reparam/tests.rs
+++ b/crates/within/src/solver/reparam/tests.rs
@@ -28,8 +28,8 @@ fn three_term_effects() -> Vec<Effect<'static>> {
 fn build_whitens_each_slope_bearing_term() {
     let mut design = Design::new(three_term_effects()).unwrap();
     let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
-    assert!(rp.unidentified.is_empty());
+    let rp = SlopeReparam::build(&mut design, &moments, None, &mut []).unwrap();
+    assert!(rp.null.dropped.is_empty());
 
     for term in [0, 2] {
         let meta = &design.terms[term];
@@ -73,9 +73,9 @@ fn unidentified_directions_ascend_across_terms() {
     ];
     let mut design = Design::new(effects).unwrap();
     let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
+    let rp = SlopeReparam::build(&mut design, &moments, None, &mut []).unwrap();
     assert_eq!(
-        rp.unidentified,
+        rp.null.dropped,
         vec![
             CoefficientPosition {
                 channel: Channel { term: 0, column: 1 },
@@ -93,7 +93,7 @@ fn unidentified_directions_ascend_across_terms() {
 fn back_transform_leaves_other_terms_untouched() {
     let mut design = Design::new(three_term_effects()).unwrap();
     let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
+    let rp = SlopeReparam::build(&mut design, &moments, None, &mut []).unwrap();
 
     let mut x: Vec<f64> = (0..design.n_dofs).map(|i| 1.0 + i as f64).collect();
     let before = x.clone();

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -10,10 +10,10 @@ use crate::Effect;
 /// in `tests/slopes_routing.rs`. A positive slope-only term is not centered by
 /// whitening, so the signed pair stays all-positive — balanced — while generic
 /// `z` keeps it strictly inside the PSD cone: genuine surplus, grounded.
-fn at(term: usize, level: usize, column: usize) -> CoefficientAddress {
+fn at(term: usize, level: u32, column: usize) -> CoefficientAddress {
     CoefficientAddress {
         channel: Channel { term, column },
-        level,
+        level: level.into(),
     }
 }
 
@@ -75,19 +75,19 @@ fn coefficient_layout_translates_addresses_both_ways() {
     assert_eq!(layout.n_levels(2), None);
 
     // Forward matches the documented `offset + column * n_levels + level`.
-    assert_eq!(layout.index(at(0, 2, 0)), Some(2));
-    assert_eq!(layout.index(at(1, 0, 0)), Some(3)); // term-1 intercept, level 0
-    assert_eq!(layout.index(at(1, 1, 1)), Some(6)); // term-1 slope, level 1
+    assert_eq!(layout.index(&at(0, 2, 0)), Some(2));
+    assert_eq!(layout.index(&at(1, 0, 0)), Some(3)); // term-1 intercept, level 0
+    assert_eq!(layout.index(&at(1, 1, 1)), Some(6)); // term-1 slope, level 1
     assert_eq!(layout.n_dofs(), 7);
 
     // Out-of-range coordinates are rejected, not silently wrapped.
-    assert_eq!(layout.index(at(1, 2, 0)), None); // level past n_levels
-    assert_eq!(layout.index(at(1, 0, 2)), None); // column past n_columns
-    assert_eq!(layout.index(at(2, 0, 0)), None); // term past n_terms
+    assert_eq!(layout.index(&at(1, 2, 0)), None); // level past n_levels
+    assert_eq!(layout.index(&at(1, 0, 2)), None); // column past n_columns
+    assert_eq!(layout.index(&at(2, 0, 0)), None); // term past n_terms
     assert_eq!(layout.address(7), None);
 
     // `address` inverts `index` for every flat slot.
     for i in 0..layout.n_dofs() {
-        assert_eq!(layout.index(layout.address(i).expect("in range")), Some(i));
+        assert_eq!(layout.index(&layout.address(i).expect("in range")), Some(i));
     }
 }

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -1,10 +1,17 @@
+use std::ops::Range;
+
+use rstest::rstest;
+
 use super::reparam::SlopeReparam;
 use super::{CoefficientAddress, CoefficientLayout};
 use crate::channel::Channel;
-use crate::config::{LocalSolverConfig, DEFAULT_DENSE_SCHUR_THRESHOLD};
+use crate::config::{
+    LocalSolverConfig, LsmrOptions, PreconditionerConfig, DEFAULT_DENSE_SCHUR_THRESHOLD,
+};
 use crate::domain::level_moments::TermMoments;
 use crate::domain::{build_local_domains, Design, Grounding, MatrixForm};
 use crate::Effect;
+use crate::Solver;
 
 /// DGP kept in lockstep with `surplus_component_sampled_matches_exact_reduction`
 /// in `tests/slopes_routing.rs`. A positive slope-only term is not centered by
@@ -36,7 +43,7 @@ fn positive_slope_only_pair_grounds_beyond_dense_threshold() {
     ];
     let mut design = Design::new(effects).expect("design");
     let moments = TermMoments::build(&design, None).expect("slopes");
-    let _reparam = SlopeReparam::build(&mut design, &moments);
+    let _reparam = SlopeReparam::build(&mut design, &moments, None, &mut []);
     let (domains, warnings) =
         build_local_domains(&design, None, &LocalSolverConfig::default()).expect("domains");
     assert!(
@@ -90,4 +97,335 @@ fn coefficient_layout_translates_addresses_both_ways() {
     for i in 0..layout.n_dofs() {
         assert_eq!(layout.index(&layout.address(i).expect("in range")), Some(i));
     }
+}
+
+/// Worker/firm/year AKM panel; each worker is observed every year and moves firm
+/// with probability `mobility`. `spec` picks how the worker's slope covariate relates
+/// to the rest of the design.
+#[derive(Clone, Copy, Debug)]
+enum SlopeSpec {
+    /// No relationship: the slope is its own variation.
+    Independent,
+    /// Exactly the year index, which term `year` reproduces per level.
+    YearIndex,
+    /// The year index perturbed off the year term's span by the given amount.
+    NearYearIndex(f64),
+    /// The same covariate carried by both the worker and the firm term.
+    SharedWithFirm,
+}
+
+struct AkmPanel {
+    worker: Vec<u32>,
+    firm: Vec<u32>,
+    year: Vec<u32>,
+    z: Vec<f64>,
+    y: Vec<f64>,
+    spec: SlopeSpec,
+}
+
+impl AkmPanel {
+    fn effects(&self) -> Vec<Effect<'_>> {
+        let worker = Effect::new(&self.worker, true, [&self.z[..]]);
+        let firm = match self.spec {
+            SlopeSpec::SharedWithFirm => Effect::new(&self.firm, true, [&self.z[..]]),
+            _ => Effect::new(&self.firm, true, []),
+        };
+        vec![
+            worker.expect("worker term"),
+            firm.expect("firm term"),
+            Effect::new(&self.year, true, []).expect("year term"),
+        ]
+    }
+}
+
+fn akm_panel(
+    n_workers: usize,
+    n_firms: usize,
+    n_years: usize,
+    mobility: f64,
+    spec: SlopeSpec,
+) -> AkmPanel {
+    let mut state = 0x2545_f491_4f6c_dd1du64;
+    let mut next = move || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        (state >> 11) as f64 / (1u64 << 53) as f64
+    };
+    let mut panel = AkmPanel {
+        worker: Vec::new(),
+        firm: Vec::new(),
+        year: Vec::new(),
+        z: Vec::new(),
+        y: Vec::new(),
+        spec,
+    };
+    let worker_fe: Vec<f64> = (0..n_workers).map(|_| next()).collect();
+    let firm_fe: Vec<f64> = (0..n_firms).map(|_| next()).collect();
+    let year_fe: Vec<f64> = (0..n_years).map(|_| next()).collect();
+    for (w, &w_fe) in worker_fe.iter().enumerate() {
+        let mut current = (next() * n_firms as f64) as usize % n_firms;
+        for (t, &t_fe) in year_fe.iter().enumerate() {
+            if next() < mobility {
+                current = (next() * n_firms as f64) as usize % n_firms;
+            }
+            let z = match spec {
+                SlopeSpec::Independent | SlopeSpec::SharedWithFirm => next(),
+                SlopeSpec::YearIndex => t as f64,
+                SlopeSpec::NearYearIndex(delta) => t as f64 + delta * next(),
+            };
+            panel.worker.push(w as u32);
+            panel.firm.push(current as u32);
+            panel.year.push(t as u32);
+            panel.z.push(z);
+            panel
+                .y
+                .push(w_fe + firm_fe[current] + t_fe + 0.3 * z + next() - 0.5);
+        }
+    }
+    panel
+}
+
+/// Largest absolute within-level mean of `demeaned`, over every term's levels.
+fn max_abs_group_mean(design: &Design<'_>, demeaned: &[f64]) -> f64 {
+    let demeaned = design.permute_obs_in(demeaned);
+    (0..design.terms.len())
+        .map(|term| {
+            let levels = design.level_column(term);
+            let n_levels = design.terms[term].n_levels();
+            let mut sums = vec![0.0f64; n_levels];
+            let mut counts = vec![0.0f64; n_levels];
+            for (obs, &level) in levels.iter().enumerate() {
+                sums[level as usize] += demeaned[obs];
+                counts[level as usize] += 1.0;
+            }
+            sums.iter()
+                .zip(&counts)
+                .filter(|&(_, &c)| c > 0.0)
+                .map(|(&s, &c)| (s / c).abs())
+                .fold(0.0f64, f64::max)
+        })
+        .fold(0.0f64, f64::max)
+}
+
+/// Rows the solve space excludes beyond whitening's drops, `None` when there are none.
+fn constrained_rank(solver: &Solver<'_>) -> Option<usize> {
+    solver
+        .reparam
+        .as_ref()
+        .map(|rp| rp.null.rank())
+        .filter(|&k| k > 0)
+}
+
+/// Every collinearity warning's verdict, in the order the screen raised them.
+fn verdicts(solver: &Solver<'_>) -> Vec<crate::AliasVerdict> {
+    solver
+        .warnings()
+        .iter()
+        .filter_map(|w| match w {
+            crate::BuildWarning::CollinearSlopeCovariate { verdict, .. } => Some(*verdict),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Every collinearity warning's residual, in the order the screen raised them.
+fn residuals(solver: &Solver<'_>) -> Vec<f64> {
+    solver
+        .warnings()
+        .iter()
+        .filter_map(|w| match w {
+            crate::BuildWarning::CollinearSlopeCovariate {
+                relative_residual, ..
+            } => Some(*relative_residual),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Solve `panel` with the spectral floor off, so only the gauge constraint can save it.
+fn solve_unfloored(panel: &AkmPanel) -> (Solver<'_>, crate::SolveResult) {
+    let solver = Solver::new(panel.effects(), None, unfloored()).expect("solver");
+    let out = solve_tight(&solver, &panel.y);
+    (solver, out)
+}
+
+fn unfloored() -> PreconditionerConfig {
+    PreconditionerConfig::Additive {
+        local_solver: LocalSolverConfig {
+            ridge: 0.0,
+            ..Default::default()
+        },
+        reduction: Default::default(),
+    }
+}
+
+fn solve_tight(solver: &Solver<'_>, y: &[f64]) -> crate::SolveResult {
+    solver
+        .solve(
+            y,
+            &LsmrOptions {
+                tol: 1e-12,
+                maxiter: 20_000,
+                ..Default::default()
+            },
+        )
+        .expect("solve")
+}
+
+fn rss(r: &[f64]) -> f64 {
+    r.iter().map(|x| x * x).sum()
+}
+
+/// What the screen's warnings decide, per relationship between the covariate and the design.
+#[rstest]
+#[case::unrelated(SlopeSpec::Independent, 0, None, 0.0..0.0)]
+#[case::exact_alias(SlopeSpec::YearIndex, 1, Some(1), 0.0..1e-20)]
+#[case::shared_covariate(SlopeSpec::SharedWithFirm, 2, Some(1), 0.0..1e-20)]
+#[case::deep_null(SlopeSpec::NearYearIndex(1e-12), 1, Some(1), 0.0..1e-20)]
+#[case::recoverable(SlopeSpec::NearYearIndex(1e-6), 1, None, 1e-20..f64::INFINITY)]
+#[case::near_alias(SlopeSpec::NearYearIndex(1e-3), 1, None, 1e-20..f64::INFINITY)]
+fn a_warned_direction_is_removed_only_when_it_carries_nothing(
+    #[case] spec: SlopeSpec,
+    #[case] warned: usize,
+    #[case] rank: Option<usize>,
+    #[case] residual: Range<f64>,
+) {
+    let panel = akm_panel(4_000, 200, 10, 0.15, spec);
+    let (solver, out) = solve_unfloored(&panel);
+    // Without the constraint an aliased solve reports a false convergence at an O(1) mean.
+    let group_mean = max_abs_group_mean(&solver.design, &out.demeaned);
+    assert!(
+        out.converged && group_mean < 1e-9,
+        "converged={}, gm={group_mean:.3e}",
+        out.converged
+    );
+    let residuals = residuals(&solver);
+    assert_eq!(residuals.len(), warned, "{residuals:?}");
+    assert!(
+        residuals.iter().all(|r| residual.contains(r)),
+        "{residuals:?} outside {residual:?}"
+    );
+    // Two warnings can name one direction, so the second is absorbed by the first.
+    assert_eq!(constrained_rank(&solver), rank);
+    let expected = match rank {
+        Some(_) => crate::AliasVerdict::Constrained,
+        None => crate::AliasVerdict::Kept,
+    };
+    assert!(
+        verdicts(&solver).iter().all(|&v| v == expected),
+        "{:?}",
+        verdicts(&solver)
+    );
+}
+
+/// A direction an aligned response could still recover must not be constrained away, so
+/// shrinking the perturbation cannot move the fit.
+#[rstest]
+#[case::loose(1e-3)]
+#[case::tight(3e-5)]
+#[case::tighter(1e-6)]
+fn shrinking_the_perturbation_does_not_move_the_fit(#[case] delta: f64) {
+    let reference = akm_panel(4_000, 200, 10, 0.15, SlopeSpec::NearYearIndex(1e-3));
+    let reference = rss(&solve_unfloored(&reference).1.demeaned);
+
+    let panel = akm_panel(4_000, 200, 10, 0.15, SlopeSpec::NearYearIndex(delta));
+    let (solver, out) = solve_unfloored(&panel);
+    let fit = rss(&out.demeaned);
+    assert!(
+        out.converged && (fit - reference).abs() <= 1e-6 * reference,
+        "converged={}, rss={fit:.12e} against {reference:.12e}",
+        out.converged
+    );
+    assert!(
+        constrained_rank(&solver).is_none(),
+        "{:?}",
+        residuals(&solver)
+    );
+}
+
+/// The covariate is the response most aligned with the cancellation, and its unexplained
+/// share scales as the perturbation squared. Constraining the direction away breaks that,
+/// so the tolerance must stay under what an aligned fit still recovers.
+#[test]
+fn an_aligned_response_is_still_recovered() {
+    let share = |delta: f64| {
+        let panel = akm_panel(4_000, 200, 10, 0.15, SlopeSpec::NearYearIndex(delta));
+        let solver = Solver::new(panel.effects(), None, unfloored()).expect("solver");
+        assert!(
+            constrained_rank(&solver).is_none(),
+            "{:?}",
+            residuals(&solver)
+        );
+        rss(&solve_tight(&solver, &panel.z).demeaned) / rss(&panel.z)
+    };
+    let (coarse, fine) = (share(1e-6), share(1e-8));
+    let ratio = fine / coarse;
+    assert!(
+        (ratio / 1e-4 - 1.0).abs() < 0.2,
+        "share {fine:.6e} against {coarse:.6e} is {ratio:.3e} of the expected 1e-4"
+    );
+}
+
+/// The verdict reads the design alone, so no preconditioner may change it.
+#[rstest]
+#[case::exact_alias(SlopeSpec::YearIndex, Some(1))]
+#[case::recoverable(SlopeSpec::NearYearIndex(1e-6), None)]
+fn the_verdict_does_not_depend_on_the_preconditioner(
+    #[case] spec: SlopeSpec,
+    #[case] rank: Option<usize>,
+) {
+    let panel = akm_panel(4_000, 200, 10, 0.15, spec);
+    let reference = residuals(&Solver::new(panel.effects(), None, unfloored()).expect("solver"));
+    for config in [PreconditionerConfig::Diagonal, unfloored()] {
+        let solver = Solver::new(panel.effects(), None, &config).expect("solver");
+        assert_eq!(residuals(&solver), reference, "{config:?}");
+        assert_eq!(constrained_rank(&solver), rank, "{config:?}");
+    }
+}
+
+/// Uniform weights cancel out of a relative residual, so they cannot move the verdict either.
+#[rstest]
+#[case::exact_alias(SlopeSpec::YearIndex, Some(1))]
+#[case::recoverable(SlopeSpec::NearYearIndex(1e-6), None)]
+fn the_verdict_survives_weight_scaling(#[case] spec: SlopeSpec, #[case] rank: Option<usize>) {
+    let panel = akm_panel(4_000, 200, 10, 0.15, spec);
+    for beta in [1e-8f64, 1e-4, 1.0, 1e4, 1e8] {
+        let w = vec![beta; panel.y.len()];
+        let solver = Solver::new(panel.effects(), Some(w), unfloored()).expect("solver");
+        assert_eq!(
+            constrained_rank(&solver),
+            rank,
+            "beta={beta:e}, {:?}",
+            residuals(&solver)
+        );
+    }
+}
+
+/// The cancellation floor of an exact alias grows with `n_obs`; the tolerance must outrun it.
+#[test]
+#[ignore = "8M observations"]
+fn the_exact_alias_floor_stays_under_the_tolerance_at_scale() {
+    let panel = akm_panel(200_000, 10_000, 40, 0.15, SlopeSpec::YearIndex);
+    let solver = Solver::new(
+        panel.effects(),
+        Some(vec![1e-4; panel.y.len()]),
+        unfloored(),
+    )
+    .expect("solver");
+    assert_eq!(
+        constrained_rank(&solver),
+        Some(1),
+        "{:?}",
+        residuals(&solver)
+    );
+
+    // The same panel's recoverable neighbour must survive where the shipped product did not.
+    let panel = akm_panel(200_000, 10_000, 40, 0.15, SlopeSpec::NearYearIndex(3e-5));
+    let solver = Solver::new(panel.effects(), None, unfloored()).expect("solver");
+    assert!(
+        constrained_rank(&solver).is_none(),
+        "{:?}",
+        residuals(&solver)
+    );
 }

--- a/crates/within/tests/metamorphic.rs
+++ b/crates/within/tests/metamorphic.rs
@@ -6,10 +6,10 @@ use within::{solve, solve_batch, Channel, CoefficientAddress, LsmrOptions};
 mod strategies;
 use strategies::{additive_precond, random_fe_problem_strategy};
 
-fn at(term: usize, level: usize, column: usize) -> CoefficientAddress {
+fn at(term: usize, level: u32, column: usize) -> CoefficientAddress {
     CoefficientAddress {
         channel: Channel { term, column },
-        level,
+        level: level.into(),
     }
 }
 
@@ -140,11 +140,11 @@ proptest! {
         prop_assert!(result.converged);
 
         for u in &result.unidentified {
-            let slot = result.layout.index(*u).unwrap();
+            let slot = result.layout.index(u).unwrap();
             prop_assert_eq!(
                 result.x[slot],
                 0.0,
-                "unidentified slot (term {}, level {}, col {}) = {}, expected exactly 0",
+                "unidentified slot (term {}, level {:?}, col {}) = {}, expected exactly 0",
                 u.channel.term,
                 u.level,
                 u.channel.column,
@@ -171,7 +171,8 @@ fn saturated_single_factor_recovers_level_means() {
     assert!(result.converged);
 
     for (level, &mean) in [2.0, 4.0, 5.0].iter().enumerate() {
-        let slot = result.layout.index(at(0, level, 0)).unwrap();
+        let label = u32::try_from(level).expect("fixture level fits u32");
+        let slot = result.layout.index(&at(0, label, 0)).unwrap();
         assert!(
             (result.x[slot] - mean).abs() < 1e-6,
             "level {level}: coefficient {} != level mean {mean}",

--- a/crates/within/tests/properties.rs
+++ b/crates/within/tests/properties.rs
@@ -8,10 +8,10 @@ use within::{
 mod strategies;
 use strategies::{additive_precond, random_fe_problem_strategy, random_slopes_problem_strategy};
 
-fn at(term: usize, level: usize, column: usize) -> CoefficientAddress {
+fn at(term: usize, level: u32, column: usize) -> CoefficientAddress {
     CoefficientAddress {
         channel: Channel { term, column },
-        level,
+        level: level.into(),
     }
 }
 
@@ -134,12 +134,13 @@ proptest! {
         for (t, f) in factors.iter().enumerate() {
             let slope_base = usize::from(f.intercept);
             for i in 0..n_obs {
-                let lvl = f.levels[i] as usize;
+                let level = f.levels[i];
                 if f.intercept {
-                    fitted[i] += x[layout.index(at(t, lvl, 0)).unwrap()];
+                    fitted[i] += x[layout.index(&at(t, level, 0)).unwrap()];
                 }
                 for (s, col) in f.slopes.iter().enumerate() {
-                    fitted[i] += x[layout.index(at(t, lvl, slope_base + s)).unwrap()] * col[i];
+                    fitted[i] +=
+                        x[layout.index(&at(t, level, slope_base + s)).unwrap()] * col[i];
                 }
             }
         }
@@ -150,16 +151,16 @@ proptest! {
         for (t, f) in factors.iter().enumerate() {
             let slope_base = usize::from(f.intercept);
             for i in 0..n_obs {
-                let lvl = f.levels[i] as usize;
+                let level = f.levels[i];
                 let wr = weights[i] * (y[i] - fitted[i]);
                 let wy = weights[i] * y[i];
                 if f.intercept {
-                    let k = layout.index(at(t, lvl, 0)).unwrap();
+                    let k = layout.index(&at(t, level, 0)).unwrap();
                     g[k] += wr;
                     g0[k] += wy;
                 }
                 for (s, col) in f.slopes.iter().enumerate() {
-                    let k = layout.index(at(t, lvl, slope_base + s)).unwrap();
+                    let k = layout.index(&at(t, level, slope_base + s)).unwrap();
                     g[k] += wr * col[i];
                     g0[k] += wy * col[i];
                 }

--- a/crates/within/tests/slopes.rs
+++ b/crates/within/tests/slopes.rs
@@ -86,10 +86,16 @@ fn solve_single(
 }
 
 /// `unidentified` as comparable `(term, level, column)` triples.
-fn drops(r: &SolveResult) -> Vec<(usize, usize, usize)> {
+fn drops(r: &SolveResult) -> Vec<(usize, u32, usize)> {
     r.unidentified
         .iter()
-        .map(|d| (d.channel.term, d.level, d.channel.column))
+        .map(|d| {
+            (
+                d.channel.term,
+                d.level.try_as_u32().expect("u32 factor label"),
+                d.channel.column,
+            )
+        })
         .collect()
 }
 
@@ -258,7 +264,13 @@ fn batch_solve_shares_unidentified_and_back_transforms_each_rhs() {
     let batch_drops: Vec<_> = batch
         .unidentified
         .iter()
-        .map(|d| (d.channel.term, d.level, d.channel.column))
+        .map(|d| {
+            (
+                d.channel.term,
+                d.level.try_as_u32().expect("u32 factor label"),
+                d.channel.column,
+            )
+        })
         .collect();
     assert_eq!(batch_drops, [(0, 1, 1)]);
     // Each RHS block is bit-identical to its single solve, back-transform included.

--- a/crates/within/tests/slopes_routing.rs
+++ b/crates/within/tests/slopes_routing.rs
@@ -290,7 +290,13 @@ fn singleton_level_in_non_first_slope_term_solves_under_default() {
     assert_eq!(
         r.unidentified
             .iter()
-            .map(|d| (d.channel.term, d.level, d.channel.column))
+            .map(|d| {
+                (
+                    d.channel.term,
+                    d.level.try_as_u32().expect("u32 factor label"),
+                    d.channel.column,
+                )
+            })
             .collect::<Vec<_>>(),
         vec![(1, 2, 1)],
     );

--- a/docs/2_solver_architecture.md
+++ b/docs/2_solver_architecture.md
@@ -172,11 +172,25 @@ We conclude with a summary of the full algorithm.
 
 5. **Assemble** Schwarz preconditioner $M^{-1}$ from subdomain factors.
 
+6. **Constrain cross-term aliasing.** A covariate that another term reproduces per level puts a
+   null in the design: with $v$ the difference of the two per-level fits, taken against the
+   whitening basis and net of the constant every term already shares, $Dv = 0$. The screen only
+   proposes such a $v$; the design decides. Orthonormalize the proposals by descending residual
+   share, dropping any whose share is spent against the rows already taken, then certify each
+   surviving row $n$ against the backward error of evaluating $An$, with $A = \sqrt{W}D$:
+
+   $$\|An\| \le \tau \sqrt{n^\top \operatorname{diag}(A^\top A)\, n}.$$
+
+   Scaling by the operator's own columns holds the verdict fixed under a uniform change of
+   weights, which $\|n\|$ alone does not. Certified rows form $V$, and the solve runs on
+   $\operatorname{range}(I - VV^\top)$, so no subdomain inverts a roundoff-scale null. A row that
+   fails stays in the solve space, where the iteration must resolve it.
+
 ### 5.2 Solve phase
 
 1. **Form the rectangular operator and right-hand side**: $A = \sqrt{W} D$, $b = \sqrt{W} y$ (both implicit — never materialized).
 
-2. **Run modified LSMR** on $(A, b)$ with preconditioner $M^{-1}$:
+2. **Run modified LSMR** on $(A, b)$ with preconditioner $PM^{-1}P$, $P = I - VV^\top$:
    - Each iteration: one $Av$, one $A^\top u$, one $M^{-1}\tilde{p}$ application, plus a constant number of vector updates.
    - Optionally reorthogonalize against the last `local_size` basis vectors.
    - Converge when $\|A^\top r_k\|_2 \leq \text{tol} \cdot \|A^\top b\|_2$.

--- a/python/within/_within.pyi
+++ b/python/within/_within.pyi
@@ -90,7 +90,7 @@ class UnidentifiedDirection:
 
     Attributes:
         term: Index into the design's term list.
-        level: Level index within the term (``0..n_levels``).
+        level: Caller-visible factor label.
         column: Column within the term's per-level block — intercept first
             (when present), then slopes in declaration order.
     """
@@ -122,12 +122,12 @@ class SolveResult:
     """Result of a single fixed-effects solve.
 
     Attributes:
-        x: Fixed-effect coefficients, shape ``(n_dofs,)``. Term-major:
-            coefficient column ``c`` of level ``level`` sits at
-            ``term_offset + c * n_levels + level``, columns ordered
-            ``[intercept?, slopes...]`` (for plain factors: all levels of
-            factor 0 first, then factor 1, etc.). Slots for unidentified
-            directions hold the minimal-norm value ``0``, never NaN.
+        x: Fixed-effect coefficients, shape ``(n_dofs,)``. Term-major by
+            compact level position ``p``: coefficient column ``c`` sits at
+            ``term_offset + c * n_levels + p``, with columns ordered
+            ``[intercept?, slopes...]``. Use ``layout`` to translate caller
+            labels to these slots. Slots for unidentified directions hold the
+            minimal-norm value ``0``, never NaN.
         unidentified: Per-level directions the data cannot identify, as
             :class:`UnidentifiedDirection` records.
         layout: Address <-> flat-``x``-index translation for the coefficients.


### PR DESCRIPTION
Closes part of #297 (goals 1 and 4; see below for 2 and 3). Stacked on #316.

A slope covariate another term reproduces per level puts an exact null in the design. The collinearity screen already finds it; here its warnings become proposals. After whitening, `SlopeReparam` builds a `NullSpace` — the one description of what the solve excludes: whitening's dropped columns plus the cross-term rows. Each proposal's direction is the per-level fit `Aᵀc / diag(AᵀA)` on its own term minus the fit on the other, net of the constant both share; the proposals are orthonormalized (pivoted, so a duplicate is spent against the row it duplicates) and each row `n` is certified by the backward error `‖An‖ ≤ 1e-11·√(nᵀdiag(AᵀA)n)`. Certified rows are projected out of the preconditioner apply (`P M⁻¹ P`); every warning records an `AliasVerdict` saying whether its direction was constrained or kept.

The LSMR audit measured `Aᵀr` in the preconditioner's metric, which cannot see a component in `ker(M⁻¹)` — exactly what the projector creates — so it now also requires the plain `‖Aᵀr‖` to have dropped.

Measured, 200k worker/firm/year panel, slope covariate = the year index, spectral floor **off**:

| | λmax(M⁻¹) | iters | converged | max group mean |
|---|---|---|---|---|
| unconstrained | 3.859e12 | 929 | **no** | 2.83 |
| constrained | 2.44 | 34 | yes | 1.7e-12 |
| ridge 1e-10, unconstrained | 2.036e6 | 34 | yes | 2.1e-12 |

Inert where the screen is silent (bit-identical), and declined where the direction carries information (`near_collinear`: λmax 1.2e8 kept, honest at ridge 0). The verdict is independent of the preconditioner and of a uniform weight scale.

Not in this PR:
- **Goal 2** (`Grounding` on global energy): after the constraint, every remaining grounded block with a large response carries a real spectrum, so the local-surplus predicate is not load-bearing in any measured cell.
- **Goal 3** (drop the spectral floor's default) is gated on #281 — the near-collinear class the projection correctly declines is the fused block's, whose default is still `None`.