### PR TITLE
Make Design a shared handle in preparation for Python API

### DIFF
--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -20,6 +20,7 @@ use crate::observation::ObservationFrame;
 use crate::BuildError;
 use ndarray::{ArrayView2, Axis};
 use std::borrow::Cow;
+use std::sync::Arc;
 
 /// A slice that is guaranteed non-empty by construction.
 #[repr(transparent)]
@@ -206,16 +207,35 @@ fn stable_argsort(key: &[u32], n_levels: usize) -> Vec<u32> {
     perm
 }
 
-/// Fixed-effects design: observation columns plus coefficient-space layout.
 #[derive(Clone, Debug)]
-pub struct Design<'a> {
+struct DesignInner<'a> {
     /// Columns in internal row order (caller's, or an owned locality-sorted copy).
     frame: ObservationFrame<'a>,
-    pub(crate) terms: Vec<TermMeta>,
-    pub(crate) n_obs: usize,
-    pub(crate) n_dofs: usize,
+    terms: Vec<TermMeta>,
+    n_obs: usize,
+    n_dofs: usize,
     /// `obs_perm[k]` = caller's original index of the observation at internal position `k`.
-    pub(crate) obs_perm: Option<Vec<u32>>,
+    obs_perm: Option<Vec<u32>>,
+}
+
+impl DesignInner<'_> {
+    fn into_owned(self) -> DesignInner<'static> {
+        DesignInner {
+            frame: self.frame.into_owned(),
+            terms: self.terms,
+            n_obs: self.n_obs,
+            n_dofs: self.n_dofs,
+            obs_perm: self.obs_perm,
+        }
+    }
+}
+
+/// Fixed-effects design: observation columns plus coefficient-space layout.
+///
+/// Cloning a design is O(1); clones share the same immutable backing data.
+#[derive(Clone, Debug)]
+pub struct Design<'a> {
+    inner: Arc<DesignInner<'a>>,
 }
 
 impl<'a> Design<'a> {
@@ -321,31 +341,38 @@ impl<'a> Design<'a> {
         };
 
         Ok(Design {
-            frame,
-            terms,
-            n_obs,
-            n_dofs: offset,
-            obs_perm,
+            inner: Arc::new(DesignInner {
+                frame,
+                terms,
+                n_obs,
+                n_dofs: offset,
+                obs_perm,
+            }),
         })
     }
 
     /// Convert the frame's columns to owned, dropping ties to caller buffers.
     pub fn into_owned(self) -> Design<'static> {
+        let inner = Arc::unwrap_or_clone(self.inner).into_owned();
         Design {
-            frame: self.frame.into_owned(),
-            terms: self.terms,
-            n_obs: self.n_obs,
-            n_dofs: self.n_dofs,
-            obs_perm: self.obs_perm,
+            inner: Arc::new(inner),
         }
+    }
+
+    pub(crate) fn terms(&self) -> &[TermMeta] {
+        &self.inner.terms
+    }
+
+    pub(crate) fn obs_perm(&self) -> Option<&[u32]> {
+        self.inner.obs_perm.as_deref()
     }
 
     /// Validate that an optional weight slice matches this design's observation count.
     pub(crate) fn validate_weights(&self, weights: Option<&[f64]>) -> Result<(), BuildError> {
         if let Some(w) = weights {
-            if w.len() != self.n_obs {
+            if w.len() != self.inner.n_obs {
                 return Err(BuildError::WeightCountMismatch {
-                    expected: self.n_obs,
+                    expected: self.inner.n_obs,
                     got: w.len(),
                 });
             }
@@ -363,8 +390,8 @@ impl<'a> Design<'a> {
 
     /// Caller order → internal order: `out[k] = v[obs_perm[k]]`; borrows when unpermuted.
     pub(crate) fn permute_obs_in<'v>(&self, v: &'v [f64]) -> Cow<'v, [f64]> {
-        debug_assert_eq!(v.len(), self.n_obs);
-        match &self.obs_perm {
+        debug_assert_eq!(v.len(), self.inner.n_obs);
+        match &self.inner.obs_perm {
             None => Cow::Borrowed(v),
             Some(perm) => Cow::Owned(perm.iter().map(|&i| v[i as usize]).collect()),
         }
@@ -372,8 +399,8 @@ impl<'a> Design<'a> {
 
     /// Internal order → caller order: `out[obs_perm[k]] = v[k]`.
     pub(crate) fn permute_obs_out(&self, v: Vec<f64>) -> Vec<f64> {
-        debug_assert_eq!(v.len(), self.n_obs);
-        match &self.obs_perm {
+        debug_assert_eq!(v.len(), self.inner.n_obs);
+        match &self.inner.obs_perm {
             None => v,
             Some(perm) => {
                 let mut out = vec![0.0; v.len()];
@@ -388,43 +415,43 @@ impl<'a> Design<'a> {
     /// Number of categorical factors in the design.
     #[inline]
     pub fn n_factors(&self) -> usize {
-        self.terms.len()
+        self.inner.terms.len()
     }
 
     fn n_loading_columns(&self) -> usize {
-        self.frame.n_loading_columns()
+        self.inner.frame.n_loading_columns()
     }
 
     /// The term's coefficient columns in layout order.
     pub(crate) fn channels(&self, term: usize) -> impl Iterator<Item = Channel> + '_ {
-        (0..self.terms[term].n_columns()).map(move |column| Channel { term, column })
+        (0..self.inner.terms[term].n_columns()).map(move |column| Channel { term, column })
     }
 
     /// How `channel` loads onto each observation.
     pub(crate) fn loading(&self, channel: Channel) -> Loading<u32> {
-        self.terms[channel.term].columns[channel.column]
+        self.inner.terms[channel.term].columns[channel.column]
     }
 
     /// Level codes for one term, in internal observation order.
     pub(crate) fn level_column(&self, term: usize) -> &[u32] {
-        self.frame.level_column(term)
+        self.inner.frame.level_column(term)
     }
 
     /// Continuous loading column in internal observation order.
     pub(crate) fn loading_column(&self, column: usize) -> &[f64] {
-        self.frame.loading_column(column)
+        self.inner.frame.loading_column(column)
     }
 
     /// Number of observations (rows of D).
     #[inline]
     pub fn n_obs(&self) -> usize {
-        self.n_obs
+        self.inner.n_obs
     }
 
     /// Total degrees of freedom (columns of D).
     #[inline]
     pub fn n_dofs(&self) -> usize {
-        self.n_dofs
+        self.inner.n_dofs
     }
 }
 
@@ -537,6 +564,19 @@ mod tests {
     }
 
     #[test]
+    fn shared_design_can_be_converted_to_owned() {
+        let owned = {
+            let levels = vec![0, 1, 0];
+            let design = Design::new([Effect::new(&levels, true, []).unwrap()]).unwrap();
+
+            design.clone().into_owned()
+        };
+
+        assert_eq!(owned.n_obs(), 3);
+        assert_eq!(owned.level_column(0), [0, 0, 1]);
+    }
+
+    #[test]
     fn validate_weights_checks_count_and_finiteness() {
         let design = Design::from_frame(frame(vec![vec![0, 0, 0, 0, 0]], vec![])).unwrap();
         assert!(design.validate_weights(None).is_ok());
@@ -571,10 +611,10 @@ mod tests {
             Design::from_frame(frame(vec![vec![2, 0, 1, 0], vec![0, 0, 1, 1]], vec![])).unwrap();
 
         // Stable argsort of [2,0,1,0] → original indices [1,3,2,0].
-        assert_eq!(design.obs_perm.as_deref(), Some(&[1u32, 3, 2, 0][..]));
-        assert!(design.terms[0].sorted);
+        assert_eq!(design.obs_perm(), Some(&[1u32, 3, 2, 0][..]));
+        assert!(design.terms()[0].sorted);
         // Factor 1's permuted column [0,1,1,0] is no longer non-decreasing.
-        assert!(!design.terms[1].sorted);
+        assert!(!design.terms()[1].sorted);
 
         assert_eq!(design.level_column(0), [0, 0, 1, 2]);
         assert_eq!(design.level_column(1), [0, 1, 1, 0]);
@@ -586,18 +626,18 @@ mod tests {
         let col0 = vec![3u32, 0, 2, 1];
         let col1: Vec<u32> = col0.iter().map(|&v| v / 2).collect();
         let design = Design::from_frame(frame(vec![col0, col1], vec![])).unwrap();
-        assert!(design.obs_perm.is_some());
-        assert!(design.terms[0].sorted);
-        assert!(design.terms[1].sorted);
+        assert!(design.obs_perm().is_some());
+        assert!(design.terms()[0].sorted);
+        assert!(design.terms()[1].sorted);
     }
 
     #[test]
     fn from_frame_keeps_sorted_input() {
         let design =
             Design::from_frame(frame(vec![vec![0, 0, 1, 2], vec![1, 0, 1, 0]], vec![])).unwrap();
-        assert!(design.obs_perm.is_none());
-        assert!(design.terms[0].sorted);
-        assert!(!design.terms[1].sorted);
+        assert!(design.obs_perm().is_none());
+        assert!(design.terms()[0].sorted);
+        assert!(!design.terms()[1].sorted);
     }
 
     #[test]
@@ -608,7 +648,7 @@ mod tests {
         ))
         .unwrap();
 
-        let perm = design.obs_perm.as_ref().expect("permutation applied");
+        let perm = design.obs_perm().expect("permutation applied");
         assert_eq!(perm, &[1, 3, 2, 0]);
         assert_eq!(design.level_column(0), [0, 0, 1, 2]);
         assert_eq!(design.loading_column(0), [20.0, 40.0, 30.0, 10.0]);
@@ -629,25 +669,25 @@ mod tests {
         let design = Design::new(effects).unwrap();
 
         // term 0: [intercept, z0, z1] over 2 levels; term 1: intercept over 3; term 2: slope.
-        assert_eq!(design.terms[0].offset, 0);
-        assert_eq!(design.terms[0].n_dofs(), 6);
-        assert_eq!(design.terms[1].offset, 6);
-        assert_eq!(design.terms[1].n_dofs(), 3);
-        assert_eq!(design.terms[2].offset, 9);
-        assert!(!matches!(design.terms[2].columns[0], Loading::Constant));
-        assert_eq!(design.terms[2].n_dofs(), 2);
-        assert_eq!(design.n_dofs, 11);
+        assert_eq!(design.terms()[0].offset, 0);
+        assert_eq!(design.terms()[0].n_dofs(), 6);
+        assert_eq!(design.terms()[1].offset, 6);
+        assert_eq!(design.terms()[1].n_dofs(), 3);
+        assert_eq!(design.terms()[2].offset, 9);
+        assert!(!matches!(design.terms()[2].columns[0], Loading::Constant));
+        assert_eq!(design.terms()[2].n_dofs(), 2);
+        assert_eq!(design.n_dofs(), 11);
 
         // slope indices resolve to the effects' loading columns in the frame.
         assert_eq!(
-            &*design.terms[0].columns,
+            &*design.terms()[0].columns,
             &[
                 Loading::Constant,
                 Loading::Covariate(0),
                 Loading::Covariate(1)
             ]
         );
-        assert_eq!(&*design.terms[2].columns, &[Loading::Covariate(2)]);
+        assert_eq!(&*design.terms()[2].columns, &[Loading::Covariate(2)]);
         assert_eq!(design.loading_column(0), &z0[..]);
         assert_eq!(design.loading_column(2), &z1[..]);
     }

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -92,7 +92,7 @@ fn residual_shares(
         moments,
         stride,
         // Grouping gathers every column, so it must buy back more than the one block.
-        order: match design.terms[term].sorted || plan.per_block == n_levels {
+        order: match design.terms()[term].sorted || plan.per_block == n_levels {
             true => RowOrder::AsIs,
             false => RowOrder::Grouped(super::stable_argsort(levels, n_levels)),
         },

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -271,7 +271,7 @@ fn a_minimal_table_budget_reproduces_the_full_table_shares() {
     ])
     .unwrap();
     // Only term 0's rows come out sorted, so the two terms take the two blocking paths.
-    assert!(design.terms[0].sorted && !design.terms[1].sorted);
+    assert!(design.terms()[0].sorted && !design.terms()[1].sorted);
     assert_eq!(shares(&design, 0, 1), shares(&design, 0, FULL_TABLE));
     for (split, whole) in shares(&design, 1, 1)
         .into_iter()
@@ -344,7 +344,7 @@ fn gappy_level_codes_screen_the_same_at_any_budget() {
         Effect::new(&b, true, [&z2[..]]).unwrap(),
     ])
     .unwrap();
-    assert!(!design.terms[1].sorted);
+    assert!(!design.terms()[1].sorted);
     for (split, whole) in shares(&design, 1, 1)
         .into_iter()
         .zip(shares(&design, 1, FULL_TABLE))

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -24,7 +24,7 @@ struct ActiveLevels {
 /// Scan observations once, marking `active[f][level]` for every level any observation uses.
 pub(crate) fn find_all_active_levels(design: &Design<'_>) -> Vec<Vec<bool>> {
     let mut active: Vec<Vec<bool>> = design
-        .terms
+        .terms()
         .iter()
         .map(|f| vec![false; f.n_levels()])
         .collect();
@@ -147,8 +147,8 @@ impl CrossTab {
         let active = build_compact_mapping(
             &all_active[pair.rows.term],
             &all_active[pair.cols.term],
-            design.terms[pair.rows.term].column_base(pair.rows.column),
-            design.terms[pair.cols.term].column_base(pair.cols.column),
+            design.terms()[pair.rows.term].column_base(pair.rows.column),
+            design.terms()[pair.cols.term].column_base(pair.cols.column),
         )?;
 
         let (c, row_diag, col_diag) = accumulate_cross_block(solver_design, weights, pair, &active);

--- a/crates/within/src/domain/cross_tab/accumulate.rs
+++ b/crates/within/src/domain/cross_tab/accumulate.rs
@@ -93,7 +93,7 @@ pub(super) fn accumulate_cross_block(
     // Dispatching on cell count alone would pick sparse where it uses MORE memory.
     let table_size = active.n_rows.saturating_mul(active.n_cols);
     let dense_cost = table_size.saturating_mul(8);
-    let sparse_cost = design.n_obs.saturating_mul(12);
+    let sparse_cost = design.n_obs().saturating_mul(12);
     let go_sparse = table_size > DENSE_TABLE_MAX_ENTRIES && sparse_cost < dense_cost;
 
     let row_levels = design.level_column(pair.rows.term);

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -339,8 +339,8 @@ fn dense_and_sparse_paths_agree_on_signed_data() {
     let active = build_compact_mapping(
         &all_active[0],
         &all_active[1],
-        design.terms[0].column_base(pair.rows.column),
-        design.terms[1].column_base(pair.cols.column),
+        design.terms()[0].column_base(pair.rows.column),
+        design.terms()[1].column_base(pair.cols.column),
     )
     .expect("both factors have active levels");
 

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -92,7 +92,7 @@ pub(crate) fn build_local_domains(
         .iter()
         .any(|&c| design.loading(c).covariate().is_some())
     {
-        compute_partition_weights(&mut domain_pairs, design.n_dofs);
+        compute_partition_weights(&mut domain_pairs, design.n_dofs());
     }
 
     Ok((domain_pairs, warnings))
@@ -237,7 +237,7 @@ mod tests {
     #[test]
     fn test_partition_of_unity() {
         let dm = make_test_design();
-        let n_dofs = dm.n_dofs;
+        let n_dofs = dm.n_dofs();
         let solver_design = SolverDesign::new(dm);
         let (domain_pairs, _) =
             build_local_domains(&solver_design, None, &LocalSolverConfig::default())
@@ -270,7 +270,7 @@ mod tests {
             Effect::new(&levels_c, true, []).expect("effect c"),
         ])
         .expect("valid slope design");
-        let n_dofs = design.n_dofs;
+        let n_dofs = design.n_dofs();
         let solver_design = SolverDesign::new(design);
         let (domain_pairs, _) =
             build_local_domains(&solver_design, None, &LocalSolverConfig::default())
@@ -302,7 +302,7 @@ mod tests {
     #[test]
     fn test_domains_cover_all_dofs() {
         let dm = make_test_design();
-        let n_dofs = dm.n_dofs;
+        let n_dofs = dm.n_dofs();
         let solver_design = SolverDesign::new(dm);
         let (domain_pairs, _) =
             build_local_domains(&solver_design, None, &LocalSolverConfig::default())

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -16,12 +16,12 @@ impl TermMoments {
     /// `None` when no term carries a covariate, so nothing downstream has work.
     pub(crate) fn build(design: &Design<'_>, weights: Option<&[f64]>) -> Option<Self> {
         let has_slopes = design
-            .terms
+            .terms()
             .iter()
             .any(|t| t.columns.iter().any(|c| c.covariate().is_some()));
         has_slopes.then(|| {
             Self(
-                (0..design.terms.len())
+                (0..design.terms().len())
                     .into_par_iter()
                     .map(|term| LevelMoments::build(design, term, weights))
                     .collect(),
@@ -61,7 +61,7 @@ fn tri_len(v: usize) -> usize {
 
 impl LevelMoments {
     fn build(design: &Design<'_>, term: usize, weights: Option<&[f64]>) -> Self {
-        let meta = &design.terms[term];
+        let meta = &design.terms()[term];
         let covariates: Box<[u32]> = meta
             .columns
             .iter()

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -40,13 +40,13 @@ impl<'a> DesignOperator<'a> {
         if let Some(sw) = sqrt_weights {
             assert_eq!(
                 sw.len(),
-                design.n_obs,
+                design.n_obs(),
                 "sqrt-weights length {} does not match design.n_obs {}",
                 sw.len(),
-                design.n_obs
+                design.n_obs()
             );
         }
-        let max_block = design.terms.iter().map(|t| t.n_dofs()).max().unwrap_or(0);
+        let max_block = design.terms().iter().map(|t| t.n_dofs()).max().unwrap_or(0);
         Self {
             solver_design,
             sqrt_weights,
@@ -91,17 +91,17 @@ impl Drop for ReentryGuard<'_> {
 
 impl Operator for DesignOperator<'_> {
     fn nrows(&self) -> usize {
-        self.solver_design.design().n_obs
+        self.solver_design.design().n_obs()
     }
 
     fn ncols(&self) -> usize {
-        self.solver_design.design().n_dofs
+        self.solver_design.design().n_dofs()
     }
 
     fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
         let design = self.solver_design.design();
-        debug_assert_eq!(x.len(), design.n_dofs);
-        debug_assert_eq!(y.len(), design.n_obs);
+        debug_assert_eq!(x.len(), design.n_dofs());
+        debug_assert_eq!(y.len(), design.n_obs());
         gather_apply(self.solver_design, x, y, self.sqrt_weights);
         Ok(())
     }
@@ -110,8 +110,8 @@ impl Operator for DesignOperator<'_> {
         #[cfg(debug_assertions)]
         let _guard = ReentryGuard::acquire(&self.adjoint_active);
         let design = self.solver_design.design();
-        debug_assert_eq!(x.len(), design.n_obs);
-        debug_assert_eq!(y.len(), design.n_dofs);
+        debug_assert_eq!(x.len(), design.n_obs());
+        debug_assert_eq!(y.len(), design.n_dofs());
         y.fill(0.0);
         // No lock needed: `solve_batch` builds one operator per RHS, so calls are sequential.
         match self.sqrt_weights {

--- a/crates/within/src/operator/design/gather.rs
+++ b/crates/within/src/operator/design/gather.rs
@@ -14,14 +14,14 @@ pub(crate) fn gather_apply(
     scale: Option<&[f64]>,
 ) {
     let design = solver_design.design();
-    debug_assert!(scale.is_none_or(|s| s.len() == design.n_obs));
-    debug_assert_eq!(src.len(), design.n_dofs);
-    debug_assert_eq!(dst.len(), design.n_obs);
+    debug_assert!(scale.is_none_or(|s| s.len() == design.n_obs()));
+    debug_assert_eq!(src.len(), design.n_dofs());
+    debug_assert_eq!(dst.len(), design.n_obs());
 
     dst.fill(0.0);
 
     for_each_chunk(dst, |chunk, row_start| {
-        for (q, t) in design.terms.iter().enumerate() {
+        for (q, t) in design.terms().iter().enumerate() {
             let (offset, n_levels) = (t.offset, t.n_levels());
             let levels = design.level_column(q);
             let col = |c: usize| &src[offset + c * n_levels..offset + (c + 1) * n_levels];

--- a/crates/within/src/operator/design/scatter.rs
+++ b/crates/within/src/operator/design/scatter.rs
@@ -18,10 +18,10 @@ pub(super) fn scatter_apply(
     base: &(impl Fn(usize) -> f64 + Sync),
 ) {
     let design = solver_design.design();
-    debug_assert_eq!(dst.len(), design.n_dofs);
-    let parallel = design.n_obs > PAR_THRESHOLD;
+    debug_assert_eq!(dst.len(), design.n_dofs());
+    let parallel = design.n_obs() > PAR_THRESHOLD;
 
-    for (q, t) in design.terms.iter().enumerate() {
+    for (q, t) in design.terms().iter().enumerate() {
         let levels = design.level_column(q);
         let block = &mut dst[t.offset..t.offset + t.n_dofs()];
         match &*t.columns {

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -80,8 +80,8 @@ mod design_tests {
     #[test]
     fn test_large_design_adjoint_property() {
         let dm = make_large_design();
-        let n_dofs = dm.n_dofs;
-        let n_rows = dm.n_obs;
+        let n_dofs = dm.n_dofs();
+        let n_rows = dm.n_obs();
         let solver_design = SolverDesign::new(dm);
         let op = DesignOperator::new(&solver_design, None);
 
@@ -116,21 +116,24 @@ mod design_tests {
         let fa: Vec<u32> = (0..n_obs as u32).collect();
         let fb: Vec<u32> = (0..n_obs).map(|i| (i % 50) as u32).collect();
         let dm = Design::from_levels_for_test(vec![fa, fb]);
-        assert!(dm.obs_perm.is_none(), "dominant factor is sorted; no perm");
+        assert!(
+            dm.obs_perm().is_none(),
+            "dominant factor is sorted; no perm"
+        );
 
         let solver_design = SolverDesign::new(dm);
         let dm = solver_design.design();
         let op = DesignOperator::new(&solver_design, None);
-        let x: Vec<f64> = (0..dm.n_dofs)
+        let x: Vec<f64> = (0..dm.n_dofs())
             .map(|i| (i as f64 * 0.17 + 1.0).sin())
             .collect();
-        let r: Vec<f64> = (0..dm.n_obs)
+        let r: Vec<f64> = (0..dm.n_obs())
             .map(|i| (i as f64 * 0.23 + 2.0).cos())
             .collect();
 
-        let mut dx = vec![0.0f64; dm.n_obs];
+        let mut dx = vec![0.0f64; dm.n_obs()];
         op.apply(&x, &mut dx).expect("apply succeeds");
-        let mut dtr = vec![0.0f64; dm.n_dofs];
+        let mut dtr = vec![0.0f64; dm.n_dofs()];
         op.apply_adjoint(&r, &mut dtr)
             .expect("apply_adjoint succeeds");
 
@@ -151,9 +154,9 @@ mod design_tests {
         let dm = solver_design.design();
         let op = DesignOperator::new(&solver_design, None);
 
-        let mut ej = vec![0.0f64; dm.n_dofs];
+        let mut ej = vec![0.0f64; dm.n_dofs()];
         ej[0] = 1.0;
-        let mut y = vec![0.0f64; dm.n_obs];
+        let mut y = vec![0.0f64; dm.n_obs()];
         op.apply(&ej, &mut y).expect("apply succeeds");
 
         for (i, &yi) in y.iter().enumerate() {
@@ -172,12 +175,12 @@ mod design_tests {
         let dm = solver_design.design();
         let op = DesignOperator::new(&solver_design, None);
 
-        let ones = vec![1.0f64; dm.n_obs];
-        let mut x = vec![0.0f64; dm.n_dofs];
+        let ones = vec![1.0f64; dm.n_obs()];
+        let mut x = vec![0.0f64; dm.n_dofs()];
         op.apply_adjoint(&ones, &mut x)
             .expect("apply_adjoint succeeds");
 
-        let expected_count = (dm.n_obs / 50) as f64;
+        let expected_count = (dm.n_obs() / 50) as f64;
         for (j, &xj) in x.iter().enumerate() {
             assert!(
                 (xj - expected_count).abs() < 1e-10,
@@ -196,10 +199,10 @@ mod design_tests {
         let x: Vec<f64> = vec![1.0, 2.0, 3.0];
         let r: Vec<f64> = vec![0.5, 1.5, -0.5, 2.0, -1.0];
 
-        let mut dx = vec![0.0f64; dm.n_obs];
+        let mut dx = vec![0.0f64; dm.n_obs()];
         op.apply(&x, &mut dx).expect("apply succeeds");
 
-        let mut dtr = vec![0.0f64; dm.n_dofs];
+        let mut dtr = vec![0.0f64; dm.n_dofs()];
         op.apply_adjoint(&r, &mut dtr)
             .expect("apply_adjoint succeeds");
 
@@ -272,7 +275,10 @@ mod design_tests {
         let fa: Vec<u32> = (0..n_obs as u32).collect();
         let fb: Vec<u32> = (0..n_obs).map(|i| ((i * 7919) % 100_000) as u32).collect();
         let dm = Design::from_levels_for_test(vec![fa, fb]);
-        assert!(dm.obs_perm.is_none(), "dominant factor is sorted; no perm");
+        assert!(
+            dm.obs_perm().is_none(),
+            "dominant factor is sorted; no perm"
+        );
         let solver_design = SolverDesign::new(dm);
         assert_scratch_reuse_matches_fresh(
             &solver_design,
@@ -286,23 +292,23 @@ mod design_tests {
     /// the first call must not bleed into the second.
     fn assert_scratch_reuse_matches_fresh(solver_design: &SolverDesign<'_>, ctx: &str) {
         let dm = solver_design.design();
-        let r: Vec<f64> = (0..dm.n_obs)
+        let r: Vec<f64> = (0..dm.n_obs())
             .map(|i| (i as f64 * 0.37 + 1.0).sin())
             .collect();
 
         // Baseline: a fresh operator that has never applied before.
         let fresh = DesignOperator::new(solver_design, None);
-        let mut baseline = vec![0.0f64; dm.n_dofs];
+        let mut baseline = vec![0.0f64; dm.n_dofs()];
         fresh
             .apply_adjoint(&r, &mut baseline)
             .expect("apply_adjoint succeeds");
 
         // The second apply on a dirtied operator must equal the fresh baseline.
         let op = DesignOperator::new(solver_design, None);
-        let mut warmup = vec![0.0f64; dm.n_dofs];
+        let mut warmup = vec![0.0f64; dm.n_dofs()];
         op.apply_adjoint(&r, &mut warmup)
             .expect("apply_adjoint succeeds");
-        let mut reused = vec![0.0f64; dm.n_dofs];
+        let mut reused = vec![0.0f64; dm.n_dofs()];
         op.apply_adjoint(&r, &mut reused)
             .expect("apply_adjoint succeeds");
 
@@ -327,8 +333,8 @@ mod slope_design_tests {
     /// the reference the operator must agree with regardless of the locality
     /// permutation.
     fn dense_matrix(design: &Design<'_>) -> Vec<Vec<f64>> {
-        let mut d = vec![vec![0.0; design.n_dofs]; design.n_obs];
-        for (q, t) in design.terms.iter().enumerate() {
+        let mut d = vec![vec![0.0; design.n_dofs()]; design.n_obs()];
+        for (q, t) in design.terms().iter().enumerate() {
             let levels = design.level_column(q);
             for (c, loading) in t.columns.iter().enumerate() {
                 let base = t.offset + c * t.n_levels();
@@ -378,8 +384,8 @@ mod slope_design_tests {
         let design = solver_design.design();
         let op = DesignOperator::new(&solver_design, None);
 
-        let x: Vec<f64> = (0..design.n_dofs).map(|j| noise(7_000 + j)).collect();
-        let mut got = vec![0.0; design.n_obs];
+        let x: Vec<f64> = (0..design.n_dofs()).map(|j| noise(7_000 + j)).collect();
+        let mut got = vec![0.0; design.n_obs()];
         op.apply(&x, &mut got).unwrap();
         let expect: Vec<f64> = dense
             .iter()
@@ -387,10 +393,10 @@ mod slope_design_tests {
             .collect();
         assert_close(&got, &expect);
 
-        let r: Vec<f64> = (0..design.n_obs).map(|i| noise(9_000 + i)).collect();
-        let mut got_t = vec![0.0; design.n_dofs];
+        let r: Vec<f64> = (0..design.n_obs()).map(|i| noise(9_000 + i)).collect();
+        let mut got_t = vec![0.0; design.n_dofs()];
         op.apply_adjoint(&r, &mut got_t).unwrap();
-        let mut expect_t = vec![0.0; design.n_dofs];
+        let mut expect_t = vec![0.0; design.n_dofs()];
         for (row, &ri) in dense.iter().zip(&r) {
             for (e, d) in expect_t.iter_mut().zip(row) {
                 *e += d * ri;
@@ -425,12 +431,12 @@ mod slope_design_tests {
         let design = solver_design.design();
         let op = DesignOperator::new(&solver_design, Some(&sqrt_weights));
 
-        let x: Vec<f64> = (0..design.n_dofs).map(|j| noise(13 * j + 1)).collect();
+        let x: Vec<f64> = (0..design.n_dofs()).map(|j| noise(13 * j + 1)).collect();
         let r: Vec<f64> = (0..n).map(|i| noise(29 * i + 5)).collect();
 
         let mut dx = vec![0.0; n];
         op.apply(&x, &mut dx).unwrap();
-        let mut dtr = vec![0.0; design.n_dofs];
+        let mut dtr = vec![0.0; design.n_dofs()];
         op.apply_adjoint(&r, &mut dtr).unwrap();
 
         let lhs: f64 = dx.iter().zip(&r).map(|(a, b)| a * b).sum();
@@ -476,8 +482,8 @@ mod weighted_adjoint_proptests {
             let solver_design = SolverDesign::new(dm);
             let dm = solver_design.design();
 
-            let n_dofs = dm.n_dofs;
-            let n_rows = dm.n_obs;
+            let n_dofs = dm.n_dofs();
+            let n_rows = dm.n_obs();
 
             let x: Vec<f64> = (0..n_dofs)
                 .map(|i| (i as f64 * 0.37 + seed as f64 * 0.13).sin())

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -214,9 +214,9 @@ fn build_diagonal(
     weights: Option<&[f64]>,
 ) -> Result<DiagonalPreconditioner, BuildError> {
     let design = solver_design.design();
-    let mut diag = vec![0.0; design.n_dofs];
+    let mut diag = vec![0.0; design.n_dofs()];
 
-    for (factor_idx, term) in design.terms.iter().enumerate() {
+    for (factor_idx, term) in design.terms().iter().enumerate() {
         let levels = design.level_column(factor_idx);
         let w = |uid: usize| weights.map_or(1.0, |ws| ws[uid]);
         for (column, loading) in term.columns.iter().enumerate() {
@@ -284,7 +284,7 @@ pub(crate) fn build_preconditioner(
                 return Ok((None, warnings));
             }
             let preconditioner =
-                build_additive_with_strategy(domains, local_solver, *reduction, design.n_dofs)?;
+                build_additive_with_strategy(domains, local_solver, *reduction, design.n_dofs())?;
             (Variant::Additive(preconditioner), warnings)
         }
         PreconditionerConfig::Diagonal => {

--- a/crates/within/src/operator/schwarz/tests.rs
+++ b/crates/within/src/operator/schwarz/tests.rs
@@ -19,7 +19,7 @@ const BLOCK_ELIM_NESTED_RAYON_CHILD_ENV: &str = "WITHIN_TEST_BLOCK_ELIM_NESTED_R
 
 fn make_test_data() -> (usize, Vec<LocalDomain>) {
     let design = Design::from_levels_for_test(vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]);
-    let n_dofs = design.n_dofs;
+    let n_dofs = design.n_dofs();
     let solver_design = SolverDesign::new(design);
     let (domain_pairs, _) =
         build_local_domains(&solver_design, None, &LocalSolverConfig::default())

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -116,7 +116,7 @@ struct CoefficientPosition {
 
 impl CoefficientPosition {
     fn to_caller_address(self, design: &Design) -> CoefficientAddress {
-        let level = design.terms[self.channel.term]
+        let level = design.terms()[self.channel.term]
             .encoding
             .label(self.level)
             .expect("coefficient position belongs to its term");
@@ -147,7 +147,7 @@ struct TermLayout {
 impl CoefficientLayout {
     pub(crate) fn from_design(design: &Design) -> Self {
         let terms = design
-            .terms
+            .terms()
             .iter()
             .map(|t| TermLayout {
                 offset: t.offset,
@@ -157,7 +157,7 @@ impl CoefficientLayout {
             .collect();
         Self {
             terms,
-            n_dofs: design.n_dofs,
+            n_dofs: design.n_dofs(),
         }
     }
 
@@ -338,8 +338,8 @@ pub struct Solver<'a> {
 impl std::fmt::Debug for Solver<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Solver")
-            .field("n_obs", &self.solver_design.design().n_obs)
-            .field("n_dofs", &self.solver_design.design().n_dofs)
+            .field("n_obs", &self.solver_design.design().n_obs())
+            .field("n_dofs", &self.solver_design.design().n_dofs())
             .field("has_weights", &self.sqrt_weights.is_some())
             .field("has_preconditioner", &self.preconditioner.is_some())
             .finish()
@@ -388,7 +388,7 @@ impl<'a> Solver<'a> {
         design.validate_weights(weights.as_deref())?;
 
         // The match keeps the unpermuted arm a plain move rather than a borrow-and-copy.
-        let weights = match &design.obs_perm {
+        let weights = match design.obs_perm() {
             Some(_) => weights.map(|w| design.permute_obs_in(&w).into_owned()),
             None => weights,
         };
@@ -414,7 +414,7 @@ impl<'a> Solver<'a> {
                 build_preconditioner(&solver_design, weights.as_deref(), Some(&c))?
             }
             PreconditionerInput::Prebuilt(p) => {
-                let n_dofs = solver_design.design().n_dofs;
+                let n_dofs = solver_design.design().n_dofs();
                 if p.nrows() != n_dofs || p.ncols() != n_dofs {
                     return Err(BuildError::PreconditionerDimensionMismatch {
                         expected: n_dofs,
@@ -457,13 +457,13 @@ impl<'a> Solver<'a> {
     fn solve_rhs(&self, y: &[f64], lsmr: &LsmrOptions) -> Result<RhsSolution, SolveError> {
         let design = self.solver_design.design();
         // `weighted_rhs` zips y with sqrt-weights, silently truncating when `y.len() > n_rows`.
-        if y.len() != design.n_obs {
+        if y.len() != design.n_obs() {
             return Err(SolveError::InvalidInput {
                 context: "Solver::solve",
                 message: format!(
                     "response vector length ({}) does not match number of observations ({})",
                     y.len(),
-                    design.n_obs
+                    design.n_obs()
                 ),
             });
         }
@@ -501,7 +501,7 @@ impl<'a> Solver<'a> {
         let time_solve = t_solve_start.elapsed().as_secs_f64();
 
         // Shapes are guaranteed here, so the bare `D x` matvec is infallible.
-        let mut demeaned = vec![0.0; design.n_obs];
+        let mut demeaned = vec![0.0; design.n_obs()];
         gather_apply(&self.solver_design, &r.x, &mut demeaned, None);
         for (d, &yi) in demeaned.iter_mut().zip(y.iter()) {
             *d = yi - *d;
@@ -585,8 +585,8 @@ impl<'a> Solver<'a> {
             .collect::<Result<Vec<_>, _>>()?;
 
         let design = self.solver_design.design();
-        let mut x = Vec::with_capacity(design.n_dofs * n_rhs);
-        let mut demeaned = Vec::with_capacity(design.n_obs * n_rhs);
+        let mut x = Vec::with_capacity(design.n_dofs() * n_rhs);
+        let mut demeaned = Vec::with_capacity(design.n_obs() * n_rhs);
         let mut converged = Vec::with_capacity(n_rhs);
         let mut iterations = Vec::with_capacity(n_rhs);
         let mut residual = Vec::with_capacity(n_rhs);
@@ -613,8 +613,8 @@ impl<'a> Solver<'a> {
             time_solve,
             time_setup: 0.0,
             time_total: t_start.elapsed().as_secs_f64(),
-            n_dofs: design.n_dofs,
-            n_obs: design.n_obs,
+            n_dofs: design.n_dofs(),
+            n_obs: design.n_obs(),
         })
     }
 
@@ -625,12 +625,12 @@ impl<'a> Solver<'a> {
 
     /// Number of DOFs (coefficients).
     pub fn n_dofs(&self) -> usize {
-        self.solver_design.design().n_dofs
+        self.solver_design.design().n_dofs()
     }
 
     /// Number of observations.
     pub fn n_obs(&self) -> usize {
-        self.solver_design.design().n_obs
+        self.solver_design.design().n_obs()
     }
 }
 

--- a/crates/within/src/solver/reparam.rs
+++ b/crates/within/src/solver/reparam.rs
@@ -49,8 +49,8 @@ impl SlopeReparam {
     ) -> Option<Self> {
         let mut terms = Vec::new();
         let mut unidentified = Vec::new();
-        for term in 0..solver_design.design().terms.len() {
-            if !solver_design.design().terms[term]
+        for term in 0..solver_design.design().terms().len() {
+            if !solver_design.design().terms()[term]
                 .columns
                 .iter()
                 .any(|c| c.covariate().is_some())
@@ -88,7 +88,7 @@ impl TermReparam {
         unidentified: &mut Vec<CoefficientPosition>,
     ) -> Self {
         let design = solver_design.design();
-        let meta = &design.terms[term];
+        let meta = &design.terms()[term];
         let (offset, n_levels) = (meta.offset, meta.n_levels());
         let mut intercept_column = None;
         let mut slope_columns = Vec::new();

--- a/crates/within/src/solver/reparam/tests.rs
+++ b/crates/within/src/solver/reparam/tests.rs
@@ -29,7 +29,7 @@ fn three_term_effects() -> Vec<Effect<'static>> {
 fn build_whitens_each_slope_bearing_term() {
     let design = Design::new(three_term_effects()).unwrap();
     let raw_loadings: Vec<(usize, Vec<f64>)> = design
-        .terms
+        .terms()
         .iter()
         .flat_map(|term| term.columns.iter())
         .filter_map(|loading| loading.covariate())
@@ -52,7 +52,7 @@ fn build_whitens_each_slope_bearing_term() {
 
     let design = solver_design.design();
     for term in [0, 2] {
-        let meta = &design.terms[term];
+        let meta = &design.terms()[term];
         let levels = design.level_column(term);
         let us: Vec<&[f64]> = meta
             .columns
@@ -118,12 +118,12 @@ fn back_transform_leaves_other_terms_untouched() {
     let rp = SlopeReparam::build(&mut solver_design, &moments).unwrap();
 
     let design = solver_design.design();
-    let mut x: Vec<f64> = (0..design.n_dofs).map(|i| 1.0 + i as f64).collect();
+    let mut x: Vec<f64> = (0..design.n_dofs()).map(|i| 1.0 + i as f64).collect();
     let before = x.clone();
     rp.back_transform(&mut x);
 
     // Plain term 1 sits between the two slope-bearing blocks.
-    let (t1, t2) = (design.terms[1].offset, design.terms[2].offset);
+    let (t1, t2) = (design.terms()[1].offset, design.terms()[2].offset);
     assert_eq!(x[t1..t2], before[t1..t2]);
     assert_ne!(x[..t1], before[..t1]);
     assert_ne!(x[t2..], before[t2..]);


### PR DESCRIPTION
This turns `Design` into an `Arc` wrapper around `DesignInner` in preparation for the a persistent Design API that also covers the Python API. It uses `Arc` to mirror the persistent `Preconditioner` functionality (although the former is an `Arc` around the whole structure, while the latter defines `Arc`s on its underlying fields):
```Rust
pub struct Design<'a> {
    inner: Arc<DesignInner<'a>>,
}
```


@schroedk I'm not convinced that using `Arc<DesignInner<'a>>` is really the nicest approach for exposing a persistent `Design` for the Python API, so would be very interested in your thoughts. The rationale that made me land on `Arc` is outlined below. Happy to discuss!

----
### Rationale for introducing an `Arc`
The core problem is ownership on the Python side: With a persistent `Design`, the native Rust `Solver` stores a borrowed reference to `Design`. The naive implementation is not expressible in safe Rust because it would be self-referential:

```Rust
struct PySolver {
    design: Py<PyDesign>,
    solver: Solver<'static>, // borrows from `design`
}
```

As an alternative to an `Arc`, I've considered exposing a `SolverState` that doesn't borrow from `Design` so that `PySolver` could be written as

```Rust
struct PySolver {
    design: Design<'static>,
    state: SolverState,
}
```
where `SolverState` stores any solver-local data:
```Rust
struct SolverState {
    loading_overrides: ...,
    sqrt_weights: ...,
    preconditioner: ...,
    reparam: ...,
    warnings: ...,
}
```
But then there are no guarantees that Python uses a `SolverState` that is consistent with a persistent `Design`, so the Python API plumbing might require additional checks and become more complicated...

