### PR TITLE
Add internal factor encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ By the Frisch-Waugh-Lovell theorem, estimating a regression of the form *y = Xβ
 
 ## Scope
 
-`within` is a low-level fixed-effects kernel. Callers pass pre-factorized categorical codes: contiguous 0-based `uint32` level codes in F-order (column-major) arrays. Formula-level convenience — DataFrames, string/object categoricals, `pandas.factorize`, and formula parsing — is intentionally out of scope and belongs to a frontend layer built on top. The pyfixest-style workflow is served by such a frontend calling `within` underneath.
+`within` is a low-level fixed-effects kernel. Callers pass categorical labels as `uint32` F-order (column-major) arrays. Labels need not be contiguous: observed labels are compacted internally, while result layouts retain the caller-visible labels. Formula-level convenience — DataFrames, string/object categoricals, `pandas.factorize`, and formula parsing — is intentionally out of scope and belongs to a frontend layer built on top. The pyfixest-style workflow is served by such a frontend calling `within` underneath.
 
 ## Installation
 

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -20,6 +20,8 @@ use crate::observation::ObservationFrame;
 use crate::BuildError;
 use ndarray::{ArrayView2, Axis};
 use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::Arc;
 
 /// A slice that is guaranteed non-empty by construction.
 #[repr(transparent)]
@@ -78,34 +80,165 @@ impl<T> Loading<T> {
     }
 }
 
-/// Mapping between caller-visible factor labels and numerical level positions.
-///
-/// This is an identity mapping for the existing dense `u32` API. Later
-/// encodings can store an explicit mapping without changing `TermMeta`.
+/// Mapping between caller-visible factor labels and compact numerical positions.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct FactorEncoding {
-    n_levels: usize,
+pub(crate) enum FactorEncoding {
+    /// Caller label `k` is internal position `k`.
+    Identity { n_levels: usize },
+    /// Arbitrary integer caller labels, ordered by internal position.
+    Integer { labels: Arc<[u32]> },
+}
+
+struct EncodedFactor {
+    encoding: FactorEncoding,
+    positions: Option<Vec<u32>>,
+    sorted: bool,
 }
 
 impl FactorEncoding {
     fn identity(n_levels: usize) -> Self {
-        Self { n_levels }
+        Self::Identity { n_levels }
+    }
+
+    fn integer(labels: Vec<u32>) -> Self {
+        debug_assert!(labels.windows(2).all(|pair| pair[0] < pair[1]));
+        Self::Integer {
+            labels: labels.into(),
+        }
+    }
+
+    fn encode_labels(labels: &[u32]) -> EncodedFactor {
+        let Some((&first, remaining)) = labels.split_first() else {
+            return EncodedFactor {
+                encoding: Self::identity(0),
+                positions: None,
+                sorted: true,
+            };
+        };
+
+        let mut min = first;
+        let mut max = first;
+        let mut previous = first;
+        let mut sorted = true;
+        for &label in remaining {
+            min = min.min(label);
+            max = max.max(label);
+            sorted &= label >= previous;
+            previous = label;
+        }
+
+        let range_width = u64::from(max) - u64::from(min) + 1;
+        let presence_by_label = usize::try_from(range_width)
+            .ok()
+            .filter(|&width| width <= labels.len())
+            .map(|width| {
+                let mut present = vec![false; width];
+                for &label in labels {
+                    present[(label - min) as usize] = true;
+                }
+                present
+            });
+
+        match presence_by_label {
+            // Path 1: labels already form the zero-based identity range.
+            Some(present) if min == 0 && present.iter().all(|&is_present| is_present) => {
+                EncodedFactor {
+                    encoding: Self::identity(present.len()),
+                    positions: None,
+                    sorted,
+                }
+            }
+            // Path 2: the observed label range is bounded by the observation count.
+            Some(present) => {
+                let range_width = present.len();
+                let caller_labels: Vec<u32> = present
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(offset, &present)| present.then_some(min + offset as u32))
+                    .collect();
+
+                let mut position_by_label = vec![0u32; range_width];
+                for (position, &label) in caller_labels.iter().enumerate() {
+                    position_by_label[(label - min) as usize] = position as u32;
+                }
+
+                let positions = labels
+                    .iter()
+                    .map(|&label| position_by_label[(label - min) as usize])
+                    .collect();
+                EncodedFactor {
+                    encoding: Self::integer(caller_labels),
+                    positions: Some(positions),
+                    sorted,
+                }
+            }
+            // Path 3: the observed label range is too wide for an indexed table.
+            None => {
+                // Collect distinct caller labels
+                let mut position_by_label = HashMap::<u32, u32>::new();
+                for &label in labels {
+                    position_by_label.entry(label).or_default();
+                }
+                // Internal positions follow ascending caller-label order
+                let mut caller_labels: Vec<u32> = position_by_label.keys().copied().collect();
+                caller_labels.sort_unstable();
+                // Populate the caller-label to internal-position map
+                for (position, &label) in caller_labels.iter().enumerate() {
+                    let position =
+                        u32::try_from(position).expect("an internal label position fits in u32");
+
+                    *position_by_label
+                        .get_mut(&label)
+                        .expect("label was collected from this map") = position;
+                }
+
+                let positions = labels
+                    .iter()
+                    .map(|label| {
+                        *position_by_label
+                            .get(label)
+                            .expect("every input label was inserted")
+                    })
+                    .collect();
+
+                EncodedFactor {
+                    encoding: Self::integer(caller_labels),
+                    positions: Some(positions),
+                    sorted,
+                }
+            }
+        }
     }
 
     pub(crate) fn n_levels(&self) -> usize {
-        self.n_levels
+        match self {
+            Self::Identity { n_levels } => *n_levels,
+            Self::Integer { labels } => labels.len(),
+        }
     }
 
     pub(crate) fn position(&self, label: u32) -> Option<usize> {
-        let position = label as usize;
-        (position < self.n_levels).then_some(position)
+        match self {
+            Self::Identity { n_levels } => {
+                let position = label as usize;
+                (position < *n_levels).then_some(position)
+            }
+            Self::Integer { labels } => labels.binary_search(&label).ok(),
+        }
     }
 
     pub(crate) fn label(&self, position: usize) -> Option<u32> {
-        if position >= self.n_levels {
-            return None;
+        match self {
+            Self::Identity { n_levels } => {
+                if position >= *n_levels {
+                    return None;
+                }
+
+                u32::try_from(position).ok()
+            }
+
+            Self::Integer { labels } => labels.get(position).copied(),
         }
-        u32::try_from(position).ok()
     }
 }
 
@@ -207,7 +340,7 @@ impl<'a> Design<'a> {
         Self::build(frame, structure, true)
     }
 
-    /// Intercept-only factors, level count `max + 1`; locality-sorts an unsorted dominant factor.
+    /// Intercept-only factors; compacts observed labels and locality-sorts an unsorted dominant factor.
     pub fn from_frame(frame: ObservationFrame<'a>) -> Result<Self, BuildError> {
         let structure = vec![NonEmpty::of(Loading::Constant); frame.n_factors()];
         Self::build(frame, structure, true)
@@ -237,7 +370,7 @@ impl<'a> Design<'a> {
 
     /// `column_structure[term]` = that term's coefficient columns, aligned with the frame.
     fn build(
-        frame: ObservationFrame<'a>,
+        mut frame: ObservationFrame<'a>,
         column_structure: Vec<NonEmpty<Loading<u32>>>,
         locality_sort: bool,
     ) -> Result<Self, BuildError> {
@@ -250,16 +383,14 @@ impl<'a> Design<'a> {
         let mut terms = Vec::with_capacity(frame.n_factors());
         let mut offset = 0;
         for (q, columns) in column_structure.into_iter().enumerate() {
-            let col = frame.level_column(q);
-            let mut max = 0;
-            let mut sorted = true;
-            let mut prev = 0;
-            for &v in col {
-                max = max.max(v);
-                sorted &= v >= prev;
-                prev = v;
+            let EncodedFactor {
+                encoding,
+                positions,
+                sorted,
+            } = FactorEncoding::encode_labels(frame.level_column(q));
+            if let Some(positions) = positions {
+                frame.replace_level_column(q, positions);
             }
-            let encoding = FactorEncoding::identity(max as usize + 1);
             let meta = TermMeta {
                 encoding,
                 offset,
@@ -508,13 +639,84 @@ mod tests {
     }
 
     #[test]
-    fn build_rejects_dof_space_exceeding_u32() {
-        // A single code of u32::MAX implies one level past the CSR column-index width.
-        let err = Design::from_frame(frame(vec![vec![u32::MAX]], vec![])).unwrap_err();
-        assert!(matches!(
-            err,
-            BuildError::DofSpaceExceedsU32 { n_dofs } if n_dofs == u32::MAX as usize + 1
-        ));
+    fn build_compacts_large_integer_label() {
+        let design = Design::from_frame(frame(vec![vec![u32::MAX]], vec![])).unwrap();
+
+        assert_eq!(design.n_dofs, 1);
+        assert_eq!(design.level_column(0), &[0]);
+        assert_eq!(design.terms[0].encoding.label(0), Some(u32::MAX));
+    }
+
+    #[test]
+    fn integer_factor_encoding_round_trips() {
+        let encoding = FactorEncoding::integer(vec![10, 100, 500]);
+
+        assert_eq!(encoding.n_levels(), 3);
+        assert_eq!(encoding.position(10), Some(0));
+        assert_eq!(encoding.position(100), Some(1));
+        assert_eq!(encoding.position(500), Some(2));
+        assert_eq!(encoding.position(99), None);
+
+        assert_eq!(encoding.label(0), Some(10));
+        assert_eq!(encoding.label(1), Some(100));
+        assert_eq!(encoding.label(2), Some(500));
+        assert_eq!(encoding.label(3), None);
+    }
+
+    #[test]
+    fn encode_labels_preserves_identity_encoding() {
+        let EncodedFactor {
+            encoding,
+            positions,
+            sorted,
+        } = FactorEncoding::encode_labels(&[2, 0, 1, 2]);
+
+        assert_eq!(encoding, FactorEncoding::identity(3));
+        assert!(positions.is_none());
+        assert!(!sorted);
+    }
+
+    #[test]
+    fn encode_labels_compacts_bounded_gappy_labels() {
+        // Range width = 3 and n_obs = 3, so this exercises the presence-table path.
+        let EncodedFactor {
+            encoding,
+            positions,
+            sorted,
+        } = FactorEncoding::encode_labels(&[2, 0, 2]);
+
+        assert_eq!(encoding, FactorEncoding::integer(vec![0, 2]));
+        assert_eq!(positions.as_deref(), Some(&[1u32, 0, 1][..]));
+        assert!(!sorted);
+    }
+
+    #[test]
+    fn encode_labels_compacts_shifted_bounded_range() {
+        let EncodedFactor {
+            encoding,
+            positions,
+            sorted,
+        } = FactorEncoding::encode_labels(&[1_000_000, 1_000_001, 1_000_002]);
+
+        assert_eq!(
+            encoding,
+            FactorEncoding::integer(vec![1_000_000, 1_000_001, 1_000_002])
+        );
+        assert_eq!(positions.as_deref(), Some(&[0u32, 1, 2][..]));
+        assert!(sorted);
+    }
+
+    #[test]
+    fn encode_labels_compacts_large_span_without_span_allocation() {
+        let EncodedFactor {
+            encoding,
+            positions,
+            sorted,
+        } = FactorEncoding::encode_labels(&[u32::MAX, 7, u32::MAX]);
+
+        assert_eq!(encoding, FactorEncoding::integer(vec![7, u32::MAX]));
+        assert_eq!(positions.as_deref(), Some(&[1u32, 0, 1][..]));
+        assert!(!sorted);
     }
 
     #[test]

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -32,9 +32,9 @@ fn design_of(columns: Vec<Vec<u32>>) -> Design<'static> {
 
 #[test]
 fn test_cross_tab_sparse_accumulation_path() {
-    // n_rows * n_cols > 5M triggers the sparse path; few observations keep both paths equal.
-    let n_obs = 200usize;
-    let n_lev = 2237usize;
+    // 2,500 observed levels per factor make n_rows * n_cols exceed the 5M threshold.
+    let n_obs = 2500usize;
+    let n_lev = n_obs;
 
     let mut fa: Vec<u32> = Vec::with_capacity(n_obs);
     let mut fb: Vec<u32> = Vec::with_capacity(n_obs);
@@ -295,28 +295,23 @@ proptest! {
 }
 
 #[test]
-fn test_find_all_active_levels_with_gaps() {
-    // Factor 0 has 5 levels but only 0, 2, 4 appear; factor 1 uses all 3.
+fn test_find_all_active_levels_after_label_compaction() {
+    // Caller labels 0, 2, and 4 become internal positions 0, 1, and 2.
     let fa = vec![0u32, 2, 4, 0, 2, 4];
     let fb = vec![0u32, 1, 2, 0, 1, 2];
     let design = design_of(vec![fa, fb]);
 
     let active = find_all_active_levels(&design);
 
-    // Factor 0: 5 levels, only 0, 2, 4 active.
-    assert_eq!(active[0].len(), 5, "factor 0 should have 5 levels");
     assert_eq!(
         active[0],
-        vec![true, false, true, false, true],
-        "factor 0 active pattern: [true, false, true, false, true]"
+        vec![true, true, true],
+        "factor 0 should contain only its three observed levels"
     );
-
-    // Factor 1: all 3 levels active.
-    assert_eq!(active[1].len(), 3, "factor 1 should have 3 levels");
     assert_eq!(
         active[1],
         vec![true, true, true],
-        "factor 1 active pattern: all true"
+        "factor 1 should retain its identity encoding"
     );
 }
 

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -99,7 +99,7 @@ pub enum BuildError {
         /// The offending value.
         value: f64,
     },
-    /// Usually raw entity IDs passed as factor codes, inflating `n_levels = max code + 1`.
+    /// The compact coefficient space exceeds the internal `u32` index width.
     #[error("design has {n_dofs} degrees of freedom, exceeding the u32 column-index limit")]
     DofSpaceExceedsU32 {
         /// Total degrees of freedom implied by the design.

--- a/crates/within/src/observation.rs
+++ b/crates/within/src/observation.rs
@@ -106,6 +106,12 @@ impl<'a> ObservationFrame<'a> {
             n_obs: perm.len(),
         }
     }
+
+    /// Replace one categorical column with owned internal level positions.
+    pub(crate) fn replace_level_column(&mut self, factor: usize, levels: Vec<u32>) {
+        debug_assert_eq!(levels.len(), self.n_obs);
+        self.categorical[factor] = Cow::Owned(levels);
+    }
 }
 
 #[cfg(test)]
@@ -136,5 +142,22 @@ mod tests {
             result,
             Err(BuildError::ObservationCountMismatch { .. })
         ));
+    }
+
+    #[test]
+    fn categorical_column_can_be_replaced() {
+        let mut frame = ObservationFrame::new(
+            vec![
+                Cow::Borrowed(&[10u32, 100, 10]),
+                Cow::Borrowed(&[0u32, 1, 2]),
+            ],
+            vec![],
+        )
+        .unwrap();
+
+        frame.replace_level_column(0, vec![0, 1, 0]);
+
+        assert_eq!(frame.level_column(0), &[0, 1, 0]);
+        assert_eq!(frame.level_column(1), &[0, 1, 2]);
     }
 }

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -730,8 +730,8 @@ impl<'a> Solver<'a> {
 /// Solve fixed-effects least squares for a design input.
 ///
 /// `design` is anything implementing [`IntoDesign`]: an observation-major
-/// `(n_obs, n_factors)` categories array (levels `0..max_level` per factor,
-/// count inferred) or a list of [`Effect`] terms.
+/// `(n_obs, n_factors)` categories array (arbitrary `u32` labels per factor,
+/// compacted internally) or a list of [`Effect`] terms.
 /// `y` is the response vector (length = n_obs).
 ///
 /// Zero-copy for F-order category arrays whose dominant factor is already

--- a/crates/within/tests/edge_cases.rs
+++ b/crates/within/tests/edge_cases.rs
@@ -179,35 +179,48 @@ fn test_diagonal_matches_unpreconditioned_solution() {
     common::assert_solutions_close(&diagonal.x, &unpreconditioned.x, 1e-6);
 }
 
-/// A factor whose observed levels leave interior gaps (`n_levels = max + 1`)
-/// produces structural zero columns of `D` — unidentified DOFs whose diagonal
-/// is zero. The unpreconditioned and additive paths both pin those coefficients
-/// to 0 and solve fine; with the pseudo-inverse of a zero diagonal, the diagonal
-/// preconditioner now matches rather than failing with `SingularDiagonal`.
+/// Gappy caller labels are compacted internally without changing the solve,
+/// while the result layout retains the original labels.
 #[test]
-fn test_diagonal_matches_unpreconditioned_on_gap_design() {
-    // Single factor observed only at levels {0, 2, 4} => n_levels = 5, so global
-    // DOFs 1 and 3 have no observations.
-    let cats = array![[0u32], [2], [4]];
+fn test_gappy_labels_match_manually_compacted_design() {
+    let gappy_categories = array![[0u32], [2], [4]];
+    let compact_categories = array![[0u32], [1], [2]];
     let y = vec![1.0, 2.0, 3.0];
     let params = LsmrOptions::default();
 
-    let diagonal = solve(
-        cats.view(),
+    let gappy = solve(
+        gappy_categories.view(),
         &y,
         None,
         &params,
         &PreconditionerConfig::Diagonal,
     )
-    .expect("diagonal solve must succeed on a gap design (pseudo-inverse of zero diagonal)");
-    let unpreconditioned = solve(cats.view(), &y, None, &params, &PreconditionerConfig::Off)
-        .expect("unpreconditioned solve");
+    .expect("gappy-label solve");
 
-    assert!(diagonal.converged, "diagonal solve must converge");
-    common::assert_solutions_close(&diagonal.x, &unpreconditioned.x, 1e-6);
-    // The unobserved DOFs are unidentified and must be pinned to exactly 0.
-    assert_eq!(diagonal.x[1], 0.0, "unobserved DOF 1 must be 0");
-    assert_eq!(diagonal.x[3], 0.0, "unobserved DOF 3 must be 0");
+    let compact = solve(
+        compact_categories.view(),
+        &y,
+        None,
+        &params,
+        &PreconditionerConfig::Diagonal,
+    )
+    .expect("manually compacted solve");
+
+    assert!(gappy.converged);
+    assert_eq!(gappy.x.len(), 3);
+    assert_eq!(gappy.layout.n_levels(0), Some(3));
+    common::assert_solutions_close(&gappy.x, &compact.x, 1e-6);
+    common::assert_solutions_close(&gappy.demeaned, &compact.demeaned, 1e-6);
+
+    for (index, caller_label) in [0u32, 2, 4].into_iter().enumerate() {
+        let address = gappy
+            .layout
+            .address(index)
+            .expect("coefficient has an address");
+
+        assert_eq!(address.level, caller_label);
+        assert_eq!(gappy.layout.index(address), Some(index));
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/within/tests/property_gaps.rs
+++ b/crates/within/tests/property_gaps.rs
@@ -1,6 +1,6 @@
 use ndarray::Array2;
 use proptest::prelude::*;
-use within::{solve, LsmrOptions, Solver};
+use within::{solve, Channel, CoefficientAddress, LsmrOptions, Solver};
 
 #[path = "common/property_strategies.rs"]
 mod strategies;
@@ -129,18 +129,19 @@ proptest! {
         let n_obs = y.len();
         let n_factors = cats.ncols();
 
-        // Compute factor offsets (same ordering as Design)
-        let mut offsets = vec![0usize; n_factors];
-        for f in 1..n_factors {
-            let n_levels_prev = *cats.column(f - 1).iter().max().unwrap() as usize + 1;
-            offsets[f] = offsets[f - 1] + n_levels_prev;
-        }
-
         for i in 0..n_obs {
             let dx_i: f64 = (0..n_factors)
-                .map(|f| {
-                    let level = cats[[i, f]] as usize;
-                    result.x[offsets[f] + level]
+                .map(|term| {
+                    let address = CoefficientAddress {
+                        channel: Channel { term, column: 0 },
+                        level: cats[[i, term]],
+                    };
+                    let index = result
+                        .layout
+                        .index(address)
+                        .expect("an observed caller label has a coefficient");
+
+                    result.x[index]
                 })
                 .sum();
             let expected_demeaned = y[i] - dx_i;

--- a/crates/within/tests/slopes.rs
+++ b/crates/within/tests/slopes.rs
@@ -2,7 +2,9 @@
 //! user's parametrization, fitted-value invariance under the internal
 //! reparametrization, and deterministic rank-drop reporting.
 
-use within::{Effect, LsmrOptions, PreconditionerConfig, SolveResult, Solver};
+use within::{
+    Channel, CoefficientAddress, Effect, LsmrOptions, PreconditionerConfig, SolveResult, Solver,
+};
 
 const TOL: f64 = 1e-6;
 
@@ -93,6 +95,18 @@ fn drops(r: &SolveResult) -> Vec<(usize, u32, usize)> {
         .collect()
 }
 
+fn coefficient(r: &SolveResult, level: u32, column: usize) -> f64 {
+    let index = r
+        .layout
+        .index(CoefficientAddress {
+            channel: Channel { term: 0, column },
+            level,
+        })
+        .expect("observed level has a coefficient");
+
+    r.x[index]
+}
+
 #[test]
 fn single_slope_recovers_per_level_ols_and_fitted_values() {
     // Non-monotonic factor so the locality sort is genuinely exercised.
@@ -156,7 +170,8 @@ fn slope_only_term_recovers_per_level_projection() {
 
 #[test]
 fn rank_drops_report_deterministically_with_exact_zeros() {
-    // Level 1 never occurs; level 2's slope is constant, so only its slope drops.
+    // Level 1 never occurs and is compacted away. Level 2's slope is constant,
+    // so only that slope is unidentified.
     let levels: Vec<u32> = vec![0, 0, 0, 2, 2, 2, 3, 3, 3];
     let z: Vec<f64> = vec![1.0, 2.0, -1.5, 2.5, 2.5, 2.5, -2.0, 0.7, 1.3];
     let y = synthetic_y(levels.len());
@@ -165,24 +180,31 @@ fn rank_drops_report_deterministically_with_exact_zeros() {
     let r = run(&PreconditionerConfig::default());
     assert!(r.converged);
     // Ascending (level, column) order.
-    assert_eq!(drops(&r), [(0, 1, 0), (0, 1, 1), (0, 2, 1)]);
+    assert_eq!(drops(&r), [(0, 2, 1)]);
 
-    // Minimal-norm 0 at exactly the dropped slots; everything else finite.
-    for slot in [1, 4 + 1, 4 + 2] {
-        assert_eq!(r.x[slot], 0.0);
-    }
+    // Minimal-norm 0 at exactly the dropped slot; everything else finite.
+    assert_eq!(r.x.len(), 6);
+    assert_eq!(coefficient(&r, 2, 1), 0.0);
     assert!(r.x.iter().all(|v| v.is_finite()));
 
     // The constant level degrades to intercept-only: a = mean(y within level).
     assert_close(
-        r.x[2],
+        coefficient(&r, 2, 0),
         (y[3] + y[4] + y[5]) / 3.0,
         "constant level intercept",
     );
     let (a, b) = per_level_intercept_slope(&levels, &z, &y, None, 4);
-    for l in [0usize, 3] {
-        assert_close(r.x[l], a[l], &format!("intercept of level {l}"));
-        assert_close(r.x[4 + l], b[l], &format!("slope of level {l}"));
+    for l in [0u32, 3] {
+        assert_close(
+            coefficient(&r, l, 0),
+            a[l as usize],
+            &format!("intercept of level {l}"),
+        );
+        assert_close(
+            coefficient(&r, l, 1),
+            b[l as usize],
+            &format!("slope of level {l}"),
+        );
     }
 
     // The explicit diagonal preconditioner agrees with the default path.

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -624,6 +624,31 @@ class TestDesign:
         assert design.n_obs == 5
         assert design.n_dofs == 5
 
+    def test_compacts_gappy_integer_labels(self):
+        categories = np.asfortranarray(
+            np.array([[100], [10], [500], [100]], dtype=np.uint32)
+        )
+        design = Design(categories)
+
+        assert design.n_obs == 4
+        assert design.n_dofs == 3
+
+        result = solve(design, np.array([1.0, 2.0, 3.0, 4.0]))
+        layout = result.layout
+
+        assert result.x.shape == (3,)
+        assert layout.n_levels(0) == 3
+        assert [layout.address(i) for i in range(3)] == [
+            (0, 10, 0),
+            (0, 100, 0),
+            (0, 500, 0),
+        ]
+        assert [layout.index(0, label, 0) for label in [10, 100, 500]] == [
+            0,
+            1,
+            2,
+        ]
+
     def test_owns_category_data(self, problem):
         cats, y = problem
         categories = as_solver_categories(cats)


### PR DESCRIPTION
This PR completes the internal factor encoding with a new persistent `Design` API

Closes #228 
Closes #268
Closes #269

----
### Encoding algorithm
For each factor, `Design` replaces the caller's observed `u32` labels with contiguous internal positions `0..k`, where `k` is the number of observed levels. Internal positions follow ascending caller-label order, so the transformation preserves sortedness.

The implementation first scans the column once to compute its minimum, maximum, and sortedness. It then chooses one of three paths:

1. **Identity:** If the observed labels already form `0..k`, the column is left unchanged and only the level count is stored.
2. **Bounded range:** If `max - min + 1 <= n_obs`, a presence table indexed by `label - min` finds the observed labels and builds a direct caller-label-to-position table. Temporary storage is therefore bounded by the number of observations, even when labels start at a large offset.
3. **Wide sparse range:** Otherwise, distinct labels are collected in a hash map, sorted, assigned contiguous positions, and used to rewrite the column. This avoids allocating memory proportional to a very large maximum label.

The resulting `FactorEncoding` stores either the identity level count or the sorted caller labels indexed by internal position. `CoefficientLayout` uses that encoding to map caller labels to coefficient indices and internal positions back to caller-visible labels, so the compact representation never leaks into result addresses.

The bounded paths run in linear time and use at most `O(n_obs)` temporary storage. For `k` observed levels, the wide sparse path uses `O(n_obs)` expected collection and rewriting time plus `O(k log k)` sorting; its lookup structure uses `O(k)` auxiliary storage.
