### PR TITLE
Separate immutable Design from solver-local state

### DIFF
--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -346,6 +346,10 @@ impl<'a> Design<'a> {
         self.terms.len()
     }
 
+    fn n_loading_columns(&self) -> usize {
+        self.frame.n_loading_columns()
+    }
+
     /// The term's coefficient columns in layout order.
     pub(crate) fn channels(&self, term: usize) -> impl Iterator<Item = Channel> + '_ {
         (0..self.terms[term].n_columns()).map(move |column| Channel { term, column })
@@ -366,11 +370,6 @@ impl<'a> Design<'a> {
         self.frame.loading_column(column)
     }
 
-    /// Replace one loading column during solver-local preparation.
-    pub(crate) fn replace_loading_column(&mut self, column: usize, values: Vec<f64>) {
-        self.frame.set_loading_column(column, values);
-    }
-
     /// Number of observations (rows of D).
     #[inline]
     pub fn n_obs(&self) -> usize {
@@ -381,6 +380,55 @@ impl<'a> Design<'a> {
     #[inline]
     pub fn n_dofs(&self) -> usize {
         self.n_dofs
+    }
+}
+
+pub(crate) struct LoadingOverrides(Vec<Option<Vec<f64>>>);
+
+impl LoadingOverrides {
+    pub(crate) fn new(design: &Design<'_>) -> Self {
+        Self((0..design.n_loading_columns()).map(|_| None).collect())
+    }
+
+    pub(crate) fn replace(&mut self, design: &Design<'_>, column: usize, values: Vec<f64>) {
+        debug_assert_eq!(values.len(), design.n_obs());
+        self.0[column] = Some(values);
+    }
+}
+
+/// Read-only solver-specific view of a design, including any transformed loadings.
+pub(crate) struct SolverDesign<'a> {
+    design: &'a Design<'a>,
+    loading_overrides: Option<&'a LoadingOverrides>,
+}
+
+impl<'a> SolverDesign<'a> {
+    #[cfg(test)]
+    pub(crate) fn new(design: &'a Design<'a>) -> Self {
+        Self {
+            design,
+            loading_overrides: None,
+        }
+    }
+
+    pub(crate) fn with_loading_overrides(
+        design: &'a Design<'a>,
+        loading_overrides: &'a LoadingOverrides,
+    ) -> Self {
+        Self {
+            design,
+            loading_overrides: Some(loading_overrides),
+        }
+    }
+
+    pub(crate) fn design(&self) -> &'a Design<'a> {
+        self.design
+    }
+
+    pub(crate) fn loading_column(&self, column: usize) -> &[f64] {
+        self.loading_overrides
+            .and_then(|overrides| overrides.0[column].as_deref())
+            .unwrap_or_else(|| self.design.loading_column(column))
     }
 }
 

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -7,7 +7,7 @@
 
 use crate::channel::ChannelPair;
 use crate::csr_block::{to_u32, CsrBlock};
-use crate::domain::Design;
+use crate::domain::{Design, SolverDesign};
 
 mod accumulate;
 use accumulate::accumulate_cross_block;
@@ -138,11 +138,12 @@ impl CrossTab {
 
     /// Reuses pre-computed active flags instead of rescanning; diagonals come back separately.
     pub(crate) fn build_for_pair_with_active(
-        design: &Design<'_>,
+        solver_design: &SolverDesign<'_>,
         weights: Option<&[f64]>,
         pair: ChannelPair,
         all_active: &[Vec<bool>],
     ) -> Option<(Self, BlockDiagonals, Vec<u32>)> {
+        let design = solver_design.design();
         let active = build_compact_mapping(
             &all_active[pair.rows.term],
             &all_active[pair.cols.term],
@@ -150,7 +151,7 @@ impl CrossTab {
             design.terms[pair.cols.term].column_base(pair.cols.column),
         )?;
 
-        let (c, row_diag, col_diag) = accumulate_cross_block(design, weights, pair, &active);
+        let (c, row_diag, col_diag) = accumulate_cross_block(solver_design, weights, pair, &active);
         let ct = c.transpose();
         let cross_tab = CrossTab { c, ct };
         let diagonals = BlockDiagonals {

--- a/crates/within/src/domain/cross_tab/accumulate.rs
+++ b/crates/within/src/domain/cross_tab/accumulate.rs
@@ -10,7 +10,7 @@
 
 use crate::channel::ChannelPair;
 use crate::csr_block::CsrBlock;
-use crate::domain::Design;
+use crate::domain::SolverDesign;
 
 use super::{to_u32, ActiveLevels};
 use crate::domain::Loading as ColumnLoading;
@@ -84,11 +84,12 @@ impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
 
 /// Accumulate into `C` plus diagonals, dispatching dense or sparse by peak transient memory.
 pub(super) fn accumulate_cross_block(
-    design: &Design<'_>,
+    solver_design: &SolverDesign<'_>,
     weights: Option<&[f64]>,
     pair: ChannelPair,
     active: &ActiveLevels,
 ) -> (CsrBlock, Vec<f64>, Vec<f64>) {
+    let design = solver_design.design();
     // Dispatching on cell count alone would pick sparse where it uses MORE memory.
     let table_size = active.n_rows.saturating_mul(active.n_cols);
     let dense_cost = table_size.saturating_mul(8);
@@ -97,8 +98,10 @@ pub(super) fn accumulate_cross_block(
 
     let row_levels = design.level_column(pair.rows.term);
     let col_levels = design.level_column(pair.cols.term);
-    let load =
-        |col: ColumnLoading<u32>| col.covariate().map(|&c| design.loading_column(c as usize));
+    let load = |col: ColumnLoading<u32>| {
+        col.covariate()
+            .map(|&c| solver_design.loading_column(c as usize))
+    };
     // One arm per loading combination; closures aren't generic, so the literals repeat.
     match (
         load(design.loading(pair.rows)),

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -7,7 +7,7 @@ use super::{build_compact_mapping, CrossTab};
 use crate::channel::{Channel, ChannelPair};
 use crate::csr_block::CsrBlock;
 use crate::domain::find_all_active_levels;
-use crate::domain::{Design, Effect};
+use crate::domain::{Design, Effect, SolverDesign};
 use crate::observation::ObservationFrame;
 
 impl CrossTab {
@@ -46,18 +46,28 @@ fn test_cross_tab_sparse_accumulation_path() {
     // Sparse path (large level counts)
     let design_sparse = design_of(vec![fa.clone(), fb.clone()]);
     let active_sparse = find_all_active_levels(&design_sparse);
-    let (ct_sparse, diag_sparse, _) =
-        CrossTab::build_for_pair_with_active(&design_sparse, None, INTERCEPT_PAIR, &active_sparse)
-            .expect("sparse cross tab should build");
+    let sparse_solver_design = SolverDesign::new(&design_sparse);
+    let (ct_sparse, diag_sparse, _) = CrossTab::build_for_pair_with_active(
+        &sparse_solver_design,
+        None,
+        INTERCEPT_PAIR,
+        &active_sparse,
+    )
+    .expect("sparse cross tab should build");
 
     // Dense reference: collapse levels so n_rows * n_cols <= 5M.
     let fa_small: Vec<u32> = fa.iter().map(|&x| x % 100).collect();
     let fb_small: Vec<u32> = fb.iter().map(|&x| x % 100).collect();
     let design_dense = design_of(vec![fa_small.clone(), fb_small.clone()]);
     let active_dense = find_all_active_levels(&design_dense);
-    let (_ct_dense, diag_dense, _) =
-        CrossTab::build_for_pair_with_active(&design_dense, None, INTERCEPT_PAIR, &active_dense)
-            .expect("dense cross tab should build");
+    let dense_solver_design = SolverDesign::new(&design_dense);
+    let (_ct_dense, diag_dense, _) = CrossTab::build_for_pair_with_active(
+        &dense_solver_design,
+        None,
+        INTERCEPT_PAIR,
+        &active_dense,
+    )
+    .expect("dense cross tab should build");
 
     // Each observation appears exactly once in its row/col bucket.
     assert_eq!(
@@ -122,8 +132,9 @@ fn test_extract_component_two_components() {
     let fb = vec![0u32, 1, 0, 1, 2, 3, 2, 3];
     let design = design_of(vec![fa, fb]);
     let all_active = find_all_active_levels(&design);
+    let solver_design = SolverDesign::new(&design);
     let (ct, parent_diag, _) =
-        CrossTab::build_for_pair_with_active(&design, None, INTERCEPT_PAIR, &all_active)
+        CrossTab::build_for_pair_with_active(&solver_design, None, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
     let components = ct.bipartite_connected_components();
@@ -234,8 +245,14 @@ proptest! {
 
         let design = design_of(vec![fa, fb]);
         let all_active = find_all_active_levels(&design);
-        let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, None, INTERCEPT_PAIR, &all_active)
-            .expect("cross tab should build");
+        let solver_design = SolverDesign::new(&design);
+        let (ct, _, _) = CrossTab::build_for_pair_with_active(
+            &solver_design,
+            None,
+            INTERCEPT_PAIR,
+            &all_active,
+        )
+        .expect("cross tab should build");
 
         let components = ct.bipartite_connected_components();
 

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -12,7 +12,7 @@ use crate::channel::{Channel, ChannelPair};
 use crate::config::LocalSolverConfig;
 use crate::{BuildError, BuildWarning};
 
-use super::{find_all_active_levels, BlockDiagonals, CrossTab, Design};
+use super::{find_all_active_levels, BlockDiagonals, CrossTab, SolverDesign};
 
 mod sddm;
 use crate::domain::Loading;
@@ -34,7 +34,7 @@ pub(crate) struct LocalDomain {
 
 /// Same-factor channel pairs are exactly orthogonal after whitening, so never enumerated.
 pub(crate) fn build_local_domains(
-    design: &Design<'_>,
+    solver_design: &SolverDesign<'_>,
     weights: Option<&[f64]>,
     config: &LocalSolverConfig,
 ) -> Result<(Vec<LocalDomain>, Vec<BuildWarning>), BuildError> {
@@ -46,6 +46,7 @@ pub(crate) fn build_local_domains(
         });
     }
 
+    let design = solver_design.design();
     let channels: Vec<Channel> = (0..design.n_factors())
         .flat_map(|term| design.channels(term))
         .collect();
@@ -65,7 +66,7 @@ pub(crate) fn build_local_domains(
         .par_iter()
         .map(|&pair| {
             let Some((full_ct, full_diag, l2g)) =
-                CrossTab::build_for_pair_with_active(design, weights, pair, &all_active)
+                CrossTab::build_for_pair_with_active(solver_design, weights, pair, &all_active)
             else {
                 return Ok((Vec::new(), Vec::new()));
             };
@@ -225,8 +226,10 @@ mod tests {
     #[test]
     fn test_full_cover_domain_count() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
+        let solver_design = SolverDesign::new(&dm);
+        let (domain_pairs, _) =
+            build_local_domains(&solver_design, None, &LocalSolverConfig::default())
+                .expect("plain domains build");
         // 3 factor pairs; each pair may produce multiple components
         assert!(domain_pairs.len() >= 3);
     }
@@ -234,9 +237,11 @@ mod tests {
     #[test]
     fn test_partition_of_unity() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
         let n_dofs = dm.n_dofs;
+        let solver_design = SolverDesign::new(&dm);
+        let (domain_pairs, _) =
+            build_local_domains(&solver_design, None, &LocalSolverConfig::default())
+                .expect("plain domains build");
         // Two-sided PoU: squared weights must sum to 1 at every DOF.
         let mut weight_sq_sum = vec![0.0; n_dofs];
         for ld in &domain_pairs {
@@ -265,9 +270,11 @@ mod tests {
             Effect::new(&levels_c, true, []).expect("effect c"),
         ])
         .expect("valid slope design");
-
-        let (domain_pairs, _) = build_local_domains(&design, None, &LocalSolverConfig::default())
-            .expect("slope domains build");
+        let n_dofs = design.n_dofs;
+        let solver_design = SolverDesign::new(&design);
+        let (domain_pairs, _) =
+            build_local_domains(&solver_design, None, &LocalSolverConfig::default())
+                .expect("slope domains build");
 
         for ld in &domain_pairs {
             for i in 0..ld.core.global_indices().len() {
@@ -280,7 +287,7 @@ mod tests {
         }
 
         // Non-vacuity: without a shared DOF, uniform vs 1/√c weights are indistinguishable.
-        let mut counts = vec![0u32; design.n_dofs];
+        let mut counts = vec![0u32; n_dofs];
         for ld in &domain_pairs {
             for &idx in ld.core.global_indices() {
                 counts[idx as usize] += 1;
@@ -295,9 +302,12 @@ mod tests {
     #[test]
     fn test_domains_cover_all_dofs() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
-        let mut covered = vec![false; dm.n_dofs];
+        let n_dofs = dm.n_dofs;
+        let solver_design = SolverDesign::new(&dm);
+        let (domain_pairs, _) =
+            build_local_domains(&solver_design, None, &LocalSolverConfig::default())
+                .expect("plain domains build");
+        let mut covered = vec![false; n_dofs];
         for ld in &domain_pairs {
             for &idx in ld.core.global_indices() {
                 covered[idx as usize] = true;

--- a/crates/within/src/observation.rs
+++ b/crates/within/src/observation.rs
@@ -59,6 +59,10 @@ impl<'a> ObservationFrame<'a> {
         self.categorical.len()
     }
 
+    pub(crate) fn n_loading_columns(&self) -> usize {
+        self.continuous.len()
+    }
+
     /// Level codes of factor `factor`.
     pub fn level_column(&self, factor: usize) -> &[u32] {
         &self.categorical[factor]
@@ -67,12 +71,6 @@ impl<'a> ObservationFrame<'a> {
     /// Loadings of continuous column `k`.
     pub fn loading_column(&self, k: usize) -> &[f64] {
         &self.continuous[k]
-    }
-
-    /// Replace loading column `i` with an owned column of matching row count.
-    pub(crate) fn set_loading_column(&mut self, i: usize, column: Vec<f64>) {
-        debug_assert_eq!(column.len(), self.n_obs);
-        self.continuous[i] = Cow::Owned(column);
     }
 
     /// Convert every column to owned, dropping ties to caller buffers.

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use portable_atomic::AtomicF64;
 use schwarz_precond::Operator;
 
-use crate::domain::Design;
+use crate::domain::SolverDesign;
 
 mod gather;
 mod scatter;
@@ -21,7 +21,7 @@ const PAR_THRESHOLD: usize = 10_000;
 
 /// Design operator `D` or `W^{1/2} D`, whose normal equations `AᵀA = DᵀWD` recover the Gramian.
 pub(crate) struct DesignOperator<'a> {
-    design: &'a Design<'a>,
+    solver_design: &'a SolverDesign<'a>,
     sqrt_weights: Option<&'a [f64]>,
     /// Sized once to the largest term's block, so it allocates per operator, not per iteration.
     scatter_scratch: Vec<AtomicF64>,
@@ -32,7 +32,11 @@ pub(crate) struct DesignOperator<'a> {
 
 impl<'a> DesignOperator<'a> {
     /// `sqrt_weights` must be pre-square-rooted and `design.n_obs` long.
-    pub(crate) fn new(design: &'a Design<'a>, sqrt_weights: Option<&'a [f64]>) -> Self {
+    pub(crate) fn new(
+        solver_design: &'a SolverDesign<'a>,
+        sqrt_weights: Option<&'a [f64]>,
+    ) -> Self {
+        let design = solver_design.design();
         if let Some(sw) = sqrt_weights {
             assert_eq!(
                 sw.len(),
@@ -44,7 +48,7 @@ impl<'a> DesignOperator<'a> {
         }
         let max_block = design.terms.iter().map(|t| t.n_dofs()).max().unwrap_or(0);
         Self {
-            design,
+            solver_design,
             sqrt_weights,
             scatter_scratch: (0..max_block).map(|_| AtomicF64::new(0.0)).collect(),
             #[cfg(debug_assertions)]
@@ -87,30 +91,34 @@ impl Drop for ReentryGuard<'_> {
 
 impl Operator for DesignOperator<'_> {
     fn nrows(&self) -> usize {
-        self.design.n_obs
+        self.solver_design.design().n_obs
     }
 
     fn ncols(&self) -> usize {
-        self.design.n_dofs
+        self.solver_design.design().n_dofs
     }
 
     fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
-        debug_assert_eq!(x.len(), self.design.n_dofs);
-        debug_assert_eq!(y.len(), self.design.n_obs);
-        gather_apply(self.design, x, y, self.sqrt_weights);
+        let design = self.solver_design.design();
+        debug_assert_eq!(x.len(), design.n_dofs);
+        debug_assert_eq!(y.len(), design.n_obs);
+        gather_apply(self.solver_design, x, y, self.sqrt_weights);
         Ok(())
     }
 
     fn apply_adjoint(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
         #[cfg(debug_assertions)]
         let _guard = ReentryGuard::acquire(&self.adjoint_active);
-        debug_assert_eq!(x.len(), self.design.n_obs);
-        debug_assert_eq!(y.len(), self.design.n_dofs);
+        let design = self.solver_design.design();
+        debug_assert_eq!(x.len(), design.n_obs);
+        debug_assert_eq!(y.len(), design.n_dofs);
         y.fill(0.0);
         // No lock needed: `solve_batch` builds one operator per RHS, so calls are sequential.
         match self.sqrt_weights {
-            Some(sw) => scatter_apply(self.design, &self.scatter_scratch, y, &|i| sw[i] * x[i]),
-            None => scatter_apply(self.design, &self.scatter_scratch, y, &|i| x[i]),
+            Some(sw) => scatter_apply(self.solver_design, &self.scatter_scratch, y, &|i| {
+                sw[i] * x[i]
+            }),
+            None => scatter_apply(self.solver_design, &self.scatter_scratch, y, &|i| x[i]),
         }
         Ok(())
     }
@@ -124,7 +132,7 @@ mod reentry_guard_tests {
     use schwarz_precond::Operator;
 
     use super::DesignOperator;
-    use crate::domain::Design;
+    use crate::domain::{Design, SolverDesign};
     use crate::observation::ObservationFrame;
 
     fn one_factor_design() -> Design<'static> {
@@ -140,13 +148,11 @@ mod reentry_guard_tests {
     #[should_panic(expected = "concurrently")]
     fn apply_adjoint_detects_in_flight_reentry() {
         let design = one_factor_design();
-        let op = DesignOperator::new(&design, None);
+        let solver_design = SolverDesign::new(&design);
+        let op = DesignOperator::new(&solver_design, None);
         // Simulate a sibling `apply_adjoint` already in flight on this operator.
         op.adjoint_active.store(true, Ordering::Release);
-        op.apply_adjoint(
-            &vec![0.0; op.design.n_obs],
-            &mut vec![0.0; op.design.n_dofs],
-        )
-        .expect("unreachable: the guard panics before returning");
+        op.apply_adjoint(&vec![0.0; op.nrows()], &mut vec![0.0; op.ncols()])
+            .expect("unreachable: the guard panics before returning");
     }
 }

--- a/crates/within/src/operator/design/gather.rs
+++ b/crates/within/src/operator/design/gather.rs
@@ -3,16 +3,17 @@
 use rayon::prelude::*;
 
 use super::PAR_THRESHOLD;
-use crate::domain::Design;
 use crate::domain::Loading;
+use crate::domain::SolverDesign;
 
 /// Gather-apply `dst[i] = Σ_t Σ_c src[…] · loading_c(i)`, times `scale[i]` when given.
 pub(crate) fn gather_apply(
-    design: &Design<'_>,
+    solver_design: &SolverDesign<'_>,
     src: &[f64],
     dst: &mut [f64],
     scale: Option<&[f64]>,
 ) {
+    let design = solver_design.design();
     debug_assert!(scale.is_none_or(|s| s.len() == design.n_obs));
     debug_assert_eq!(src.len(), design.n_dofs);
     debug_assert_eq!(dst.len(), design.n_obs);
@@ -27,25 +28,25 @@ pub(crate) fn gather_apply(
             match &*t.columns {
                 [Loading::Constant] => gather_term(chunk, row_start, levels, [col(0)], |_| [1.0]),
                 [Loading::Constant, Loading::Covariate(c0)] => {
-                    let z0 = design.loading_column(*c0 as usize);
+                    let z0 = solver_design.loading_column(*c0 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1)], |i| [1.0, z0[i]])
                 }
                 [Loading::Constant, Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                    let z0 = design.loading_column(*c0 as usize);
-                    let z1 = design.loading_column(*c1 as usize);
+                    let z0 = solver_design.loading_column(*c0 as usize);
+                    let z1 = solver_design.loading_column(*c1 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1), col(2)], |i| {
                         [1.0, z0[i], z1[i]]
                     })
                 }
                 [Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                    let z0 = design.loading_column(*c0 as usize);
-                    let z1 = design.loading_column(*c1 as usize);
+                    let z0 = solver_design.loading_column(*c0 as usize);
+                    let z1 = solver_design.loading_column(*c1 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1)], |i| {
                         [z0[i], z1[i]]
                     })
                 }
                 [Loading::Covariate(c0)] => {
-                    let z0 = design.loading_column(*c0 as usize);
+                    let z0 = solver_design.loading_column(*c0 as usize);
                     gather_term(chunk, row_start, levels, [col(0)], |i| [z0[i]])
                 }
                 columns => {
@@ -59,7 +60,7 @@ pub(crate) fn gather_apply(
                             acc += match loading {
                                 Loading::Constant => coef,
                                 Loading::Covariate(k) => {
-                                    coef * design.loading_column(*k as usize)[i]
+                                    coef * solver_design.loading_column(*k as usize)[i]
                                 }
                             };
                         }

--- a/crates/within/src/operator/design/scatter.rs
+++ b/crates/within/src/operator/design/scatter.rs
@@ -8,15 +8,16 @@ use rayon::prelude::*;
 
 use super::PAR_THRESHOLD;
 use crate::domain::Loading;
-use crate::domain::{Design, TermMeta};
+use crate::domain::{SolverDesign, TermMeta};
 
 /// Adjoint scatter over all terms; `base(i)` is the row value each column scales by its loading.
 pub(super) fn scatter_apply(
-    design: &Design<'_>,
+    solver_design: &SolverDesign<'_>,
     scratch: &[AtomicF64],
     dst: &mut [f64],
     base: &(impl Fn(usize) -> f64 + Sync),
 ) {
+    let design = solver_design.design();
     debug_assert_eq!(dst.len(), design.n_dofs);
     let parallel = design.n_obs > PAR_THRESHOLD;
 
@@ -28,23 +29,23 @@ pub(super) fn scatter_apply(
                 scatter_term::<1>(block, t, levels, parallel, scratch, |i| [base(i)])
             }
             [Loading::Constant, Loading::Covariate(c0)] => {
-                let z0 = design.loading_column(*c0 as usize);
+                let z0 = solver_design.loading_column(*c0 as usize);
                 scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [b, z0[i] * b]
                 })
             }
             [Loading::Constant, Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                let z0 = design.loading_column(*c0 as usize);
-                let z1 = design.loading_column(*c1 as usize);
+                let z0 = solver_design.loading_column(*c0 as usize);
+                let z1 = solver_design.loading_column(*c1 as usize);
                 scatter_term::<3>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [b, z0[i] * b, z1[i] * b]
                 })
             }
             [Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                let z0 = design.loading_column(*c0 as usize);
-                let z1 = design.loading_column(*c1 as usize);
+                let z0 = solver_design.loading_column(*c0 as usize);
+                let z1 = solver_design.loading_column(*c1 as usize);
                 scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [z0[i] * b, z1[i] * b]
@@ -59,7 +60,7 @@ pub(super) fn scatter_apply(
                             scatter_term::<1>(slot, t, levels, parallel, scratch, |i| [base(i)]);
                         }
                         Loading::Covariate(k) => {
-                            let z = design.loading_column(*k as usize);
+                            let z = solver_design.loading_column(*k as usize);
                             scatter_term::<1>(slot, t, levels, parallel, scratch, move |i| {
                                 [z[i] * base(i)]
                             });

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -1,5 +1,5 @@
 mod design_tests {
-    use crate::domain::Design;
+    use crate::domain::{Design, SolverDesign};
     use crate::linalg::dot;
     use crate::operator::DesignOperator;
     use schwarz_precond::Operator;
@@ -12,7 +12,8 @@ mod design_tests {
     #[test]
     fn test_design_operator_dimensions() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let solver_design = SolverDesign::new(&schema);
+        let op = DesignOperator::new(&solver_design, None);
         assert_eq!(op.nrows(), 5);
         assert_eq!(op.ncols(), 7);
     }
@@ -20,7 +21,8 @@ mod design_tests {
     #[test]
     fn test_design_operator_adjoint() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let solver_design = SolverDesign::new(&schema);
+        let op = DesignOperator::new(&solver_design, None);
 
         let x = vec![1.0, -0.5, 2.0, 0.3, -1.0, 0.7, 1.5];
         let r = vec![0.1, 0.2, -0.3, 0.4, -0.5];
@@ -39,7 +41,8 @@ mod design_tests {
     #[test]
     fn test_apply_unweighted_values() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let solver_design = SolverDesign::new(&schema);
+        let op = DesignOperator::new(&solver_design, None);
         let x = vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 40.0];
         let mut y = vec![0.0; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
@@ -49,7 +52,8 @@ mod design_tests {
     #[test]
     fn test_apply_adjoint_unweighted_values() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let solver_design = SolverDesign::new(&schema);
+        let op = DesignOperator::new(&solver_design, None);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0; 7];
         op.apply_adjoint(&r, &mut x)
@@ -78,7 +82,8 @@ mod design_tests {
         let dm = make_large_design();
         let n_dofs = dm.n_dofs;
         let n_rows = dm.n_obs;
-        let op = DesignOperator::new(&dm, None);
+        let solver_design = SolverDesign::new(&dm);
+        let op = DesignOperator::new(&solver_design, None);
 
         let x: Vec<f64> = (0..n_dofs).map(|i| (i as f64 * 0.17 + 1.0).sin()).collect();
         let r: Vec<f64> = (0..n_rows).map(|i| (i as f64 * 0.23 + 2.0).cos()).collect();
@@ -113,7 +118,9 @@ mod design_tests {
         let dm = Design::from_levels_for_test(vec![fa, fb]);
         assert!(dm.obs_perm.is_none(), "dominant factor is sorted; no perm");
 
-        let op = DesignOperator::new(&dm, None);
+        let solver_design = SolverDesign::new(&dm);
+        let dm = solver_design.design();
+        let op = DesignOperator::new(&solver_design, None);
         let x: Vec<f64> = (0..dm.n_dofs)
             .map(|i| (i as f64 * 0.17 + 1.0).sin())
             .collect();
@@ -134,13 +141,15 @@ mod design_tests {
             "Adjoint property violated: <D·x, r>={lhs} vs <x, D^T·r>={rhs}"
         );
 
-        assert_scratch_reuse_matches_fresh(&dm, "fold: non-dominant unsorted 50 levels");
+        assert_scratch_reuse_matches_fresh(&solver_design, "fold: non-dominant unsorted 50 levels");
     }
 
     #[test]
     fn test_large_design_matvec_correctness() {
         let dm = make_large_design();
-        let op = DesignOperator::new(&dm, None);
+        let solver_design = SolverDesign::new(&dm);
+        let dm = solver_design.design();
+        let op = DesignOperator::new(&solver_design, None);
 
         let mut ej = vec![0.0f64; dm.n_dofs];
         ej[0] = 1.0;
@@ -159,7 +168,9 @@ mod design_tests {
     #[test]
     fn test_large_design_apply_adjoint_correctness() {
         let dm = make_large_design();
-        let op = DesignOperator::new(&dm, None);
+        let solver_design = SolverDesign::new(&dm);
+        let dm = solver_design.design();
+        let op = DesignOperator::new(&solver_design, None);
 
         let ones = vec![1.0f64; dm.n_obs];
         let mut x = vec![0.0f64; dm.n_dofs];
@@ -178,7 +189,9 @@ mod design_tests {
     #[test]
     fn test_single_factor_design_adjoint_property() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let solver_design = SolverDesign::new(&dm);
+        let dm = solver_design.design();
+        let op = DesignOperator::new(&solver_design, None);
 
         let x: Vec<f64> = vec![1.0, 2.0, 3.0];
         let r: Vec<f64> = vec![0.5, 1.5, -0.5, 2.0, -1.0];
@@ -202,7 +215,8 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_values() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let solver_design = SolverDesign::new(&dm);
+        let op = DesignOperator::new(&solver_design, None);
         let x = vec![10.0, 20.0, 30.0];
         let mut y = vec![0.0f64; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
@@ -212,7 +226,8 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_adjoint_values() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let solver_design = SolverDesign::new(&dm);
+        let op = DesignOperator::new(&solver_design, None);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0f64; 3];
         op.apply_adjoint(&r, &mut x)
@@ -245,7 +260,11 @@ mod design_tests {
         // The three pairs route Sequential, Fold and SortedCoalesced respectively.
         for (n_obs, n_levels) in [(200usize, 16usize), (15_000, 64), (150_000, 100_000)] {
             let dm = make_strategy_design(n_obs, n_levels);
-            assert_scratch_reuse_matches_fresh(&dm, &format!("n_obs={n_obs}, n_levels={n_levels}"));
+            let solver_design = SolverDesign::new(&dm);
+            assert_scratch_reuse_matches_fresh(
+                &solver_design,
+                &format!("n_obs={n_obs}, n_levels={n_levels}"),
+            );
         }
 
         // A large unsorted non-dominant factor cannot coalesce.
@@ -254,27 +273,32 @@ mod design_tests {
         let fb: Vec<u32> = (0..n_obs).map(|i| ((i * 7919) % 100_000) as u32).collect();
         let dm = Design::from_levels_for_test(vec![fa, fb]);
         assert!(dm.obs_perm.is_none(), "dominant factor is sorted; no perm");
-        assert_scratch_reuse_matches_fresh(&dm, "atomic: non-dominant unsorted 100K levels");
+        let solver_design = SolverDesign::new(&dm);
+        assert_scratch_reuse_matches_fresh(
+            &solver_design,
+            "atomic: non-dominant unsorted 100K levels",
+        );
     }
 
     /// `apply_adjoint` reuses the operator's atomic scatter scratch across
     /// calls (cf. the removed `SCATTER_FOLD_POOL` leak): a second call on the
     /// *same* operator must match a freshly built operator — stale values from
     /// the first call must not bleed into the second.
-    fn assert_scratch_reuse_matches_fresh(dm: &Design<'_>, ctx: &str) {
+    fn assert_scratch_reuse_matches_fresh(solver_design: &SolverDesign<'_>, ctx: &str) {
+        let dm = solver_design.design();
         let r: Vec<f64> = (0..dm.n_obs)
             .map(|i| (i as f64 * 0.37 + 1.0).sin())
             .collect();
 
         // Baseline: a fresh operator that has never applied before.
-        let fresh = DesignOperator::new(dm, None);
+        let fresh = DesignOperator::new(solver_design, None);
         let mut baseline = vec![0.0f64; dm.n_dofs];
         fresh
             .apply_adjoint(&r, &mut baseline)
             .expect("apply_adjoint succeeds");
 
         // The second apply on a dirtied operator must equal the fresh baseline.
-        let op = DesignOperator::new(dm, None);
+        let op = DesignOperator::new(solver_design, None);
         let mut warmup = vec![0.0f64; dm.n_dofs];
         op.apply_adjoint(&r, &mut warmup)
             .expect("apply_adjoint succeeds");
@@ -287,7 +311,7 @@ mod design_tests {
 }
 
 mod slope_design_tests {
-    use crate::domain::{Design, Effect, Loading};
+    use crate::domain::{Design, Effect, Loading, SolverDesign};
     use crate::operator::DesignOperator;
     use schwarz_precond::Operator;
 
@@ -350,7 +374,9 @@ mod slope_design_tests {
         ];
         let design = Design::new(effects).unwrap();
         let dense = dense_matrix(&design);
-        let op = DesignOperator::new(&design, None);
+        let solver_design = SolverDesign::new(&design);
+        let design = solver_design.design();
+        let op = DesignOperator::new(&solver_design, None);
 
         let x: Vec<f64> = (0..design.n_dofs).map(|j| noise(7_000 + j)).collect();
         let mut got = vec![0.0; design.n_obs];
@@ -395,7 +421,9 @@ mod slope_design_tests {
         ];
         let design = Design::new(effects).unwrap();
         let sqrt_weights: Vec<f64> = (0..n).map(|i| (0.5 + noise(i).abs()).sqrt()).collect();
-        let op = DesignOperator::new(&design, Some(&sqrt_weights));
+        let solver_design = SolverDesign::new(&design);
+        let design = solver_design.design();
+        let op = DesignOperator::new(&solver_design, Some(&sqrt_weights));
 
         let x: Vec<f64> = (0..design.n_dofs).map(|j| noise(13 * j + 1)).collect();
         let r: Vec<f64> = (0..n).map(|i| noise(29 * i + 5)).collect();
@@ -415,7 +443,7 @@ mod slope_design_tests {
 }
 
 mod weighted_adjoint_proptests {
-    use crate::domain::Design;
+    use crate::domain::{Design, SolverDesign};
     use crate::operator::DesignOperator;
     use proptest::prelude::*;
     use schwarz_precond::Operator;
@@ -445,6 +473,8 @@ mod weighted_adjoint_proptests {
                 .collect();
 
             let dm = Design::from_levels_for_test(vec![fa, fb]);
+            let solver_design = SolverDesign::new(&dm);
+            let dm = solver_design.design();
 
             let n_dofs = dm.n_dofs;
             let n_rows = dm.n_obs;
@@ -456,7 +486,7 @@ mod weighted_adjoint_proptests {
                 .map(|i| (i as f64 * 0.29 + seed as f64 * 0.07).cos())
                 .collect();
 
-            let op_unweighted = DesignOperator::new(&dm, None);
+            let op_unweighted = DesignOperator::new(&solver_design, None);
             let mut dx = vec![0.0f64; n_rows];
             op_unweighted.apply(&x, &mut dx).unwrap();
             let lhs: f64 = dx
@@ -467,7 +497,7 @@ mod weighted_adjoint_proptests {
                 .sum();
 
             let sqrt_weights: Vec<f64> = weights.iter().map(|w| w.sqrt()).collect();
-            let op_weighted = DesignOperator::new(&dm, Some(&sqrt_weights));
+            let op_weighted = DesignOperator::new(&solver_design, Some(&sqrt_weights));
             let wr = op_weighted.weighted_rhs(&r);
             let mut wdtr = vec![0.0f64; n_dofs];
             op_weighted.apply_adjoint(&wr, &mut wdtr).unwrap();

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -9,8 +9,7 @@ use std::time::{Duration, Instant};
 
 use crate::block_elim::BlockElimSolver;
 use crate::config::{LocalSolverConfig, PreconditionerConfig};
-use crate::domain::Loading;
-use crate::domain::{Design, LocalDomain};
+use crate::domain::{Loading, LocalDomain, SolverDesign};
 use crate::{BuildError, BuildWarning};
 
 #[cfg(test)]
@@ -211,9 +210,10 @@ impl Operator for Preconditioner {
 }
 
 fn build_diagonal(
-    design: &Design<'_>,
+    solver_design: &SolverDesign<'_>,
     weights: Option<&[f64]>,
 ) -> Result<DiagonalPreconditioner, BuildError> {
+    let design = solver_design.design();
     let mut diag = vec![0.0; design.n_dofs];
 
     for (factor_idx, term) in design.terms.iter().enumerate() {
@@ -229,7 +229,7 @@ fn build_diagonal(
                     }
                 }
                 Loading::Covariate(z_col) => {
-                    let z = design.loading_column(*z_col as usize);
+                    let z = solver_design.loading_column(*z_col as usize);
                     for (uid, &level) in levels.iter().enumerate() {
                         // Keep `w * z * z` left-to-right: a zero weight kills a huge `z` first.
                         slice[level as usize] += w(uid) * z[uid] * z[uid];
@@ -258,12 +258,13 @@ fn build_diagonal(
 
 /// Build a [`Preconditioner`] from a design and optional weights, plus any warnings.
 pub(crate) fn build_preconditioner(
-    design: &Design<'_>,
+    solver_design: &SolverDesign<'_>,
     weights: Option<&[f64]>,
     config: Option<&PreconditionerConfig>,
 ) -> Result<(Option<Preconditioner>, Vec<BuildWarning>), BuildError> {
     use crate::domain::build_local_domains;
 
+    let design = solver_design.design();
     // Weights are pre-validated by the sole caller, whose permutation preserves length and sign.
     let default_cfg = PreconditionerConfig::default();
     let resolved = config.unwrap_or(&default_cfg);
@@ -277,7 +278,7 @@ pub(crate) fn build_preconditioner(
             local_solver,
             reduction,
         } => {
-            let (domains, warnings) = build_local_domains(design, weights, local_solver)?;
+            let (domains, warnings) = build_local_domains(solver_design, weights, local_solver)?;
             if domains.is_empty() {
                 // No factor-pair subdomains means no useful Schwarz; fall back to plain LSMR.
                 return Ok((None, warnings));
@@ -287,7 +288,7 @@ pub(crate) fn build_preconditioner(
             (Variant::Additive(preconditioner), warnings)
         }
         PreconditionerConfig::Diagonal => {
-            let preconditioner = build_diagonal(design, weights)?;
+            let preconditioner = build_diagonal(solver_design, weights)?;
             (Variant::Diagonal(preconditioner), Vec::new())
         }
     };

--- a/crates/within/src/operator/schwarz/tests.rs
+++ b/crates/within/src/operator/schwarz/tests.rs
@@ -10,18 +10,21 @@ use crate::config::{
 use schwarz_precond::SubdomainCore;
 
 use crate::csr_block::CsrBlock;
-use crate::domain::{build_local_domains, Design, LocalDomain};
+use crate::domain::{build_local_domains, Design, LocalDomain, SolverDesign};
 use crate::domain::{CrossTab, LocalComponent};
 use crate::operator::schwarz::build_additive_with_strategy;
 use schwarz_precond::{LocalSolver, Operator, ReductionStrategy};
 
 const BLOCK_ELIM_NESTED_RAYON_CHILD_ENV: &str = "WITHIN_TEST_BLOCK_ELIM_NESTED_RAYON_CHILD";
 
-fn make_test_data() -> (Design<'static>, Vec<LocalDomain>) {
+fn make_test_data() -> (usize, Vec<LocalDomain>) {
     let design = Design::from_levels_for_test(vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]);
-    let (domain_pairs, _) = build_local_domains(&design, None, &LocalSolverConfig::default())
-        .expect("plain domains build");
-    (design, domain_pairs)
+    let n_dofs = design.n_dofs;
+    let solver_design = SolverDesign::new(&design);
+    let (domain_pairs, _) =
+        build_local_domains(&solver_design, None, &LocalSolverConfig::default())
+            .expect("plain domains build");
+    (n_dofs, domain_pairs)
 }
 
 fn synthetic_sparse_cross_tab(n_keep: usize, elim_ratio: usize) -> (CrossTab, Vec<f64>) {
@@ -202,13 +205,13 @@ fn test_block_elim_parallel_reduction_nested_rayon_does_not_deadlock() {
 
 #[test]
 fn test_build_additive_with_strategy() {
-    let (design, domain_pairs) = make_test_data();
+    let (n_dofs, domain_pairs) = make_test_data();
     let config = LocalSolverConfig::default();
     let strategy = schwarz_precond::ReductionStrategy::default();
-    let schwarz = build_additive_with_strategy(domain_pairs, &config, strategy, design.n_dofs)
+    let schwarz = build_additive_with_strategy(domain_pairs, &config, strategy, n_dofs)
         .expect("build schwarz with explicit domains");
-    let r = vec![1.0; design.n_dofs];
-    let mut z = vec![0.0; design.n_dofs];
+    let r = vec![1.0; n_dofs];
+    let mut z = vec![0.0; n_dofs];
     schwarz.apply(&r, &mut z).expect("schwarz apply succeeds");
 }
 

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -13,7 +13,7 @@ use crate::channel::Channel;
 use crate::config::{LsmrOptions, PreconditionerConfig};
 use crate::domain::collinearity::detect_collinear_slopes;
 use crate::domain::level_moments::TermMoments;
-use crate::domain::{Design, Effect, FactorEncoding};
+use crate::domain::{Design, Effect, FactorEncoding, LoadingOverrides, SolverDesign};
 use crate::observation::ObservationFrame;
 use crate::operator::design::gather_apply;
 use crate::operator::schwarz::{build_preconditioner, Preconditioner};
@@ -325,6 +325,256 @@ impl BatchSolveResult {
     }
 }
 
+struct SolverState {
+    loading_overrides: LoadingOverrides,
+    /// `sqrt(W)` in the design's internal observation order, computed once and
+    /// borrowed by the per-RHS [`DesignOperator`]s (raw weights are needed only
+    /// during construction).
+    sqrt_weights: Option<Vec<f64>>,
+    preconditioner: Option<Preconditioner>,
+    reparam: Option<SlopeReparam>,
+    warnings: Vec<BuildWarning>,
+}
+
+impl SolverState {
+    fn new(
+        design: &Design,
+        weights: Option<Vec<f64>>,
+        preconditioner: impl Into<PreconditionerInput>,
+    ) -> Result<Self, BuildError> {
+        design.validate_weights(weights.as_deref())?;
+
+        // The match keeps the unpermuted arm a plain move rather than a borrow-and-copy.
+        let weights = match &design.obs_perm {
+            Some(_) => weights.map(|w| design.permute_obs_in(&w).into_owned()),
+            None => weights,
+        };
+
+        // Both readers below need the raw loadings, so the moments precede whitening.
+        let moments = TermMoments::build(design, weights.as_deref());
+        let mut warnings = moments
+            .as_ref()
+            .map(|m| detect_collinear_slopes(design, weights.as_deref(), m))
+            .unwrap_or_default();
+
+        let mut loading_overrides = LoadingOverrides::new(design);
+        // Reparametrize the slope columns (if any) before the preconditioner reads the frame.
+        let reparam = moments
+            .as_ref()
+            .and_then(|m| SlopeReparam::build(design, &mut loading_overrides, m));
+
+        let solver_design = SolverDesign::with_loading_overrides(design, &loading_overrides);
+
+        let (preconditioner, build_warnings) = match preconditioner.into() {
+            PreconditionerInput::Default => {
+                build_preconditioner(&solver_design, weights.as_deref(), None)?
+            }
+            PreconditionerInput::Config(c) => {
+                build_preconditioner(&solver_design, weights.as_deref(), Some(&c))?
+            }
+            PreconditionerInput::Prebuilt(p) => {
+                let n_dofs = design.n_dofs;
+                if p.nrows() != n_dofs || p.ncols() != n_dofs {
+                    return Err(BuildError::PreconditionerDimensionMismatch {
+                        expected: n_dofs,
+                        actual_rows: p.nrows(),
+                        actual_cols: p.ncols(),
+                    });
+                }
+                (Some(p), Vec::new())
+            }
+        };
+
+        warnings.extend(build_warnings);
+
+        let sqrt_weights = weights.map(|mut w| {
+            for wi in &mut w {
+                *wi = wi.sqrt();
+            }
+            w
+        });
+        Ok(Self {
+            loading_overrides,
+            sqrt_weights,
+            preconditioner,
+            reparam,
+            warnings,
+        })
+    }
+
+    /// Shared per-RHS solve: validate `y`, run (m)lsmr, demean, and
+    /// back-transform slopes. Excludes the design-level `layout` / `warnings` /
+    /// `unidentified`, which the public entry points attach once (see
+    /// [`RhsSolution`]).
+    fn solve_rhs(
+        &self,
+        design: &Design,
+        y: &[f64],
+        lsmr: &LsmrOptions,
+    ) -> Result<RhsSolution, SolveError> {
+        let solver_design = SolverDesign::with_loading_overrides(design, &self.loading_overrides);
+        // `weighted_rhs` zips y with sqrt-weights, silently truncating when `y.len() > n_rows`.
+        if y.len() != design.n_obs {
+            return Err(SolveError::InvalidInput {
+                context: "Solver::solve",
+                message: format!(
+                    "response vector length ({}) does not match number of observations ({})",
+                    y.len(),
+                    design.n_obs
+                ),
+            });
+        }
+        if let Some((index, &value)) = y.iter().enumerate().find(|&(_, &v)| !v.is_finite()) {
+            return Err(SolveError::InvalidInput {
+                context: "Solver::solve",
+                message: format!("response at index {index} must be finite, got {value}"),
+            });
+        }
+
+        let t_start = Instant::now();
+
+        // The gather is a recurring per-solve cost of the locality sort, so it counts as setup.
+        let y_internal = design.permute_obs_in(y);
+        let y: &[f64] = &y_internal;
+
+        let rect_op = DesignOperator::new(&solver_design, self.sqrt_weights.as_deref());
+        let b = rect_op.weighted_rhs(y);
+        let b: &[f64] = &b;
+
+        let t_solve_start = Instant::now();
+        let time_setup = t_solve_start.duration_since(t_start).as_secs_f64();
+
+        let r = match self.preconditioner.as_ref() {
+            Some(p) => {
+                let options = MlsmrOptions {
+                    local_size: lsmr.local_size,
+                    ..Default::default()
+                };
+                mlsmr(&rect_op, b, p, lsmr.tol, lsmr.maxiter, options)?
+            }
+            None => lsmr_solve(&rect_op, b, lsmr.tol, lsmr.maxiter, lsmr.local_size)?,
+        };
+
+        let time_solve = t_solve_start.elapsed().as_secs_f64();
+
+        // Shapes are guaranteed here, so the bare `D x` matvec is infallible.
+        let mut demeaned = vec![0.0; design.n_obs];
+        gather_apply(&solver_design, &r.x, &mut demeaned, None);
+        for (d, &yi) in demeaned.iter_mut().zip(y.iter()) {
+            *d = yi - *d;
+        }
+
+        let mut x = r.x;
+        if let Some(rp) = &self.reparam {
+            rp.back_transform(&mut x);
+        }
+
+        Ok(RhsSolution {
+            x,
+            // Back to the caller's observation order (no-op if not reordered).
+            demeaned: design.permute_obs_out(demeaned),
+            converged: r.converged,
+            iterations: r.iterations,
+            // Read from the LSMR recurrence at no extra cost; see `SolveResult::residual`.
+            residual: r.normal_eq_residual,
+            time_setup,
+            time_solve,
+        })
+    }
+
+    /// Per-level directions the data cannot identify, shared across all RHS:
+    /// identification depends only on the design and weights, never on `y`.
+    fn unidentified(&self, design: &Design) -> Vec<CoefficientAddress> {
+        let Some(reparam) = &self.reparam else {
+            return Vec::new();
+        };
+        reparam
+            .unidentified
+            .iter()
+            .copied()
+            .map(|position| position.to_caller_address(design))
+            .collect()
+    }
+
+    /// Solve for a single RHS vector with the given LSMR tuning.
+    fn solve<'o>(
+        &self,
+        design: &Design,
+        y: &[f64],
+        lsmr: impl Into<Option<&'o LsmrOptions>>,
+    ) -> Result<SolveResult, SolveError> {
+        let default = LsmrOptions::default();
+        let lsmr = lsmr.into().unwrap_or(&default);
+
+        let t_start = Instant::now();
+        let solution = self.solve_rhs(design, y, lsmr)?;
+
+        Ok(SolveResult {
+            x: solution.x,
+            unidentified: self.unidentified(design),
+            warnings: self.warnings.clone(),
+            layout: CoefficientLayout::from_design(design),
+            demeaned: solution.demeaned,
+            converged: solution.converged,
+            iterations: solution.iterations,
+            residual: solution.residual,
+            time_total: t_start.elapsed().as_secs_f64(),
+            time_setup: solution.time_setup,
+            time_solve: solution.time_solve,
+        })
+    }
+    /// Solve for multiple RHS vectors in parallel.
+    fn solve_batch<'o>(
+        &self,
+        design: &Design,
+        ys: &[&[f64]],
+        lsmr: impl Into<Option<&'o LsmrOptions>>,
+    ) -> Result<BatchSolveResult, SolveError> {
+        let t_start = Instant::now();
+        let default = LsmrOptions::default();
+        let lsmr = lsmr.into().unwrap_or(&default);
+        let n_rhs = ys.len();
+
+        // Collecting into `Result` fails fast on the first per-RHS error, not during the fold.
+        let solutions: Vec<RhsSolution> = ys
+            .par_iter()
+            .map(|y| self.solve_rhs(design, y, lsmr))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut x = Vec::with_capacity(design.n_dofs * n_rhs);
+        let mut demeaned = Vec::with_capacity(design.n_obs * n_rhs);
+        let mut converged = Vec::with_capacity(n_rhs);
+        let mut iterations = Vec::with_capacity(n_rhs);
+        let mut residual = Vec::with_capacity(n_rhs);
+        let mut time_solve = Vec::with_capacity(n_rhs);
+
+        for solution in solutions {
+            x.extend_from_slice(&solution.x);
+            demeaned.extend_from_slice(&solution.demeaned);
+            converged.push(solution.converged);
+            iterations.push(solution.iterations);
+            residual.push(solution.residual);
+            time_solve.push(solution.time_solve);
+        }
+
+        Ok(BatchSolveResult {
+            x,
+            unidentified: self.unidentified(design),
+            warnings: self.warnings.clone(),
+            layout: CoefficientLayout::from_design(design),
+            demeaned,
+            converged,
+            iterations,
+            residual,
+            time_solve,
+            time_setup: 0.0,
+            time_total: t_start.elapsed().as_secs_f64(),
+            n_dofs: design.n_dofs,
+            n_obs: design.n_obs,
+        })
+    }
+}
+
 /// Persistent solver that owns its preconditioner for reuse across multiple solves.
 ///
 /// Build once with [`Solver::new`], then call [`Solver::solve`] or
@@ -338,13 +588,7 @@ impl BatchSolveResult {
 /// one-shot weighted solve from a borrowed slice, use the free [`solve`] function.
 pub struct Solver<'a> {
     design: Design<'a>,
-    /// `sqrt(W)` in the design's internal observation order, computed once and
-    /// borrowed by the per-RHS [`DesignOperator`]s (raw weights are needed only
-    /// during construction).
-    sqrt_weights: Option<Vec<f64>>,
-    preconditioner: Option<Preconditioner>,
-    reparam: Option<SlopeReparam>,
-    warnings: Vec<BuildWarning>,
+    state: SolverState,
 }
 
 impl std::fmt::Debug for Solver<'_> {
@@ -352,8 +596,8 @@ impl std::fmt::Debug for Solver<'_> {
         f.debug_struct("Solver")
             .field("n_obs", &self.design.n_obs)
             .field("n_dofs", &self.design.n_dofs)
-            .field("has_weights", &self.sqrt_weights.is_some())
-            .field("has_preconditioner", &self.preconditioner.is_some())
+            .field("has_weights", &self.state.sqrt_weights.is_some())
+            .field("has_preconditioner", &self.state.preconditioner.is_some())
             .finish()
     }
 }
@@ -396,156 +640,15 @@ impl<'a> Solver<'a> {
         weights: Option<Vec<f64>>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
-        let mut design = design.into_design()?;
-        design.validate_weights(weights.as_deref())?;
-
-        // The match keeps the unpermuted arm a plain move rather than a borrow-and-copy.
-        let weights = match &design.obs_perm {
-            Some(_) => weights.map(|w| design.permute_obs_in(&w).into_owned()),
-            None => weights,
-        };
-
-        // Both readers below need the raw loadings, so the moments precede whitening.
-        let moments = TermMoments::build(&design, weights.as_deref());
-        let mut warnings = moments
-            .as_ref()
-            .map(|m| detect_collinear_slopes(&design, weights.as_deref(), m))
-            .unwrap_or_default();
-
-        // Reparametrize the slope columns (if any) before the preconditioner reads the frame.
-        let reparam = moments
-            .as_ref()
-            .and_then(|m| SlopeReparam::build(&mut design, m));
-
-        let (preconditioner, build_warnings) = match preconditioner.into() {
-            PreconditionerInput::Default => {
-                build_preconditioner(&design, weights.as_deref(), None)?
-            }
-            PreconditionerInput::Config(c) => {
-                build_preconditioner(&design, weights.as_deref(), Some(&c))?
-            }
-            PreconditionerInput::Prebuilt(p) => {
-                if p.nrows() != design.n_dofs || p.ncols() != design.n_dofs {
-                    return Err(BuildError::PreconditionerDimensionMismatch {
-                        expected: design.n_dofs,
-                        actual_rows: p.nrows(),
-                        actual_cols: p.ncols(),
-                    });
-                }
-                (Some(p), Vec::new())
-            }
-        };
-
-        warnings.extend(build_warnings);
-
-        let sqrt_weights = weights.map(|mut w| {
-            for wi in &mut w {
-                *wi = wi.sqrt();
-            }
-            w
-        });
-
-        Ok(Self {
-            design,
-            sqrt_weights,
-            preconditioner,
-            reparam,
-            warnings,
-        })
+        let design = design.into_design()?;
+        let state = SolverState::new(&design, weights, preconditioner)?;
+        Ok(Self { design, state })
     }
 
     /// Non-fatal events from design screening and the preconditioner build; a reused
     /// pre-built preconditioner contributes none (its own were reported when built).
     pub fn warnings(&self) -> &[BuildWarning] {
-        &self.warnings
-    }
-
-    /// Shared per-RHS solve: validate `y`, run (m)lsmr, demean, and
-    /// back-transform slopes. Excludes the design-level `layout` / `warnings` /
-    /// `unidentified`, which the public entry points attach once (see
-    /// [`RhsSolution`]).
-    fn solve_rhs(&self, y: &[f64], lsmr: &LsmrOptions) -> Result<RhsSolution, SolveError> {
-        // `weighted_rhs` zips y with sqrt-weights, silently truncating when `y.len() > n_rows`.
-        if y.len() != self.design.n_obs {
-            return Err(SolveError::InvalidInput {
-                context: "Solver::solve",
-                message: format!(
-                    "response vector length ({}) does not match number of observations ({})",
-                    y.len(),
-                    self.design.n_obs
-                ),
-            });
-        }
-        if let Some((index, &value)) = y.iter().enumerate().find(|&(_, &v)| !v.is_finite()) {
-            return Err(SolveError::InvalidInput {
-                context: "Solver::solve",
-                message: format!("response at index {index} must be finite, got {value}"),
-            });
-        }
-
-        let t_start = Instant::now();
-
-        // The gather is a recurring per-solve cost of the locality sort, so it counts as setup.
-        let y_internal = self.design.permute_obs_in(y);
-        let y: &[f64] = &y_internal;
-
-        let rect_op = DesignOperator::new(&self.design, self.sqrt_weights.as_deref());
-        let b = rect_op.weighted_rhs(y);
-        let b: &[f64] = &b;
-
-        let t_solve_start = Instant::now();
-        let time_setup = t_solve_start.duration_since(t_start).as_secs_f64();
-
-        let r = match self.preconditioner.as_ref() {
-            Some(p) => {
-                let options = MlsmrOptions {
-                    local_size: lsmr.local_size,
-                    ..Default::default()
-                };
-                mlsmr(&rect_op, b, p, lsmr.tol, lsmr.maxiter, options)?
-            }
-            None => lsmr_solve(&rect_op, b, lsmr.tol, lsmr.maxiter, lsmr.local_size)?,
-        };
-
-        let time_solve = t_solve_start.elapsed().as_secs_f64();
-
-        // Shapes are guaranteed here, so the bare `D x` matvec is infallible.
-        let mut demeaned = vec![0.0; self.design.n_obs];
-        gather_apply(&self.design, &r.x, &mut demeaned, None);
-        for (d, &yi) in demeaned.iter_mut().zip(y.iter()) {
-            *d = yi - *d;
-        }
-
-        let mut x = r.x;
-        if let Some(rp) = &self.reparam {
-            rp.back_transform(&mut x);
-        }
-
-        Ok(RhsSolution {
-            x,
-            // Back to the caller's observation order (no-op if not reordered).
-            demeaned: self.design.permute_obs_out(demeaned),
-            converged: r.converged,
-            iterations: r.iterations,
-            // Read from the LSMR recurrence at no extra cost; see `SolveResult::residual`.
-            residual: r.normal_eq_residual,
-            time_setup,
-            time_solve,
-        })
-    }
-
-    /// Per-level directions the data cannot identify, shared across all RHS:
-    /// identification depends only on the design and weights, never on `y`.
-    fn unidentified(&self) -> Vec<CoefficientAddress> {
-        let Some(reparam) = &self.reparam else {
-            return Vec::new();
-        };
-        reparam
-            .unidentified
-            .iter()
-            .copied()
-            .map(|position| position.to_caller_address(&self.design))
-            .collect()
+        &self.state.warnings
     }
 
     /// Solve for a single RHS vector with the given LSMR tuning.
@@ -554,25 +657,7 @@ impl<'a> Solver<'a> {
         y: &[f64],
         lsmr: impl Into<Option<&'o LsmrOptions>>,
     ) -> Result<SolveResult, SolveError> {
-        let default = LsmrOptions::default();
-        let lsmr = lsmr.into().unwrap_or(&default);
-
-        let t_start = Instant::now();
-        let solution = self.solve_rhs(y, lsmr)?;
-
-        Ok(SolveResult {
-            x: solution.x,
-            unidentified: self.unidentified(),
-            warnings: self.warnings.clone(),
-            layout: CoefficientLayout::from_design(&self.design),
-            demeaned: solution.demeaned,
-            converged: solution.converged,
-            iterations: solution.iterations,
-            residual: solution.residual,
-            time_total: t_start.elapsed().as_secs_f64(),
-            time_setup: solution.time_setup,
-            time_solve: solution.time_solve,
-        })
+        self.state.solve(&self.design, y, lsmr)
     }
 
     /// Solve for multiple RHS vectors in parallel.
@@ -581,53 +666,12 @@ impl<'a> Solver<'a> {
         ys: &[&[f64]],
         lsmr: impl Into<Option<&'o LsmrOptions>>,
     ) -> Result<BatchSolveResult, SolveError> {
-        let t_start = Instant::now();
-        let default = LsmrOptions::default();
-        let lsmr = lsmr.into().unwrap_or(&default);
-        let n_rhs = ys.len();
-
-        // Collecting into `Result` fails fast on the first per-RHS error, not during the fold.
-        let solutions: Vec<RhsSolution> = ys
-            .par_iter()
-            .map(|y| self.solve_rhs(y, lsmr))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let mut x = Vec::with_capacity(self.design.n_dofs * n_rhs);
-        let mut demeaned = Vec::with_capacity(self.design.n_obs * n_rhs);
-        let mut converged = Vec::with_capacity(n_rhs);
-        let mut iterations = Vec::with_capacity(n_rhs);
-        let mut residual = Vec::with_capacity(n_rhs);
-        let mut time_solve = Vec::with_capacity(n_rhs);
-
-        for solution in solutions {
-            x.extend_from_slice(&solution.x);
-            demeaned.extend_from_slice(&solution.demeaned);
-            converged.push(solution.converged);
-            iterations.push(solution.iterations);
-            residual.push(solution.residual);
-            time_solve.push(solution.time_solve);
-        }
-
-        Ok(BatchSolveResult {
-            x,
-            unidentified: self.unidentified(),
-            warnings: self.warnings.clone(),
-            layout: CoefficientLayout::from_design(&self.design),
-            demeaned,
-            converged,
-            iterations,
-            residual,
-            time_solve,
-            time_setup: 0.0,
-            time_total: t_start.elapsed().as_secs_f64(),
-            n_dofs: self.design.n_dofs,
-            n_obs: self.design.n_obs,
-        })
+        self.state.solve_batch(&self.design, ys, lsmr)
     }
 
     /// Access the preconditioner (for serialization or reuse across solvers).
     pub fn preconditioner(&self) -> Option<&Preconditioner> {
-        self.preconditioner.as_ref()
+        self.state.preconditioner.as_ref()
     }
 
     /// Number of DOFs (coefficients).

--- a/crates/within/src/solver/reparam.rs
+++ b/crates/within/src/solver/reparam.rs
@@ -1,7 +1,7 @@
 //! Within-level reparametrization of a design's varying-slope terms.
 
 use crate::domain::level_moments::{BasisScratch, TermMoments};
-use crate::domain::Design;
+use crate::domain::{Design, LoadingOverrides};
 
 use super::CoefficientPosition;
 use crate::channel::Channel;
@@ -39,11 +39,15 @@ struct LevelTransform {
 }
 
 impl SlopeReparam {
-    /// Orthonormalize every slope-bearing term's loading columns in place;
+    /// Install orthonormalized loading overrides for every slope-bearing term;
     /// `None` for slope-free designs. Unidentified directions become
     /// exact-zero columns, so the minimal-norm solve leaves exact-`0`
     /// coefficients.
-    pub(crate) fn build(design: &mut Design<'_>, moments: &TermMoments) -> Option<Self> {
+    pub(crate) fn build(
+        design: &Design<'_>,
+        loading_overrides: &mut LoadingOverrides,
+        moments: &TermMoments,
+    ) -> Option<Self> {
         let mut terms = Vec::new();
         let mut unidentified = Vec::new();
         for term in 0..design.terms.len() {
@@ -54,7 +58,13 @@ impl SlopeReparam {
             {
                 continue;
             }
-            terms.push(TermReparam::build(design, term, moments, &mut unidentified));
+            terms.push(TermReparam::build(
+                design,
+                loading_overrides,
+                term,
+                moments,
+                &mut unidentified,
+            ));
         }
         (!terms.is_empty()).then_some(Self {
             terms,
@@ -71,10 +81,11 @@ impl SlopeReparam {
 }
 
 impl TermReparam {
-    /// Whiten one term's loading columns in place, appending its unidentified
+    /// Whiten one term's solver-local loading columns, appending its unidentified
     /// directions ascending in `(level, column)`.
     fn build(
-        design: &mut Design<'_>,
+        design: &Design<'_>,
+        loading_overrides: &mut LoadingOverrides,
         term: usize,
         moments: &TermMoments,
         unidentified: &mut Vec<CoefficientPosition>,
@@ -141,7 +152,7 @@ impl TermReparam {
             }
         }
         for (out, &c) in u_cols.into_iter().zip(&z_cols) {
-            design.replace_loading_column(c, out);
+            loading_overrides.replace(design, c, out);
         }
 
         Self {

--- a/crates/within/src/solver/reparam/tests.rs
+++ b/crates/within/src/solver/reparam/tests.rs
@@ -3,7 +3,8 @@
 
 use crate::channel::Channel;
 use crate::domain::level_moments::TermMoments;
-use crate::domain::Effect;
+use crate::domain::{Effect, LoadingOverrides, SolverDesign};
+use crate::Design;
 
 use super::*;
 
@@ -26,10 +27,29 @@ fn three_term_effects() -> Vec<Effect<'static>> {
 
 #[test]
 fn build_whitens_each_slope_bearing_term() {
-    let mut design = Design::new(three_term_effects()).unwrap();
+    let design = Design::new(three_term_effects()).unwrap();
+    let raw_loadings: Vec<(usize, Vec<f64>)> = design
+        .terms
+        .iter()
+        .flat_map(|term| term.columns.iter())
+        .filter_map(|loading| loading.covariate())
+        .map(|&column| {
+            let column = column as usize;
+            (column, design.loading_column(column).to_vec())
+        })
+        .collect();
     let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
+    let mut loading_overrides = LoadingOverrides::new(&design);
+    let rp = SlopeReparam::build(&design, &mut loading_overrides, &moments).unwrap();
+    let solver_design = SolverDesign::with_loading_overrides(&design, &loading_overrides);
     assert!(rp.unidentified.is_empty());
+    for (column, expected) in raw_loadings {
+        assert_eq!(
+            solver_design.design().loading_column(column),
+            expected.as_slice(),
+            "canonical loading column {column} was mutated"
+        );
+    }
 
     for term in [0, 2] {
         let meta = &design.terms[term];
@@ -38,7 +58,7 @@ fn build_whitens_each_slope_bearing_term() {
             .columns
             .iter()
             .filter_map(|c| c.covariate())
-            .map(|&k| design.loading_column(k as usize))
+            .map(|&k| solver_design.loading_column(k as usize))
             .collect();
         for level in 0..meta.n_levels() {
             let obs: Vec<usize> = (0..levels.len())
@@ -71,9 +91,10 @@ fn unidentified_directions_ascend_across_terms() {
         Effect::new(&f0, true, [&z0[..]]).unwrap(),
         Effect::new(&f1, true, [&z1[..]]).unwrap(),
     ];
-    let mut design = Design::new(effects).unwrap();
+    let design = Design::new(effects).unwrap();
     let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
+    let mut loading_overrides = LoadingOverrides::new(&design);
+    let rp = SlopeReparam::build(&design, &mut loading_overrides, &moments).unwrap();
     assert_eq!(
         rp.unidentified,
         vec![
@@ -91,9 +112,10 @@ fn unidentified_directions_ascend_across_terms() {
 
 #[test]
 fn back_transform_leaves_other_terms_untouched() {
-    let mut design = Design::new(three_term_effects()).unwrap();
+    let design = Design::new(three_term_effects()).unwrap();
     let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
+    let mut loading_overrides = LoadingOverrides::new(&design);
+    let rp = SlopeReparam::build(&design, &mut loading_overrides, &moments).unwrap();
 
     let mut x: Vec<f64> = (0..design.n_dofs).map(|i| 1.0 + i as f64).collect();
     let before = x.clone();

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -3,7 +3,9 @@ use super::{CoefficientAddress, CoefficientLayout};
 use crate::channel::Channel;
 use crate::config::{LocalSolverConfig, DEFAULT_DENSE_SCHUR_THRESHOLD};
 use crate::domain::level_moments::TermMoments;
-use crate::domain::{build_local_domains, Design, Grounding, MatrixForm};
+use crate::domain::{
+    build_local_domains, Design, Grounding, LoadingOverrides, MatrixForm, SolverDesign,
+};
 use crate::Effect;
 
 /// DGP kept in lockstep with `surplus_component_sampled_matches_exact_reduction`
@@ -34,11 +36,13 @@ fn positive_slope_only_pair_grounds_beyond_dense_threshold() {
         Effect::new(&f, false, [&z[..]]).expect("slope effect"),
         Effect::new(&g, true, []).expect("plain effect"),
     ];
-    let mut design = Design::new(effects).expect("design");
+    let design = Design::new(effects).expect("design");
     let moments = TermMoments::build(&design, None).expect("slopes");
-    let _reparam = SlopeReparam::build(&mut design, &moments);
+    let mut loading_overrides = LoadingOverrides::new(&design);
+    let _reparam = SlopeReparam::build(&design, &mut loading_overrides, &moments);
+    let solver_design = SolverDesign::with_loading_overrides(&design, &loading_overrides);
     let (domains, warnings) =
-        build_local_domains(&design, None, &LocalSolverConfig::default()).expect("domains");
+        build_local_domains(&solver_design, None, &LocalSolverConfig::default()).expect("domains");
     assert!(
         domains.iter().any(|ld| {
             let ct = &ld.component.matrix.cross_tab;


### PR DESCRIPTION
This refactor separates the immutable fixed-effects `Design` from solver-local state in preparation for persistent design reuse.

- `SolverDesign` becomes a read-only borrowed view of a `Design`, with optional solver-local loading overrides.
- `LoadingOverrides` stores transformed slope loading columns without mutating the shared design.
- `SolverState` owns weight-dependent preparation and solve state and operates against a borrowed design.

The public persistent `Design` construction and reuse APIs follow in #319 and #327.

This folds the former #323 and #324 into this PR so the complete internal state separation can be reviewed as one change.