### PR TITLE
Make the Rust Solver reuse a persistent Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,10 @@ let r = solve(categories.view(), &y, None, &lsmr, &diagonal)?;
 Persistent solver — build once, solve many:
 
 ```rust
-use within::Solver;
+use within::{Design, Solver};
 
-let solver = Solver::new(categories.view(), None, None)?;
+let design = Design::from_categories(categories.view())?;
+let solver = Solver::new(&design, None, None)?;
 let r1 = solver.solve(&y, &LsmrOptions::default())?;
 let r2 = solver.solve(&another_y, &LsmrOptions::default())?;  // reuses preconditioner
 ```
@@ -245,8 +246,8 @@ let at = CoefficientAddress { channel: Channel { term: 0, column: 1 }, level: 3.
 println!("{}", r.x[r.layout.index(&at).unwrap()]);
 ```
 
-`Solver::new` takes the same `Vec<Effect>`, so a slope design can be reused
-across solves like any other.
+Build a persistent slope design with `Design::new(terms)`, then pass `&design`
+to each `Solver::new` call that should reuse it.
 
 ### Lower-level access
 

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -30,7 +30,8 @@ fn build_and_solve<'a>(
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(SolveResult, Vec<BuildWarning>), WithinError> {
     let t_start = Instant::now();
-    let solver = Solver::new(design, weights, precond)?;
+    let design = design.into_design()?;
+    let solver = Solver::new(&design, weights, precond)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve(y, lsmr)?;
     result.time_setup += time_setup;
@@ -47,7 +48,8 @@ fn build_and_solve_batch<'a>(
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(BatchSolveResult, Vec<BuildWarning>), WithinError> {
     let t_start = Instant::now();
-    let solver = Solver::new(design, weights, precond)?;
+    let design = design.into_design()?;
+    let solver = Solver::new(&design, weights, precond)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve_batch(ys, lsmr)?;
     result.time_setup += time_setup;
@@ -261,7 +263,8 @@ impl PySolver {
             DesignSource::Categories(categories) => {
                 let cats = categories.as_array();
                 py.detach(move || -> Result<Solver<'static>, BuildError> {
-                    Solver::new(cats.into_design()?.into_owned(), weights_vec, precond)
+                    let design = cats.into_design()?.into_owned();
+                    Solver::new(&design, weights_vec, precond)
                 })
             }
             DesignSource::Effects(terms) => {
@@ -269,7 +272,7 @@ impl PySolver {
                     let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                     // The solver outlives the terms' buffers, so lower to owned columns first.
                     let design = Design::new(effects)?.into_owned();
-                    Solver::new(design, weights_vec, precond)
+                    Solver::new(&design, weights_vec, precond)
                 })
             }
         }

--- a/crates/within/benches/fixest.rs
+++ b/crates/within/benches/fixest.rs
@@ -96,7 +96,7 @@ fn run_lsmr_one_level(design: &Design<'_>, y: &[f64], ac2: bool) {
         local_solver: cfg,
         reduction: ReductionStrategy::Auto,
     };
-    let solver = Solver::new(design.clone(), None, &precond).expect("solver build");
+    let solver = Solver::new(design, None, &precond).expect("solver build");
     let _ = solver.solve(y, &params).expect("solve");
 }
 

--- a/crates/within/benches/store_backend.rs
+++ b/crates/within/benches/store_backend.rs
@@ -96,7 +96,8 @@ fn bench_store_backends(c: &mut Criterion) {
         // C-order view: ingest copies each strided column once.
         group.bench_function(BenchmarkId::new("Array(C)", &p.label), |b| {
             b.iter(|| {
-                let solver = Solver::new(p.categories_c.view(), None, precond_ref).unwrap();
+                let design = within::Design::from_categories(p.categories_c.view()).unwrap();
+                let solver = Solver::new(&design, None, precond_ref).unwrap();
                 let r = solver.solve(&p.y, &p.params).unwrap();
                 assert!(r.converged);
             });
@@ -105,7 +106,8 @@ fn bench_store_backends(c: &mut Criterion) {
         // F-order view: contiguous columns borrowed zero-copy.
         group.bench_function(BenchmarkId::new("Array(F)", &p.label), |b| {
             b.iter(|| {
-                let solver = Solver::new(p.categories_f.view(), None, precond_ref).unwrap();
+                let design = within::Design::from_categories(p.categories_f.view()).unwrap();
+                let solver = Solver::new(&design, None, precond_ref).unwrap();
                 let r = solver.solve(&p.y, &p.params).unwrap();
                 assert!(r.converged);
             });

--- a/crates/within/benches/wallclock_1m3fe.rs
+++ b/crates/within/benches/wallclock_1m3fe.rs
@@ -40,7 +40,7 @@ fn main() {
     let mut best = u128::MAX;
     for _ in 0..RUNS {
         let start = Instant::now();
-        let solver = Solver::new(design.clone(), None, &precond).expect("solver build");
+        let solver = Solver::new(&design, None, &precond).expect("solver build");
         let result = solver.solve(&y, &params).expect("solve");
         best = best.min(start.elapsed().as_nanos());
         black_box(&result);

--- a/crates/within/examples/profile_hot_loop.rs
+++ b/crates/within/examples/profile_hot_loop.rs
@@ -50,7 +50,7 @@ fn main() {
     };
 
     let t_build = Instant::now();
-    let solver = Solver::new(design, None, &precond).expect("solver build");
+    let solver = Solver::new(&design, None, &precond).expect("solver build");
     eprintln!(
         "preconditioner build: {:.3}s",
         t_build.elapsed().as_secs_f64()

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -461,10 +461,10 @@ pub(crate) struct SolverDesign<'a> {
 }
 
 impl<'a> SolverDesign<'a> {
-    pub(crate) fn new(design: Design<'a>) -> Self {
+    pub(crate) fn new(design: &Design<'a>) -> Self {
         let loading_overrides = (0..design.n_loading_columns()).map(|_| None).collect();
         Self {
-            design,
+            design: design.clone(),
             loading_overrides,
         }
     }

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -46,7 +46,7 @@ fn test_cross_tab_sparse_accumulation_path() {
     // Sparse path (large level counts)
     let design_sparse = design_of(vec![fa.clone(), fb.clone()]);
     let active_sparse = find_all_active_levels(&design_sparse);
-    let sparse_solver_design = SolverDesign::new(design_sparse);
+    let sparse_solver_design = SolverDesign::new(&design_sparse);
     let (ct_sparse, diag_sparse, _) = CrossTab::build_for_pair_with_active(
         &sparse_solver_design,
         None,
@@ -60,7 +60,7 @@ fn test_cross_tab_sparse_accumulation_path() {
     let fb_small: Vec<u32> = fb.iter().map(|&x| x % 100).collect();
     let design_dense = design_of(vec![fa_small.clone(), fb_small.clone()]);
     let active_dense = find_all_active_levels(&design_dense);
-    let dense_solver_design = SolverDesign::new(design_dense);
+    let dense_solver_design = SolverDesign::new(&design_dense);
     let (_ct_dense, diag_dense, _) = CrossTab::build_for_pair_with_active(
         &dense_solver_design,
         None,
@@ -132,7 +132,7 @@ fn test_extract_component_two_components() {
     let fb = vec![0u32, 1, 0, 1, 2, 3, 2, 3];
     let design = design_of(vec![fa, fb]);
     let all_active = find_all_active_levels(&design);
-    let solver_design = SolverDesign::new(design);
+    let solver_design = SolverDesign::new(&design);
     let (ct, parent_diag, _) =
         CrossTab::build_for_pair_with_active(&solver_design, None, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
@@ -245,7 +245,7 @@ proptest! {
 
         let design = design_of(vec![fa, fb]);
         let all_active = find_all_active_levels(&design);
-        let solver_design = SolverDesign::new(design);
+        let solver_design = SolverDesign::new(&design);
         let (ct, _, _) = CrossTab::build_for_pair_with_active(
             &solver_design,
             None,

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -226,7 +226,7 @@ mod tests {
     #[test]
     fn test_full_cover_domain_count() {
         let dm = make_test_design();
-        let solver_design = SolverDesign::new(dm);
+        let solver_design = SolverDesign::new(&dm);
         let (domain_pairs, _) =
             build_local_domains(&solver_design, None, &LocalSolverConfig::default())
                 .expect("plain domains build");
@@ -238,7 +238,7 @@ mod tests {
     fn test_partition_of_unity() {
         let dm = make_test_design();
         let n_dofs = dm.n_dofs();
-        let solver_design = SolverDesign::new(dm);
+        let solver_design = SolverDesign::new(&dm);
         let (domain_pairs, _) =
             build_local_domains(&solver_design, None, &LocalSolverConfig::default())
                 .expect("plain domains build");
@@ -271,7 +271,7 @@ mod tests {
         ])
         .expect("valid slope design");
         let n_dofs = design.n_dofs();
-        let solver_design = SolverDesign::new(design);
+        let solver_design = SolverDesign::new(&design);
         let (domain_pairs, _) =
             build_local_domains(&solver_design, None, &LocalSolverConfig::default())
                 .expect("slope domains build");
@@ -303,7 +303,7 @@ mod tests {
     fn test_domains_cover_all_dofs() {
         let dm = make_test_design();
         let n_dofs = dm.n_dofs();
-        let solver_design = SolverDesign::new(dm);
+        let solver_design = SolverDesign::new(&dm);
         let (domain_pairs, _) =
             build_local_domains(&solver_design, None, &LocalSolverConfig::default())
                 .expect("plain domains build");

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -148,7 +148,7 @@ mod reentry_guard_tests {
     #[should_panic(expected = "concurrently")]
     fn apply_adjoint_detects_in_flight_reentry() {
         let design = one_factor_design();
-        let solver_design = SolverDesign::new(design);
+        let solver_design = SolverDesign::new(&design);
         let op = DesignOperator::new(&solver_design, None);
         // Simulate a sibling `apply_adjoint` already in flight on this operator.
         op.adjoint_active.store(true, Ordering::Release);

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -12,7 +12,7 @@ mod design_tests {
     #[test]
     fn test_design_operator_dimensions() {
         let schema = make_test_design();
-        let solver_design = SolverDesign::new(schema);
+        let solver_design = SolverDesign::new(&schema);
         let op = DesignOperator::new(&solver_design, None);
         assert_eq!(op.nrows(), 5);
         assert_eq!(op.ncols(), 7);
@@ -21,7 +21,7 @@ mod design_tests {
     #[test]
     fn test_design_operator_adjoint() {
         let schema = make_test_design();
-        let solver_design = SolverDesign::new(schema);
+        let solver_design = SolverDesign::new(&schema);
         let op = DesignOperator::new(&solver_design, None);
 
         let x = vec![1.0, -0.5, 2.0, 0.3, -1.0, 0.7, 1.5];
@@ -41,7 +41,7 @@ mod design_tests {
     #[test]
     fn test_apply_unweighted_values() {
         let schema = make_test_design();
-        let solver_design = SolverDesign::new(schema);
+        let solver_design = SolverDesign::new(&schema);
         let op = DesignOperator::new(&solver_design, None);
         let x = vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 40.0];
         let mut y = vec![0.0; 5];
@@ -52,7 +52,7 @@ mod design_tests {
     #[test]
     fn test_apply_adjoint_unweighted_values() {
         let schema = make_test_design();
-        let solver_design = SolverDesign::new(schema);
+        let solver_design = SolverDesign::new(&schema);
         let op = DesignOperator::new(&solver_design, None);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0; 7];
@@ -82,7 +82,7 @@ mod design_tests {
         let dm = make_large_design();
         let n_dofs = dm.n_dofs();
         let n_rows = dm.n_obs();
-        let solver_design = SolverDesign::new(dm);
+        let solver_design = SolverDesign::new(&dm);
         let op = DesignOperator::new(&solver_design, None);
 
         let x: Vec<f64> = (0..n_dofs).map(|i| (i as f64 * 0.17 + 1.0).sin()).collect();
@@ -121,7 +121,7 @@ mod design_tests {
             "dominant factor is sorted; no perm"
         );
 
-        let solver_design = SolverDesign::new(dm);
+        let solver_design = SolverDesign::new(&dm);
         let dm = solver_design.design();
         let op = DesignOperator::new(&solver_design, None);
         let x: Vec<f64> = (0..dm.n_dofs())
@@ -150,7 +150,7 @@ mod design_tests {
     #[test]
     fn test_large_design_matvec_correctness() {
         let dm = make_large_design();
-        let solver_design = SolverDesign::new(dm);
+        let solver_design = SolverDesign::new(&dm);
         let dm = solver_design.design();
         let op = DesignOperator::new(&solver_design, None);
 
@@ -171,7 +171,7 @@ mod design_tests {
     #[test]
     fn test_large_design_apply_adjoint_correctness() {
         let dm = make_large_design();
-        let solver_design = SolverDesign::new(dm);
+        let solver_design = SolverDesign::new(&dm);
         let dm = solver_design.design();
         let op = DesignOperator::new(&solver_design, None);
 
@@ -192,7 +192,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_design_adjoint_property() {
         let dm = make_single_factor_design();
-        let solver_design = SolverDesign::new(dm);
+        let solver_design = SolverDesign::new(&dm);
         let dm = solver_design.design();
         let op = DesignOperator::new(&solver_design, None);
 
@@ -218,7 +218,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_values() {
         let dm = make_single_factor_design();
-        let solver_design = SolverDesign::new(dm);
+        let solver_design = SolverDesign::new(&dm);
         let op = DesignOperator::new(&solver_design, None);
         let x = vec![10.0, 20.0, 30.0];
         let mut y = vec![0.0f64; 5];
@@ -229,7 +229,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_adjoint_values() {
         let dm = make_single_factor_design();
-        let solver_design = SolverDesign::new(dm);
+        let solver_design = SolverDesign::new(&dm);
         let op = DesignOperator::new(&solver_design, None);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0f64; 3];
@@ -263,7 +263,7 @@ mod design_tests {
         // The three pairs route Sequential, Fold and SortedCoalesced respectively.
         for (n_obs, n_levels) in [(200usize, 16usize), (15_000, 64), (150_000, 100_000)] {
             let dm = make_strategy_design(n_obs, n_levels);
-            let solver_design = SolverDesign::new(dm);
+            let solver_design = SolverDesign::new(&dm);
             assert_scratch_reuse_matches_fresh(
                 &solver_design,
                 &format!("n_obs={n_obs}, n_levels={n_levels}"),
@@ -279,7 +279,7 @@ mod design_tests {
             dm.obs_perm().is_none(),
             "dominant factor is sorted; no perm"
         );
-        let solver_design = SolverDesign::new(dm);
+        let solver_design = SolverDesign::new(&dm);
         assert_scratch_reuse_matches_fresh(
             &solver_design,
             "atomic: non-dominant unsorted 100K levels",
@@ -380,7 +380,7 @@ mod slope_design_tests {
         ];
         let design = Design::new(effects).unwrap();
         let dense = dense_matrix(&design);
-        let solver_design = SolverDesign::new(design);
+        let solver_design = SolverDesign::new(&design);
         let design = solver_design.design();
         let op = DesignOperator::new(&solver_design, None);
 
@@ -427,7 +427,7 @@ mod slope_design_tests {
         ];
         let design = Design::new(effects).unwrap();
         let sqrt_weights: Vec<f64> = (0..n).map(|i| (0.5 + noise(i).abs()).sqrt()).collect();
-        let solver_design = SolverDesign::new(design);
+        let solver_design = SolverDesign::new(&design);
         let design = solver_design.design();
         let op = DesignOperator::new(&solver_design, Some(&sqrt_weights));
 
@@ -479,7 +479,7 @@ mod weighted_adjoint_proptests {
                 .collect();
 
             let dm = Design::from_levels_for_test(vec![fa, fb]);
-            let solver_design = SolverDesign::new(dm);
+            let solver_design = SolverDesign::new(&dm);
             let dm = solver_design.design();
 
             let n_dofs = dm.n_dofs();

--- a/crates/within/src/operator/schwarz/tests.rs
+++ b/crates/within/src/operator/schwarz/tests.rs
@@ -20,7 +20,7 @@ const BLOCK_ELIM_NESTED_RAYON_CHILD_ENV: &str = "WITHIN_TEST_BLOCK_ELIM_NESTED_R
 fn make_test_data() -> (usize, Vec<LocalDomain>) {
     let design = Design::from_levels_for_test(vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]);
     let n_dofs = design.n_dofs();
-    let solver_design = SolverDesign::new(design);
+    let solver_design = SolverDesign::new(&design);
     let (domain_pairs, _) =
         build_local_domains(&solver_design, None, &LocalSolverConfig::default())
             .expect("plain domains build");

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -23,9 +23,9 @@ mod reparam;
 mod tests;
 use reparam::SlopeReparam;
 
-/// Fallible conversion into a [`Design`] for [`Solver::new`]: a categories
-/// matrix (`ArrayView2<u32>`), a list of [`Effect`] terms, or a pass-through
-/// [`Design`].
+/// Fallible conversion into a [`Design`] for [`solve`] and [`solve_batch`]: a
+/// categories matrix (`ArrayView2<u32>`), a list of [`Effect`] terms, or a
+/// borrowed or owned [`Design`].
 pub trait IntoDesign<'a> {
     /// Build the [`Design`], validating inputs along the way.
     fn into_design(self) -> Result<Design<'a>, BuildError>;
@@ -40,6 +40,12 @@ impl<'a> IntoDesign<'a> for ArrayView2<'a, u32> {
 impl<'a> IntoDesign<'a> for Design<'a> {
     fn into_design(self) -> Result<Design<'a>, BuildError> {
         Ok(self)
+    }
+}
+
+impl<'a> IntoDesign<'a> for &Design<'a> {
+    fn into_design(self) -> Result<Design<'a>, BuildError> {
+        Ok(self.clone())
     }
 }
 
@@ -320,10 +326,10 @@ impl BatchSolveResult {
 /// preconditioner factorization happens only at construction time; LSMR tuning
 /// ([`LsmrOptions`]) is supplied per call.
 ///
-/// Ownership: each observation column is borrowed or owned independently
-/// (`Cow`); a solver that outlives its inputs — e.g. one returned across the
-/// Python boundary — uses owned columns. Weights are always owned; for a
-/// one-shot weighted solve from a borrowed slice, use the free [`solve`] function.
+/// The solver retains an O(1) clone of the immutable [`Design`] handle. Its
+/// lifetime is therefore still constrained by any data borrowed by the design.
+/// Weights are always owned; for a one-shot weighted solve from a borrowed
+/// slice, use the free [`solve`] function.
 pub struct Solver<'a> {
     solver_design: SolverDesign<'a>,
     /// `sqrt(W)` in the design's internal observation order, computed once and
@@ -364,8 +370,8 @@ struct RhsSolution {
 impl<'a> Solver<'a> {
     /// Construct a solver.
     ///
-    /// `design` accepts raw categories (`ArrayView2<u32>`) or a pre-built
-    /// [`Design`]. `preconditioner` accepts:
+    /// `design` is a pre-built [`Design`] that can be reused across solvers.
+    /// `preconditioner` accepts:
     /// - `None` — build the library default Schwarz preconditioner
     /// - `&PreconditionerConfig` / `Some(&PreconditionerConfig)` — build from a tuned config
     /// - `PreconditionerConfig::Off` — solve unpreconditioned
@@ -373,18 +379,17 @@ impl<'a> Solver<'a> {
     /// - [`Preconditioner`] or `&Preconditioner` — reuse a previously built one
     ///
     /// `weights` is `None` for unweighted, or an owned `Vec<f64>` that the
-    /// solver takes ownership of (it re-reads the weights on every solve). To
-    /// solve once from a borrowed slice, use the free [`solve`] function.
+    /// solver takes ownership of. To solve once from a borrowed slice, use the
+    /// free [`solve`] function.
     ///
     /// LSMR tuning ([`LsmrOptions`]) is supplied per call to [`Solver::solve`] /
     /// [`Solver::solve_batch`], not at construction; preconditioner factorization
     /// state is the only expensive thing built here.
     pub fn new(
-        design: impl IntoDesign<'a>,
+        design: &Design<'a>,
         weights: Option<Vec<f64>>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
-        let design = design.into_design()?;
         design.validate_weights(weights.as_deref())?;
 
         // The match keeps the unpermuted arm a plain move rather than a borrow-and-copy.
@@ -394,10 +399,10 @@ impl<'a> Solver<'a> {
         };
 
         // Both readers below need the raw loadings, so the moments precede whitening.
-        let moments = TermMoments::build(&design, weights.as_deref());
+        let moments = TermMoments::build(design, weights.as_deref());
         let mut warnings = moments
             .as_ref()
-            .map(|m| detect_collinear_slopes(&design, weights.as_deref(), m))
+            .map(|m| detect_collinear_slopes(design, weights.as_deref(), m))
             .unwrap_or_default();
 
         let mut solver_design = SolverDesign::new(design);
@@ -658,7 +663,8 @@ pub fn solve<'a, 'o>(
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<SolveResult, WithinError> {
     let t_start = Instant::now();
-    let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
+    let design = design.into_design()?;
+    let solver = Solver::new(&design, weights.map(|w| w.to_vec()), preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve(y, lsmr)?;
     // Include solver construction (preconditioner build) in setup time
@@ -679,7 +685,8 @@ pub fn solve_batch<'a, 'o>(
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<BatchSolveResult, WithinError> {
     let t_start = Instant::now();
-    let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
+    let design = design.into_design()?;
+    let solver = Solver::new(&design, weights.map(|w| w.to_vec()), preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve_batch(ys, lsmr)?;
     result.time_setup += time_setup;

--- a/crates/within/src/solver/reparam/tests.rs
+++ b/crates/within/src/solver/reparam/tests.rs
@@ -39,7 +39,7 @@ fn build_whitens_each_slope_bearing_term() {
         })
         .collect();
     let moments = TermMoments::build(&design, None).unwrap();
-    let mut solver_design = SolverDesign::new(design);
+    let mut solver_design = SolverDesign::new(&design);
     let rp = SlopeReparam::build(&mut solver_design, &moments).unwrap();
     assert!(rp.unidentified.is_empty());
     for (column, expected) in raw_loadings {
@@ -93,7 +93,7 @@ fn unidentified_directions_ascend_across_terms() {
     ];
     let design = Design::new(effects).unwrap();
     let moments = TermMoments::build(&design, None).unwrap();
-    let mut solver_design = SolverDesign::new(design);
+    let mut solver_design = SolverDesign::new(&design);
     let rp = SlopeReparam::build(&mut solver_design, &moments).unwrap();
     assert_eq!(
         rp.unidentified,
@@ -114,7 +114,7 @@ fn unidentified_directions_ascend_across_terms() {
 fn back_transform_leaves_other_terms_untouched() {
     let design = Design::new(three_term_effects()).unwrap();
     let moments = TermMoments::build(&design, None).unwrap();
-    let mut solver_design = SolverDesign::new(design);
+    let mut solver_design = SolverDesign::new(&design);
     let rp = SlopeReparam::build(&mut solver_design, &moments).unwrap();
 
     let design = solver_design.design();

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -36,7 +36,7 @@ fn positive_slope_only_pair_grounds_beyond_dense_threshold() {
     ];
     let design = Design::new(effects).expect("design");
     let moments = TermMoments::build(&design, None).expect("slopes");
-    let mut solver_design = SolverDesign::new(design);
+    let mut solver_design = SolverDesign::new(&design);
     let _reparam = SlopeReparam::build(&mut solver_design, &moments);
     let (domains, warnings) =
         build_local_domains(&solver_design, None, &LocalSolverConfig::default()).expect("domains");

--- a/crates/within/tests/api_pinning.rs
+++ b/crates/within/tests/api_pinning.rs
@@ -2,41 +2,53 @@
 //! argument shapes: if any call form below stops compiling, the public surface shifted.
 
 use ndarray::Array2;
-use within::{solve, solve_batch, LsmrOptions, PreconditionerConfig, Solver};
+use within::{solve, solve_batch, Design, LsmrOptions, PreconditionerConfig, Solver};
 
 fn cats() -> Array2<u32> {
     Array2::from_shape_vec((4, 2), vec![0u32, 0, 1, 1, 2, 0, 3, 1]).expect("cats")
 }
 
 #[test]
+fn design_handle_is_reusable_across_solvers() {
+    let categories = cats();
+    let design = Design::from_categories(categories.view()).unwrap();
+
+    let unweighted = Solver::new(&design, None, None).unwrap();
+    let weighted = Solver::new(&design, Some(vec![1.0; design.n_obs()]), None).unwrap();
+
+    assert_eq!(unweighted.n_dofs(), weighted.n_dofs());
+}
+
+#[test]
 fn precond_input_call_shapes_compile() {
     let categories = cats();
+    let design = Design::from_categories(categories.view()).unwrap();
     let cfg = PreconditionerConfig::default();
 
     // Obtain a prebuilt preconditioner through the public path.
-    let setup = Solver::new(categories.view(), None, &cfg).unwrap();
+    let setup = Solver::new(&design, None, &cfg).unwrap();
     let prec = setup
         .preconditioner()
         .expect("default solver has a preconditioner")
         .clone();
 
     // Shape 1: bare `None` — resolves through `From<Option<&PreconditionerConfig>>`.
-    let _ = Solver::new(categories.view(), None, None).expect("None form");
+    let _ = Solver::new(&design, None, None).expect("None form");
 
     // Shape 2: `&PreconditionerConfig` — resolves through `From<&PreconditionerConfig>`.
-    let _ = Solver::new(categories.view(), None, &cfg).expect("&Cfg form");
+    let _ = Solver::new(&design, None, &cfg).expect("&Cfg form");
 
     // Shape 3: `Option<&PreconditionerConfig>` — explicit `Some(&cfg)`.
-    let _ = Solver::new(categories.view(), None, Some(&cfg)).expect("Some(&Cfg) form");
+    let _ = Solver::new(&design, None, Some(&cfg)).expect("Some(&Cfg) form");
 
     // Shape 4: owned `Preconditioner` — resolves through `From<Preconditioner>`.
-    let _ = Solver::new(categories.view(), None, prec.clone()).expect("owned Prec form");
+    let _ = Solver::new(&design, None, prec.clone()).expect("owned Prec form");
 
     // Shape 5: `&Preconditioner` — resolves through `From<&Preconditioner>` (cheap clone).
-    let _ = Solver::new(categories.view(), None, &prec).expect("&Prec form");
+    let _ = Solver::new(&design, None, &prec).expect("&Prec form");
 
     // Shape 6: owned `Preconditioner` again, consumed last so `prec` is moved here.
-    let _ = Solver::new(categories.view(), None, prec).expect("owned Prec form (move)");
+    let _ = Solver::new(&design, None, prec).expect("owned Prec form (move)");
 }
 
 #[test]
@@ -44,24 +56,26 @@ fn precond_input_owned_config_form() {
     // Owned `PreconditionerConfig` resolves through `From<PreconditionerConfig>`.
     // Kept separate so the main shape sweep stays focused on the &/None variants.
     let categories = cats();
+    let design = Design::from_categories(categories.view()).unwrap();
     let cfg = PreconditionerConfig::default();
-    let _ = Solver::new(categories.view(), None, cfg).expect("owned Cfg form");
+    let _ = Solver::new(&design, None, cfg).expect("owned Cfg form");
 }
 
 #[test]
 fn solve_free_function_precond_call_shapes_compile() {
     let categories = cats();
+    let design = Design::from_categories(categories.view()).unwrap();
     let y = vec![0.0; 4];
     let lsmr = LsmrOptions::default();
     let cfg = PreconditionerConfig::default();
 
-    let setup = Solver::new(categories.view(), None, &cfg).unwrap();
+    let setup = Solver::new(&design, None, &cfg).unwrap();
     let prec = setup
         .preconditioner()
         .expect("default solver has a preconditioner")
         .clone();
 
-    let _ = solve(categories.view(), &y, None, &lsmr, None).expect("None form");
+    let _ = solve(&design, &y, None, &lsmr, None).expect("borrowed Design form");
     let _ = solve(categories.view(), &y, None, &lsmr, &cfg).expect("&Cfg form");
     let _ = solve(categories.view(), &y, None, &lsmr, Some(&cfg)).expect("Some(&Cfg) form");
     let _ = solve(categories.view(), &y, None, &lsmr, prec.clone()).expect("owned Prec form");
@@ -83,15 +97,16 @@ fn solve_free_function_precond_call_shapes_compile() {
 #[test]
 fn solver_new_weights_call_shapes_compile() {
     let categories = cats();
+    let design = Design::from_categories(categories.view()).unwrap();
     let w_vec: Vec<f64> = vec![1.0; 4];
 
     // Bare `None` — infers, because `weights` is the concrete `Option<Vec<f64>>`
     // (no turbofish needed). The persistent solver owns its weights; borrow-based
     // one-shot weighting lives on the free `solve` function instead.
-    let _ = Solver::new(categories.view(), None, None).expect("None weights");
+    let _ = Solver::new(&design, None, None).expect("None weights");
 
     // Owned `Vec<f64>` weights — moved into the solver.
-    let _ = Solver::new(categories.view(), Some(w_vec), None).expect("Vec<f64> weights");
+    let _ = Solver::new(&design, Some(w_vec), None).expect("Vec<f64> weights");
 }
 
 #[test]
@@ -104,6 +119,7 @@ fn options_are_optional_and_tuned_additive_builds_from_crate_root() {
     };
 
     let categories = cats();
+    let design = Design::from_categories(categories.view()).unwrap();
     let y = vec![0.0; 4];
     let opts = LsmrOptions::default();
 
@@ -115,7 +131,7 @@ fn options_are_optional_and_tuned_additive_builds_from_crate_root() {
         },
         reduction: ReductionStrategy::Auto,
     };
-    let solver = Solver::new(categories.view(), None, tuned).expect("tuned Additive builds");
+    let solver = Solver::new(&design, None, tuned).expect("tuned Additive builds");
 
     // `None` accepts the default options; `&opts` still works.
     let _ = solver.solve(&y, None).expect("solve, default options");

--- a/crates/within/tests/domain.rs
+++ b/crates/within/tests/domain.rs
@@ -190,22 +190,20 @@ fn test_intercept_only_effects_match_categories_bitwise() {
             .expect("frame"),
     )
     .expect("categories design");
-    let cat = Solver::new(categories, None, &precond)
+    let cat = Solver::new(&categories, None, &precond)
         .expect("categories solver")
         .solve(&y, &params)
         .expect("categories solve");
 
-    let eff = Solver::new(
-        vec![
-            Effect::new(&col0, true, []).expect("effect 0"),
-            Effect::new(&col1, true, []).expect("effect 1"),
-        ],
-        None,
-        &precond,
-    )
-    .expect("effect solver")
-    .solve(&y, &params)
-    .expect("effect solve");
+    let effects = Design::new(vec![
+        Effect::new(&col0, true, []).expect("effect 0"),
+        Effect::new(&col1, true, []).expect("effect 1"),
+    ])
+    .expect("effects design");
+    let eff = Solver::new(&effects, None, &precond)
+        .expect("effect solver")
+        .solve(&y, &params)
+        .expect("effect solve");
 
     // Bit-identity is only meaningful if both solves actually converged:
     // `Solver::solve` returns `Ok` even at `maxiter`, so without this the
@@ -254,7 +252,8 @@ fn test_slope_chain_design_converges_fast() {
         Effect::new(&worker, true, [&z[..]]).expect("slope effect"),
         Effect::new(&firm, true, []).expect("plain effect"),
     ];
-    let solver = Solver::new(effects, None, PreconditionerConfig::default()).expect("solver build");
+    let design = Design::new(effects).expect("design");
+    let solver = Solver::new(&design, None, PreconditionerConfig::default()).expect("solver build");
     let params = LsmrOptions {
         tol: 1e-8,
         maxiter: 500,

--- a/crates/within/tests/edge_cases.rs
+++ b/crates/within/tests/edge_cases.rs
@@ -234,7 +234,7 @@ fn test_maxiter_1_partial_result() {
         maxiter: 1,
         ..LsmrOptions::default()
     };
-    let solver = Solver::new(design, None, None).expect("solver build");
+    let solver = Solver::new(&design, None, None).expect("solver build");
     let result = solver.solve(&y, &params).expect("solve with maxiter=1");
 
     // Convergence is not expected (tolerance is unreachable in 1 iteration),
@@ -279,7 +279,7 @@ fn test_large_design_convergence() {
         ..LsmrOptions::default()
     };
     let precond = additive_precond();
-    let solver = Solver::new(design, None, &precond).expect("solver build");
+    let solver = Solver::new(&design, None, &precond).expect("solver build");
     let result = solver.solve(&y, &params).expect("large design solve");
 
     assert!(
@@ -302,7 +302,7 @@ fn test_zero_rhs_zero_solution() {
     let y = vec![0.0f64; design.n_obs()];
 
     let params = LsmrOptions::default();
-    let solver = Solver::new(design, None, None).expect("solver build");
+    let solver = Solver::new(&design, None, None).expect("solver build");
     let result = solver.solve(&y, &params).expect("zero RHS solve");
 
     assert!(result.converged, "zero RHS should trivially converge");
@@ -357,7 +357,7 @@ fn test_repeated_solve_is_deterministic() {
 
     let params = LsmrOptions::default();
     let precond = additive_precond();
-    let solver = Solver::new(design, None, &precond).expect("solver build");
+    let solver = Solver::new(&design, None, &precond).expect("solver build");
 
     let r1 = solver.solve(&y, &params).expect("first solve");
     let r2 = solver.solve(&y, &params).expect("second solve");

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -46,7 +46,7 @@ fn test_weight_count_mismatch_error() {
     )
     .expect("frame ok");
     let design = Design::from_frame(frame).expect("valid design");
-    let result = Solver::new(design, Some(vec![1.0, 2.0]), None);
+    let result = Solver::new(&design, Some(vec![1.0, 2.0]), None);
     let err = result.expect_err("expected WeightCountMismatch error, got Ok");
     match err {
         BuildError::WeightCountMismatch { .. } => {}
@@ -76,14 +76,16 @@ fn test_preconditioner_dimension_mismatch_error() {
     // Reusing a larger design's preconditioner must trip the dim check in Solver::new.
     let big = Array2::from_shape_vec((4, 2), vec![0u32, 0, 1, 1, 2, 0, 3, 1]).expect("big array");
     let small = Array2::from_shape_vec((3, 2), vec![0u32, 0, 1, 1, 0, 0]).expect("small array");
+    let big_design = Design::from_categories(big.view()).expect("big design");
+    let small_design = Design::from_categories(small.view()).expect("small design");
 
-    let big_solver = Solver::new(big.view(), None, None).expect("big solver");
+    let big_solver = Solver::new(&big_design, None, None).expect("big solver");
     let prebuilt = big_solver
         .preconditioner()
         .expect("default solver has a preconditioner")
         .clone();
 
-    let result = Solver::new(small.view(), None, prebuilt);
+    let result = Solver::new(&small_design, None, prebuilt);
     let err = result.expect_err("expected PreconditionerDimensionMismatch, got Ok");
     match err {
         BuildError::PreconditionerDimensionMismatch {
@@ -116,7 +118,8 @@ fn test_non_finite_response_rejected() {
     }
 
     // The persistent Solver API funnels through the same guard, so it cannot be bypassed.
-    let solver = Solver::new(cats.view(), None, &precond).expect("solver");
+    let design = Design::from_categories(cats.view()).expect("design");
+    let solver = Solver::new(&design, None, &precond).expect("solver");
     match solver.solve(&y, &params).unwrap_err() {
         SolveError::InvalidInput { message, .. } => {
             assert!(
@@ -168,7 +171,7 @@ fn test_solver_accepts_slope_bearing_design_alongside_other_terms() {
     ];
     // Cross-factor routing (#61): slope terms alongside other terms build.
     let design = Design::new(effects).expect("slope design builds");
-    Solver::new(design, None, None).expect("signed routing builds");
+    Solver::new(&design, None, None).expect("signed routing builds");
 }
 
 // One wiring check per enum: From conversions and the transparent source() forward.
@@ -220,7 +223,7 @@ fn test_invalid_ridge_rejected() {
             Effect::new(&f, true, []).expect("f"),
             Effect::new(&g, true, []).expect("g"),
         ];
-        match Solver::new(effects, None, &precond) {
+        match Solver::new(&Design::new(effects).expect("design"), None, &precond) {
             Err(BuildError::InvalidRidge { value }) => assert_eq!(value.to_bits(), ridge.to_bits()),
             other => panic!("expected InvalidRidge for {ridge}, got {other:?}"),
         }

--- a/crates/within/tests/ingest.rs
+++ b/crates/within/tests/ingest.rs
@@ -54,7 +54,7 @@ fn f_order_view_matches_owned_columns() {
         .map(|f| cats.column(f).iter().copied().collect())
         .collect();
     let design = common::make_design(factor_cols).expect("valid design");
-    let solver = within::Solver::new(design, None, additive_precond()).expect("solver");
+    let solver = within::Solver::new(&design, None, additive_precond()).expect("solver");
     let result_owned = solver.solve(&y, &default_params()).expect("owned solve");
 
     assert!(result_view.converged);
@@ -111,7 +111,7 @@ fn column_reversed_view_ingests_in_logical_order() {
     // Oracle: the same columns handed over owned, in swapped order.
     let design =
         common::make_design(vec![vec![1, 0, 1, 0, 2], vec![0, 1, 0, 1, 2]]).expect("valid design");
-    let solver = within::Solver::new(design, None, additive_precond()).expect("solver");
+    let solver = within::Solver::new(&design, None, additive_precond()).expect("solver");
     let result_owned = solver.solve(&y, &default_params()).expect("owned solve");
 
     assert_eq!(result_rev.x, result_owned.x, "must be bit-identical");

--- a/crates/within/tests/orchestrate_solve.rs
+++ b/crates/within/tests/orchestrate_solve.rs
@@ -14,7 +14,7 @@ fn test_lsmr_unpreconditioned() {
         maxiter: 1000,
         ..Default::default()
     };
-    let solver = Solver::new(design, None, None).expect("build solver");
+    let solver = Solver::new(&design, None, None).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_normal_equations_satisfied(&common::test_categories(), None, &y, &result, 1e-6);
@@ -34,7 +34,7 @@ fn test_lsmr_preconditioned() {
         local_solver: LocalSolverConfig::default(),
         reduction: ReductionStrategy::Auto,
     };
-    let solver = Solver::new(design, None, &precond).expect("build solver");
+    let solver = Solver::new(&design, None, &precond).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_normal_equations_satisfied(&common::test_categories(), None, &y, &result, 1e-6);
@@ -51,7 +51,7 @@ fn test_lsmr_diagonal_preconditioned() {
         ..Default::default()
     };
     let precond = PreconditionerConfig::Diagonal;
-    let solver = Solver::new(design, None, &precond).expect("build solver");
+    let solver = Solver::new(&design, None, &precond).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_solution_finite(&result);
@@ -68,7 +68,7 @@ fn test_lsmr_least_squares() {
         maxiter: 1000,
         ..Default::default()
     };
-    let solver = Solver::new(design, None, None).expect("build solver");
+    let solver = Solver::new(&design, None, None).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     assert!(result.converged, "LSMR LS did not converge");
     common::assert_solution_finite(&result);
@@ -88,7 +88,7 @@ fn test_lsmr_least_squares_weighted_preconditioned() {
         ..Default::default()
     };
     let precond = PreconditionerConfig::default();
-    let solver = Solver::new(design, Some(weights.clone()), &precond).expect("build solver");
+    let solver = Solver::new(&design, Some(weights.clone()), &precond).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_solution_finite(&result);

--- a/crates/within/tests/properties.rs
+++ b/crates/within/tests/properties.rs
@@ -1,7 +1,7 @@
 use proptest::prelude::*;
 use within::{
-    solve, Channel, CoefficientAddress, Effect, LsmrOptions, Preconditioner, PreconditionerConfig,
-    Solver,
+    solve, Channel, CoefficientAddress, Design, Effect, LsmrOptions, Preconditioner,
+    PreconditionerConfig, Solver,
 };
 
 #[path = "common/property_strategies.rs"]
@@ -26,7 +26,8 @@ proptest! {
     fn prop_preconditioner_serde_roundtrip((cats, _y) in random_fe_problem_strategy()) {
         let precond = additive_precond();
 
-        let solver = within::Solver::new(cats.view(), None, &precond).unwrap();
+        let design = within::Design::from_categories(cats.view()).unwrap();
+        let solver = within::Solver::new(&design, None, &precond).unwrap();
         let fe_precond = solver.preconditioner().unwrap();
 
         let bytes = postcard::to_stdvec(fe_precond).unwrap();
@@ -121,7 +122,7 @@ proptest! {
             maxiter: 2000,
             local_size: Some(10),
         };
-        let result = Solver::new(effects, Some(weights.clone()), PreconditionerConfig::default())
+        let result = Solver::new(&Design::new(effects).expect("design"), Some(weights.clone()), PreconditionerConfig::default())
             .expect("build solver")
             .solve(y.as_slice(), &params)
             .expect("solve");

--- a/crates/within/tests/property_gaps.rs
+++ b/crates/within/tests/property_gaps.rs
@@ -77,9 +77,9 @@ proptest! {
 
     /// `solve()` and `Solver::new().solve(, &params)` must produce bit-identical
     /// results given the same design and RHS: the wrappers differ only in
-    /// timing accounting. Both ingest the raw view into a frame design,
-    /// so they share the same locality sort (or its absence) and run in
-    /// identical internal row order on any input.
+    /// timing accounting. Both build the design from the same raw view, so they
+    /// share the same locality sort (or its absence) and run in identical
+    /// internal row order on any input.
     #[test]
     fn prop_solve_vs_solver_identical((cats, y) in random_fe_problem_strategy()) {
         let params = LsmrOptions {
@@ -92,7 +92,8 @@ proptest! {
         let result_a = solve(cats.view(), &y, None, &params, &precond).unwrap();
 
         // Path B: Solver::new() — identical to solve() but without timing wrapper
-        let solver_b = Solver::new(cats.view(), None, &precond).unwrap();
+        let design = within::Design::from_categories(cats.view()).unwrap();
+        let solver_b = Solver::new(&design, None, &precond).unwrap();
         let result_b = solver_b.solve(&y, &params).unwrap();
 
         prop_assert_eq!(

--- a/crates/within/tests/slopes.rs
+++ b/crates/within/tests/slopes.rs
@@ -2,7 +2,7 @@
 //! user's parametrization, fitted-value invariance under the internal
 //! reparametrization, and deterministic rank-drop reporting.
 
-use within::{Effect, LsmrOptions, PreconditionerConfig, SolveResult, Solver};
+use within::{Design, Effect, LsmrOptions, PreconditionerConfig, SolveResult, Solver};
 
 const TOL: f64 = 1e-6;
 
@@ -58,14 +58,12 @@ fn solve_with(
     y: &[f64],
     config: &PreconditionerConfig,
 ) -> SolveResult {
-    Solver::new(
-        vec![Effect::new(levels, intercept, [z]).expect("effect")],
-        weights,
-        config,
-    )
-    .expect("solver")
-    .solve(y, &LsmrOptions::default())
-    .expect("solve")
+    let design =
+        Design::new(vec![Effect::new(levels, intercept, [z]).expect("effect")]).expect("design");
+    Solver::new(&design, weights, config)
+        .expect("solver")
+        .solve(y, &LsmrOptions::default())
+        .expect("solve")
 }
 
 fn solve_single(
@@ -251,13 +249,10 @@ fn batch_solve_shares_unidentified_and_back_transforms_each_rhs() {
     let z: Vec<f64> = vec![1.0, 2.0, 3.0, 2.5, 2.5, 2.5];
     let y1 = synthetic_y(levels.len());
     let y2: Vec<f64> = y1.iter().map(|v| v * -1.5 + 0.3).collect();
+    let design =
+        Design::new(vec![Effect::new(&levels, true, [&z[..]]).expect("effect")]).expect("design");
 
-    let solver = Solver::new(
-        vec![Effect::new(&levels, true, [&z[..]]).expect("effect")],
-        None,
-        PreconditionerConfig::default(),
-    )
-    .expect("solver");
+    let solver = Solver::new(&design, None, PreconditionerConfig::default()).expect("solver");
     let opts = LsmrOptions::default();
     let batch = solver.solve_batch(&[&y1, &y2], &opts).expect("batch");
 
@@ -300,15 +295,15 @@ fn three_slopes_solve_bounded_with_exact_rank_drops() {
         })
         .collect();
     let y = synthetic_y(n);
+    let design = Design::new(vec![
+        Effect::new(&levels, true, [&z1[..], &z2, &z3]).expect("effect")
+    ])
+    .expect("design");
 
-    let r = Solver::new(
-        vec![Effect::new(&levels, true, [&z1[..], &z2, &z3]).expect("effect")],
-        None,
-        PreconditionerConfig::default(),
-    )
-    .expect("solver")
-    .solve(&y, &LsmrOptions::default())
-    .expect("solve");
+    let r = Solver::new(&design, None, PreconditionerConfig::default())
+        .expect("solver")
+        .solve(&y, &LsmrOptions::default())
+        .expect("solve");
     assert!(r.converged);
     assert!(
         r.iterations <= 30,

--- a/crates/within/tests/slopes_routing.rs
+++ b/crates/within/tests/slopes_routing.rs
@@ -2,13 +2,19 @@
 //! factors through balanced/scaled signed subdomains, with frustrated
 //! components solving through their Gremban double cover (#62).
 
-use within::{Effect, LsmrOptions, Preconditioner, PreconditionerConfig, SchurMode, Solver};
+use within::{
+    Design, Effect, LsmrOptions, Preconditioner, PreconditionerConfig, SchurMode, Solver,
+};
 
 fn lcg(seed: &mut u64) -> u64 {
     *seed = seed
         .wrapping_mul(6364136223846793005)
         .wrapping_add(1442695040888963407);
     *seed
+}
+
+fn design<'a>(effects: Vec<Effect<'a>>) -> Design<'a> {
+    Design::new(effects).expect("design")
 }
 
 #[test]
@@ -36,7 +42,7 @@ fn two_factor_slope_solves_with_bounded_iterations() {
         Effect::new(&f, true, [&z[..]]).expect("slope effect"),
         Effect::new(&g, true, []).expect("plain effect"),
     ];
-    let r = Solver::new(effects, None, PreconditionerConfig::default())
+    let r = Solver::new(&design(effects), None, PreconditionerConfig::default())
         .expect("signed routing builds")
         .solve(&y, &LsmrOptions::default())
         .expect("solve");
@@ -69,7 +75,7 @@ fn unit_trends_plus_time_effects_boundary() {
         Effect::new(&unit, true, [&t[..]]).expect("trend effect"),
         Effect::new(&time, true, []).expect("time effect"),
     ];
-    let r = Solver::new(effects, None, PreconditionerConfig::default())
+    let r = Solver::new(&design(effects), None, PreconditionerConfig::default())
         .expect("PSD-boundary routing builds")
         .solve(&y, &LsmrOptions::default())
         .expect("solve");
@@ -90,7 +96,7 @@ fn frustrated_component_solves_via_cover() {
         Effect::new(&g, true, []).expect("plain effect"),
     ];
 
-    let r = Solver::new(effects, None, PreconditionerConfig::default())
+    let r = Solver::new(&design(effects), None, PreconditionerConfig::default())
         .expect("frustrated component builds via its Gremban cover")
         .solve(&y, &LsmrOptions::default())
         .expect("solve");
@@ -147,7 +153,7 @@ fn frustrated_two_factor_slope_solves_with_bounded_iterations() {
         Effect::new(&f, true, [&z[..]]).expect("slope effect"),
         Effect::new(&g, true, []).expect("plain effect"),
     ];
-    let r = Solver::new(effects, None, PreconditionerConfig::default())
+    let r = Solver::new(&design(effects), None, PreconditionerConfig::default())
         .expect("frustrated routing builds")
         .solve(&y, &LsmrOptions::default())
         .expect("solve");
@@ -169,7 +175,7 @@ fn near_collinear_cross_term_direction_survives_routing() {
         Effect::new(&f, false, [&z1[..]]).unwrap(),
         Effect::new(&f, false, [&z2[..]]).unwrap(),
     ];
-    let r = Solver::new(effects, None, PreconditionerConfig::default())
+    let r = Solver::new(&design(effects), None, PreconditionerConfig::default())
         .expect("near-collinear pair builds")
         .solve(&y, &LsmrOptions::default())
         .expect("solve");
@@ -218,7 +224,7 @@ fn surplus_component_sampled_matches_exact_reduction() {
             },
             reduction: Default::default(),
         };
-        Solver::new(effects, None, config)
+        Solver::new(&design(effects), None, config)
             .expect("build")
             .solve(&y, &LsmrOptions::default())
             .expect("solve")
@@ -273,7 +279,7 @@ fn singleton_level_in_non_first_slope_term_solves_under_default() {
         ]
     };
 
-    let solver = Solver::new(effects(), None, PreconditionerConfig::default())
+    let solver = Solver::new(&design(effects()), None, PreconditionerConfig::default())
         .expect("default preconditioner builds");
 
     // The preconditioner must match the operator's column count, uncovered ones included.
@@ -303,7 +309,7 @@ fn singleton_level_in_non_first_slope_term_solves_under_default() {
 
     // The demeaned residual is gauge-invariant, so it agrees though raw coefficients need not.
     for cfg in [PreconditionerConfig::Off, PreconditionerConfig::Diagonal] {
-        let alt = Solver::new(effects(), None, cfg)
+        let alt = Solver::new(&design(effects()), None, cfg)
             .expect("alt preconditioner builds")
             .solve(&y, &LsmrOptions::default())
             .expect("alt solve");
@@ -319,7 +325,7 @@ fn singleton_level_in_non_first_slope_term_solves_under_default() {
     let bytes = postcard::to_stdvec(precond).expect("serialize");
     let restored: Preconditioner = postcard::from_bytes(&bytes).expect("deserialize");
     assert_eq!(restored.ncols(), solver.n_dofs());
-    let reused = Solver::new(effects(), None, restored)
+    let reused = Solver::new(&design(effects()), None, restored)
         .expect("reused preconditioner accepted")
         .solve(&y, &LsmrOptions::default())
         .expect("reused solve");
@@ -390,7 +396,7 @@ fn dual_factor_slopes_build_across_loading_shapes() {
             Effect::new(&year, true, []).expect("year effect"),
             Effect::new(&firm, true, [&z_firm[..]]).expect("firm slope"),
         ];
-        let r = Solver::new(effects, None, PreconditionerConfig::default())
+        let r = Solver::new(&design(effects), None, PreconditionerConfig::default())
             .unwrap_or_else(|e| panic!("{what}: build failed: {e}"))
             .solve(&y, &LsmrOptions::default())
             .unwrap_or_else(|e| panic!("{what}: solve failed: {e}"));

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -1,6 +1,6 @@
-use ndarray::array;
+use ndarray::{array, Array2};
 use within::{
-    solve, ApproxCholConfig, ApproxSchurConfig, Effect, LocalSolverConfig, LsmrOptions,
+    solve, ApproxCholConfig, ApproxSchurConfig, Design, Effect, LocalSolverConfig, LsmrOptions,
     Preconditioner, PreconditionerConfig, ReductionStrategy, ScalingConfig, ScalingFailure,
     SchurMode, Solver,
 };
@@ -22,6 +22,14 @@ fn categories_and_y() -> (ndarray::Array2<u32>, Vec<f64>) {
     (categories, y)
 }
 
+fn category_design(categories: &Array2<u32>) -> Design<'_> {
+    Design::from_categories(categories.view()).expect("design")
+}
+
+fn effect_design<'a>(effects: Vec<Effect<'a>>) -> Design<'a> {
+    Design::new(effects).expect("design")
+}
+
 #[test]
 fn test_solver_matches_oneshot() {
     let (categories, y) = categories_and_y();
@@ -30,7 +38,7 @@ fn test_solver_matches_oneshot() {
 
     let oneshot = solve(categories.view(), &y, None, &params, &precond).expect("oneshot");
 
-    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver = Solver::new(&category_design(&categories), None, &precond).expect("solver build");
     let result = solver.solve(&y, &params).expect("solver solve");
 
     assert!(result.converged);
@@ -46,7 +54,7 @@ fn test_solver_demeaned() {
     let params = default_params();
     let precond = additive_precond();
 
-    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver = Solver::new(&category_design(&categories), None, &precond).expect("solver build");
     let result = solver.solve(&y, &params).expect("solver solve");
 
     assert_eq!(result.demeaned.len(), y.len());
@@ -63,7 +71,7 @@ fn test_solver_no_preconditioner() {
     let (categories, y) = categories_and_y();
     let params = default_params();
 
-    let solver = Solver::new(categories.view(), None, None).expect("solver build");
+    let solver = Solver::new(&category_design(&categories), None, None).expect("solver build");
     let result = solver.solve(&y, &params).expect("solver solve");
 
     assert!(result.converged);
@@ -76,7 +84,7 @@ fn test_solver_diagonal_preconditioner() {
     let params = default_params();
     let precond = PreconditionerConfig::Diagonal;
 
-    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver = Solver::new(&category_design(&categories), None, &precond).expect("solver build");
     assert!(
         solver.preconditioner().is_some(),
         "diagonal preconditioner should be cached"
@@ -92,7 +100,7 @@ fn test_diagonal_preconditioner_single_factor_is_cached() {
     let categories = array![[0u32], [1], [0], [2], [1]];
     let precond = PreconditionerConfig::Diagonal;
 
-    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver = Solver::new(&category_design(&categories), None, &precond).expect("solver build");
 
     let cached = solver
         .preconditioner()
@@ -112,7 +120,7 @@ fn test_solver_batch() {
     let params = default_params();
     let precond = additive_precond();
 
-    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver = Solver::new(&category_design(&categories), None, &precond).expect("solver build");
 
     let r1 = solver.solve(&y1, &params).expect("solve y1");
     let r2 = solver.solve(&y2, &params).expect("solve y2");
@@ -159,7 +167,8 @@ fn test_solver_batch_term_design_shares_drop_report() {
     ];
     let params = default_params();
 
-    let solver = Solver::new(effects, None, additive_precond()).expect("solver build");
+    let solver =
+        Solver::new(&effect_design(effects), None, additive_precond()).expect("solver build");
     let batch = solver
         .solve_batch(&[&ys[0], &ys[1]], &params)
         .expect("solve batch");
@@ -183,7 +192,7 @@ fn test_unidentified_empty_for_plain_factors() {
     let params = default_params();
     let precond = additive_precond();
 
-    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver = Solver::new(&category_design(&categories), None, &precond).expect("solver build");
 
     let single = solver.solve(&y, &params).expect("solve");
     assert!(single.unidentified.is_empty());
@@ -197,7 +206,7 @@ fn test_unidentified_empty_for_plain_factors() {
 fn test_solver_properties() {
     let (categories, _) = categories_and_y();
 
-    let solver = Solver::new(categories.view(), None, None).expect("solver build");
+    let solver = Solver::new(&category_design(&categories), None, None).expect("solver build");
 
     assert_eq!(solver.n_dofs(), 5); // 3 levels + 2 levels
     assert_eq!(solver.n_obs(), 5);
@@ -225,7 +234,7 @@ fn test_additive_serde_roundtrip_preserves_config_and_solution() {
         reduction: ReductionStrategy::AtomicScatter,
     };
 
-    let solver1 = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver1 = Solver::new(&category_design(&categories), None, &precond).expect("solver build");
     let r1 = solver1.solve(&y, &params).expect("solve 1");
 
     // Serialize preconditioner
@@ -240,8 +249,8 @@ fn test_additive_serde_roundtrip_preserves_config_and_solution() {
     let precond2: Preconditioner = postcard::from_bytes(&bytes).expect("deserialize");
     assert_eq!(precond2.config(), &precond);
     assert_eq!(precond2.build_duration(), precond_ref.build_duration());
-    let solver2 =
-        Solver::new(categories.view(), None, precond2).expect("solver from preconditioner");
+    let solver2 = Solver::new(&category_design(&categories), None, precond2)
+        .expect("solver from preconditioner");
     assert_eq!(
         solver2
             .preconditioner()
@@ -260,7 +269,7 @@ fn test_additive_serde_roundtrip_preserves_config_and_solution() {
 fn test_diagonal_serde_roundtrip() {
     let (categories, _) = categories_and_y();
     let precond = PreconditionerConfig::Diagonal;
-    let solver = Solver::new(categories.view(), None, &precond).expect("solver build");
+    let solver = Solver::new(&category_design(&categories), None, &precond).expect("solver build");
     let precond_ref = solver
         .preconditioner()
         .expect("should have diagonal preconditioner");
@@ -287,7 +296,7 @@ fn test_solver_accepts_prebuilt_design() {
     let params = default_params();
     let precond = additive_precond();
 
-    let solver = Solver::new(design, None, &precond).expect("prebuilt design");
+    let solver = Solver::new(&design, None, &precond).expect("prebuilt design");
     let result = solver.solve(&y, &params).expect("solve");
     assert!(result.converged);
 }
@@ -316,14 +325,14 @@ fn test_internal_locality_sort_is_transparent() {
 
     let make_solver = |weights: Option<Vec<f64>>| {
         let design = common::make_design(vec![col0.clone(), col1.clone()]).expect("design");
-        Solver::new(design, weights, &precond).expect("solver")
+        Solver::new(&design, weights, &precond).expect("solver")
     };
     let make_oracle = |weights: Option<Vec<f64>>| {
         let frame =
             ObservationFrame::new(vec![col0.clone().into(), col1.clone().into()], Vec::new())
                 .expect("frame");
         let design = Design::from_frame_unsorted(frame).expect("oracle design");
-        Solver::new(design, weights, &precond).expect("oracle solver")
+        Solver::new(&design, weights, &precond).expect("oracle solver")
     };
 
     // The weighted run also exercises the weights-permutation path.

--- a/crates/within/tests/warnings.rs
+++ b/crates/within/tests/warnings.rs
@@ -2,7 +2,7 @@
 //! [`BuildWarning`]s, not just [`Solver::warnings`] (#165).
 
 use within::{
-    solve, solve_batch, BuildWarning, Effect, LocalSolverConfig, PreconditionerConfig,
+    solve, solve_batch, BuildWarning, Design, Effect, LocalSolverConfig, PreconditionerConfig,
     ReductionStrategy, ScalingConfig, ScalingFailure, Solver,
 };
 
@@ -55,7 +55,8 @@ fn free_solve_surfaces_build_warnings() {
     );
 
     // The result field mirrors the solver accessor exactly.
-    let solver = Solver::new(warning_effects(), None, &cfg).expect("solver");
+    let design = Design::new(warning_effects()).expect("design");
+    let solver = Solver::new(&design, None, &cfg).expect("solver");
     assert_eq!(result.warnings.as_slice(), solver.warnings());
 }
 
@@ -74,6 +75,7 @@ fn free_solve_batch_surfaces_build_warnings() {
     );
 
     // The result field mirrors the solver accessor exactly.
-    let solver = Solver::new(warning_effects(), None, &cfg).expect("solver");
+    let design = Design::new(warning_effects()).expect("design");
+    let solver = Solver::new(&design, None, &cfg).expect("solver");
     assert_eq!(result.warnings.as_slice(), solver.warnings());
 }

--- a/crates/within/tests/wire_format_fixture.rs
+++ b/crates/within/tests/wire_format_fixture.rs
@@ -3,7 +3,7 @@
 //! cross-version encoding shifts the same-build round-trip test cannot.
 //! Regenerate via the `#[ignore]`d `regenerate_wire_format_fixture` test.
 
-use within::{Effect, LsmrOptions, Preconditioner, PreconditionerConfig, Solver};
+use within::{Design, Effect, LsmrOptions, Preconditioner, PreconditionerConfig, Solver};
 
 const WIRE_FORMAT_VERSION: u32 = 16;
 const PRECOND_BYTES: &[u8] = include_bytes!("fixtures/preconditioner_v16.postcard");
@@ -25,6 +25,10 @@ fn fixture_effects<'a>(f: &'a [u32], g: &'a [u32], z: &'a [f64]) -> Vec<Effect<'
     ]
 }
 
+fn fixture_design<'a>(f: &'a [u32], g: &'a [u32], z: &'a [f64]) -> Design<'a> {
+    Design::new(fixture_effects(f, g, z)).expect("fixture design")
+}
+
 #[test]
 fn wire_format_fixture_deserializes_and_solves() {
     let _ = WIRE_FORMAT_VERSION;
@@ -32,9 +36,9 @@ fn wire_format_fixture_deserializes_and_solves() {
     let (f, g, z, y) = fixture_problem();
     let prebuilt: Preconditioner =
         postcard::from_bytes(PRECOND_BYTES).expect("deserialize fixture preconditioner");
+    let design = fixture_design(&f, &g, &z);
 
-    let solver = Solver::new(fixture_effects(&f, &g, &z), None, prebuilt)
-        .expect("build solver from fixture");
+    let solver = Solver::new(&design, None, prebuilt).expect("build solver from fixture");
     let result = solver
         .solve(&y, &LsmrOptions::default())
         .expect("solve with fixture preconditioner");
@@ -42,12 +46,7 @@ fn wire_format_fixture_deserializes_and_solves() {
     assert!(result.converged, "fixture-built solver should converge");
 
     // Compare against a fresh build to detect any semantic regression.
-    let fresh = Solver::new(
-        fixture_effects(&f, &g, &z),
-        None,
-        PreconditionerConfig::default(),
-    )
-    .expect("fresh solver");
+    let fresh = Solver::new(&design, None, PreconditionerConfig::default()).expect("fresh solver");
     let fresh_result = fresh
         .solve(&y, &LsmrOptions::default())
         .expect("fresh solve");
@@ -64,12 +63,9 @@ fn wire_format_fixture_deserializes_and_solves() {
 #[test]
 fn signed_route_preconditioner_round_trips() {
     let (f, g, z, y) = fixture_problem();
-    let solver1 = Solver::new(
-        fixture_effects(&f, &g, &z),
-        None,
-        PreconditionerConfig::default(),
-    )
-    .expect("build solver");
+    let design = fixture_design(&f, &g, &z);
+    let solver1 =
+        Solver::new(&design, None, PreconditionerConfig::default()).expect("build solver");
     let r1 = solver1.solve(&y, &LsmrOptions::default()).expect("solve 1");
 
     let bytes = postcard::to_stdvec(solver1.preconditioner().expect("has preconditioner"))
@@ -77,8 +73,7 @@ fn signed_route_preconditioner_round_trips() {
     let restored: Preconditioner = postcard::from_bytes(&bytes).expect("deserialize");
     assert_eq!(restored.config(), &PreconditionerConfig::default());
 
-    let solver2 =
-        Solver::new(fixture_effects(&f, &g, &z), None, restored).expect("solver from round-trip");
+    let solver2 = Solver::new(&design, None, restored).expect("solver from round-trip");
     let r2 = solver2.solve(&y, &LsmrOptions::default()).expect("solve 2");
 
     for (a, b) in r1.x.iter().zip(r2.x.iter()) {
@@ -106,12 +101,8 @@ fn regenerate_wire_format_fixture() {
     use std::path::PathBuf;
 
     let (f, g, z, _) = fixture_problem();
-    let solver = Solver::new(
-        fixture_effects(&f, &g, &z),
-        None,
-        PreconditionerConfig::default(),
-    )
-    .expect("build solver");
+    let design = fixture_design(&f, &g, &z);
+    let solver = Solver::new(&design, None, PreconditionerConfig::default()).expect("build solver");
     let prec = solver
         .preconditioner()
         .expect("default solver has a preconditioner");


### PR DESCRIPTION
Addresses the Rust side of #269. A persistent Design Python API will follow in a separate PR