### PR TITLE
Enable Solver construction from borrowed design

### DIFF
--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -575,8 +575,27 @@ impl SolverState {
 /// Python boundary — uses owned columns. Weights are always owned; for a
 /// one-shot weighted solve from a borrowed slice, use the free [`solve`] function.
 pub struct Solver<'a> {
-    design: Design<'a>,
+    design: SolverDesignStorage<'a>,
     state: SolverState,
+}
+
+// A compatibility layer to support the existing [`Solver::new`] constructor for a solver with
+// an owned Design. This prevents having to update all existing call-sites and keeps
+// the diff in this PR small. Consider removing this and enforce strict borrowing
+enum SolverDesignStorage<'a> {
+    Owned(Design<'a>),
+    Borrowed(&'a Design<'a>),
+}
+
+impl<'a> std::ops::Deref for SolverDesignStorage<'a> {
+    type Target = Design<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Owned(design) => design,
+            Self::Borrowed(design) => design,
+        }
+    }
 }
 
 impl std::fmt::Debug for Solver<'_> {
@@ -630,7 +649,26 @@ impl<'a> Solver<'a> {
     ) -> Result<Self, BuildError> {
         let design = design.into_design()?;
         let state = SolverState::new(&design, weights, preconditioner)?;
-        Ok(Self { design, state })
+        Ok(Self {
+            design: SolverDesignStorage::Owned(design),
+            state,
+        })
+    }
+
+    /// Construct a solver from a borrowed design.
+    ///
+    /// The returned solver borrows `design` and cannot outlive it.
+    pub fn from_design(
+        design: &'a Design<'a>,
+        weights: Option<Vec<f64>>,
+        preconditioner: impl Into<PreconditionerInput>,
+    ) -> Result<Self, BuildError> {
+        let state = SolverState::new(design, weights, preconditioner)?;
+
+        Ok(Self {
+            design: SolverDesignStorage::Borrowed(design),
+            state,
+        })
     }
 
     /// Non-fatal events from design screening and the preconditioner build; a reused

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -1,6 +1,6 @@
 use ndarray::array;
 use within::{
-    solve, ApproxCholConfig, ApproxSchurConfig, Effect, LocalSolverConfig, LsmrOptions,
+    solve, ApproxCholConfig, ApproxSchurConfig, Design, Effect, LocalSolverConfig, LsmrOptions,
     Preconditioner, PreconditionerConfig, ReductionStrategy, ScalingConfig, ScalingFailure,
     SchurMode, Solver,
 };
@@ -37,6 +37,36 @@ fn test_solver_matches_oneshot() {
     assert_eq!(result.x.len(), oneshot.x.len());
     for (a, b) in result.x.iter().zip(oneshot.x.iter()) {
         assert!((a - b).abs() < 1e-12, "x mismatch: {} vs {}", a, b);
+    }
+}
+
+#[test]
+fn test_solver_matches_design_reuse() {
+    let (categories, y) = categories_and_y();
+    let params = default_params();
+    let precond = additive_precond();
+    let weights = vec![1.0; y.len()];
+
+    let design = Design::from_categories(categories.view()).expect("design build");
+
+    let unweighted = Solver::from_design(&design, None, &precond).expect("unweighted solver build");
+    let weighted = Solver::from_design(&design, Some(weights.clone()), &precond)
+        .expect("weighted solver build");
+
+    let unweighted_result = unweighted.solve(&y, &params).expect("unweighted solve");
+    let weighted_result = weighted.solve(&y, &params).expect("weighted solve");
+
+    assert!(unweighted_result.converged);
+    assert!(weighted_result.converged);
+
+    let expected = Solver::new(categories.view(), Some(weights), &precond)
+        .expect("owning solver build")
+        .solve(&y, &params)
+        .expect("owning solve");
+
+    assert_eq!(weighted_result.x.len(), expected.x.len());
+    for (actual, expected) in weighted_result.x.iter().zip(expected.x.iter()) {
+        assert!((actual - expected).abs() < 1e-12);
     }
 }
 


### PR DESCRIPTION
Introduces `Solver::from_design` to construct a solver from a persistent, borrowed `&'a Design<'a>`.

To keep the diff minimal, I have not removed the existing `Solver::new` construction which takes ownership of a `Design`. This is facilitated by a (somewhat hacky) enum that distinguishes the existing owned construction from the new borrowed one: https://github.com/py-econometrics/within/blob/4c204070434ff788435814bd8faafc7e3d2d7dd2/crates/within/src/solver.rs#L585-L588


In case we end up liking the separation of `Design` and `SolverState`, we may want to get rid of it. (This will create a large diff because every call-site using `Solver::new` will have to be updated).