### PR TITLE
Use compact levels directly in cross tabs

### DIFF
--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -6,7 +6,7 @@ mod effect;
 pub(crate) mod factor_pairs;
 pub(crate) mod level_moments;
 
-pub(crate) use cross_tab::{find_all_active_levels, BlockDiagonals, CrossTab};
+pub(crate) use cross_tab::{BlockDiagonals, CrossTab};
 
 pub use effect::Effect;
 

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -3,87 +3,15 @@
 //! [`CrossTab`] holds `C` as a [`CsrBlock`] plus its precomputed transpose and
 //! the two diagonals (rather than assembling the symmetric block matrix), and
 //! supports bipartite connected-components splitting and per-component extraction.
-//! Levels are stored compactly with a `local_to_global` map for active levels only.
+//! Levels use the design's compact positions, with a `local_to_global` map into
+//! the full coefficient space.
 
 use crate::channel::ChannelPair;
 use crate::csr_block::{to_u32, CsrBlock};
-use crate::domain::{Design, SolverDesign};
+use crate::domain::SolverDesign;
 
 mod accumulate;
 use accumulate::accumulate_cross_block;
-
-/// Compact mapping of active levels for a factor pair, plus its local-to-global vector.
-struct ActiveLevels {
-    row_map: Vec<u32>,
-    n_rows: usize,
-    col_map: Vec<u32>,
-    n_cols: usize,
-    local_to_global: Vec<u32>,
-}
-
-/// Scan observations once, marking `active[f][level]` for every level any observation uses.
-pub(crate) fn find_all_active_levels(design: &Design<'_>) -> Vec<Vec<bool>> {
-    let mut active: Vec<Vec<bool>> = design
-        .terms
-        .iter()
-        .map(|f| vec![false; f.n_levels()])
-        .collect();
-    // Factor-outer/obs-inner: all writes for a factor land in one `active[f]` buffer.
-    for (f, col) in active.iter_mut().enumerate() {
-        for &v in design.level_column(f) {
-            col[v as usize] = true;
-        }
-    }
-    active
-}
-
-/// Compact-index each active level, returning the global-to-compact map and active count.
-fn compact_map(active: &[bool]) -> (Vec<u32>, usize) {
-    let mut map = vec![u32::MAX; active.len()];
-    let mut n = 0u32;
-    for (j, &a) in active.iter().enumerate() {
-        if a {
-            map[j] = n;
-            n += 1;
-        }
-    }
-    (map, n as usize)
-}
-
-/// `base_rows`/`base_cols` are the channels' global DOF offsets.
-fn build_compact_mapping(
-    active_rows: &[bool],
-    active_cols: &[bool],
-    base_rows: usize,
-    base_cols: usize,
-) -> Option<ActiveLevels> {
-    let (row_map, n_rows) = compact_map(active_rows);
-    let (col_map, n_cols) = compact_map(active_cols);
-
-    if n_rows == 0 || n_cols == 0 {
-        return None;
-    }
-
-    let mut local_to_global = Vec::with_capacity(n_rows + n_cols);
-    for (j, &a) in active_rows.iter().enumerate() {
-        if a {
-            local_to_global.push(to_u32(base_rows + j));
-        }
-    }
-    for (k, &a) in active_cols.iter().enumerate() {
-        if a {
-            local_to_global.push(to_u32(base_cols + k));
-        }
-    }
-
-    Some(ActiveLevels {
-        row_map,
-        n_rows,
-        col_map,
-        n_cols,
-        local_to_global,
-    })
-}
 
 /// A connected component in a bipartite factor-pair graph, in compact 0-based parent indices.
 pub(crate) struct BipartiteComponent {
@@ -136,29 +64,32 @@ impl CrossTab {
         self.c.nrows + self.c.ncols
     }
 
-    /// Reuses pre-computed active flags instead of rescanning; diagonals come back separately.
-    pub(crate) fn build_for_pair_with_active(
+    /// Build one channel pair; diagonals come back separately.
+    pub(crate) fn build_for_pair(
         solver_design: &SolverDesign<'_>,
         weights: Option<&[f64]>,
         pair: ChannelPair,
-        all_active: &[Vec<bool>],
-    ) -> Option<(Self, BlockDiagonals, Vec<u32>)> {
+    ) -> (Self, BlockDiagonals, Vec<u32>) {
         let design = solver_design.design();
-        let active = build_compact_mapping(
-            &all_active[pair.rows.term],
-            &all_active[pair.cols.term],
-            design.terms[pair.rows.term].column_base(pair.rows.column),
-            design.terms[pair.cols.term].column_base(pair.cols.column),
-        )?;
+        let n_rows = design.terms[pair.rows.term].n_levels();
+        let n_cols = design.terms[pair.cols.term].n_levels();
 
-        let (c, row_diag, col_diag) = accumulate_cross_block(solver_design, weights, pair, &active);
+        let (c, row_diag, col_diag) =
+            accumulate_cross_block(solver_design, weights, pair, n_rows, n_cols);
         let ct = c.transpose();
         let cross_tab = CrossTab { c, ct };
         let diagonals = BlockDiagonals {
             rows: row_diag,
             cols: col_diag,
         };
-        Some((cross_tab, diagonals, active.local_to_global))
+        let row_base = design.terms[pair.rows.term].column_base(pair.rows.column);
+        let col_base = design.terms[pair.cols.term].column_base(pair.cols.column);
+        let local_to_global = (0..n_rows)
+            .map(|level| to_u32(row_base + level))
+            .chain((0..n_cols).map(|level| to_u32(col_base + level)))
+            .collect();
+
+        (cross_tab, diagonals, local_to_global)
     }
 
     /// Symmetric adjacency over local `[q | r]` indexing: q-nodes walk `C`, r-nodes walk `Cᵀ`.

--- a/crates/within/src/domain/cross_tab/accumulate.rs
+++ b/crates/within/src/domain/cross_tab/accumulate.rs
@@ -12,7 +12,7 @@ use crate::channel::ChannelPair;
 use crate::csr_block::CsrBlock;
 use crate::domain::SolverDesign;
 
-use super::{to_u32, ActiveLevels};
+use super::to_u32;
 use crate::domain::Loading as ColumnLoading;
 
 /// Hard cap on the dense accumulator (~40 MB); larger tables always go sparse.
@@ -61,24 +61,18 @@ pub(super) struct PairColumns<'a, Lq: Loading, Lr: Loading> {
 }
 
 impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
-    /// `None` when either level is inactive, so the observation is skipped.
     #[inline]
-    fn decode(&self, active: &ActiveLevels, uid: usize) -> Option<Contribution> {
-        let cj = active.row_map[self.row_levels[uid] as usize];
-        let ck = active.col_map[self.col_levels[uid] as usize];
-        if cj == u32::MAX || ck == u32::MAX {
-            return None;
-        }
+    fn decode(&self, uid: usize) -> Contribution {
         let w = self.weights.map_or(1.0, |w| w[uid]);
         let l_row = self.row_load.at(uid);
         let l_col = self.col_load.at(uid);
-        Some(Contribution {
-            cj: cj as usize,
-            ck: ck as usize,
+        Contribution {
+            cj: self.row_levels[uid] as usize,
+            ck: self.col_levels[uid] as usize,
             cell: w * l_row * l_col,
             row_diag: w * l_row * l_row,
             col_diag: w * l_col * l_col,
-        })
+        }
     }
 }
 
@@ -87,11 +81,12 @@ pub(super) fn accumulate_cross_block(
     solver_design: &SolverDesign<'_>,
     weights: Option<&[f64]>,
     pair: ChannelPair,
-    active: &ActiveLevels,
+    n_rows: usize,
+    n_cols: usize,
 ) -> (CsrBlock, Vec<f64>, Vec<f64>) {
     let design = solver_design.design();
     // Dispatching on cell count alone would pick sparse where it uses MORE memory.
-    let table_size = active.n_rows.saturating_mul(active.n_cols);
+    let table_size = n_rows.saturating_mul(n_cols);
     let dense_cost = table_size.saturating_mul(8);
     let sparse_cost = design.n_obs.saturating_mul(12);
     let go_sparse = table_size > DENSE_TABLE_MAX_ENTRIES && sparse_cost < dense_cost;
@@ -115,7 +110,8 @@ pub(super) fn accumulate_cross_block(
                 col_load: Unit,
                 weights,
             },
-            active,
+            n_rows,
+            n_cols,
             go_sparse,
         ),
         (Some(zq), None) => accumulate(
@@ -126,7 +122,8 @@ pub(super) fn accumulate_cross_block(
                 col_load: Unit,
                 weights,
             },
-            active,
+            n_rows,
+            n_cols,
             go_sparse,
         ),
         (None, Some(zr)) => accumulate(
@@ -137,7 +134,8 @@ pub(super) fn accumulate_cross_block(
                 col_load: zr,
                 weights,
             },
-            active,
+            n_rows,
+            n_cols,
             go_sparse,
         ),
         (Some(zq), Some(zr)) => accumulate(
@@ -148,7 +146,8 @@ pub(super) fn accumulate_cross_block(
                 col_load: zr,
                 weights,
             },
-            active,
+            n_rows,
+            n_cols,
             go_sparse,
         ),
     }
@@ -157,32 +156,30 @@ pub(super) fn accumulate_cross_block(
 /// Size-dispatched accumulation for one monomorphized loading combination.
 fn accumulate<Lq: Loading, Lr: Loading>(
     cols: PairColumns<'_, Lq, Lr>,
-    active: &ActiveLevels,
+    n_rows: usize,
+    n_cols: usize,
     go_sparse: bool,
 ) -> (CsrBlock, Vec<f64>, Vec<f64>) {
     if go_sparse {
-        accumulate_sparse_cross_block(cols, active)
+        accumulate_sparse_cross_block(cols, n_rows, n_cols)
     } else {
-        accumulate_dense_cross_block(cols, active)
+        accumulate_dense_cross_block(cols, n_rows, n_cols)
     }
 }
 
 /// Dense path: flat `n_rows * n_cols` table with O(1) accumulation per observation.
 pub(super) fn accumulate_dense_cross_block<Lq: Loading, Lr: Loading>(
     cols: PairColumns<'_, Lq, Lr>,
-    active: &ActiveLevels,
+    n_rows: usize,
+    n_cols: usize,
 ) -> (CsrBlock, Vec<f64>, Vec<f64>) {
     let n_obs = cols.row_levels.len();
-    let n_rows = active.n_rows;
-    let n_cols = active.n_cols;
     let mut row_diag = vec![0.0f64; n_rows];
     let mut col_diag = vec![0.0f64; n_cols];
     let mut table = vec![0.0f64; n_rows * n_cols];
 
     for uid in 0..n_obs {
-        let Some(o) = cols.decode(active, uid) else {
-            continue;
-        };
+        let o = cols.decode(uid);
         debug_assert!(o.cj < n_rows && o.ck < n_cols);
         row_diag[o.cj] += o.row_diag;
         col_diag[o.ck] += o.col_diag;
@@ -196,19 +193,16 @@ pub(super) fn accumulate_dense_cross_block<Lq: Loading, Lr: Loading>(
 /// Sparse path: bucket by row, then dedup each row through a dense `n_cols` workspace.
 pub(super) fn accumulate_sparse_cross_block<Lq: Loading, Lr: Loading>(
     cols: PairColumns<'_, Lq, Lr>,
-    active: &ActiveLevels,
+    n_rows: usize,
+    n_cols: usize,
 ) -> (CsrBlock, Vec<f64>, Vec<f64>) {
     let n_obs = cols.row_levels.len();
-    let n_rows = active.n_rows;
-    let n_cols = active.n_cols;
     let mut row_diag = vec![0.0f64; n_rows];
     let mut col_diag = vec![0.0f64; n_cols];
 
     let mut row_counts = vec![0u32; n_rows];
     for uid in 0..n_obs {
-        let Some(o) = cols.decode(active, uid) else {
-            continue;
-        };
+        let o = cols.decode(uid);
         row_diag[o.cj] += o.row_diag;
         col_diag[o.ck] += o.col_diag;
         row_counts[o.cj] += 1;
@@ -224,9 +218,7 @@ pub(super) fn accumulate_sparse_cross_block<Lq: Loading, Lr: Loading>(
     let mut bucket_vals = vec![0.0f64; total_entries];
     let mut cursor = bucket_indptr[..n_rows].to_vec();
     for uid in 0..n_obs {
-        let Some(o) = cols.decode(active, uid) else {
-            continue;
-        };
+        let o = cols.decode(uid);
         let pos = cursor[o.cj] as usize;
         bucket_cols[pos] = to_u32(o.ck);
         bucket_vals[pos] = o.cell;

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -3,10 +3,9 @@ use proptest::prelude::*;
 use super::accumulate::{
     accumulate_dense_cross_block, accumulate_sparse_cross_block, PairColumns, Unit,
 };
-use super::{build_compact_mapping, CrossTab};
+use super::CrossTab;
 use crate::channel::{Channel, ChannelPair};
 use crate::csr_block::CsrBlock;
-use crate::domain::find_all_active_levels;
 use crate::domain::{Design, Effect, SolverDesign};
 use crate::observation::ObservationFrame;
 
@@ -45,29 +44,17 @@ fn test_cross_tab_sparse_accumulation_path() {
 
     // Sparse path (large level counts)
     let design_sparse = design_of(vec![fa.clone(), fb.clone()]);
-    let active_sparse = find_all_active_levels(&design_sparse);
     let sparse_solver_design = SolverDesign::new(&design_sparse);
-    let (ct_sparse, diag_sparse, _) = CrossTab::build_for_pair_with_active(
-        &sparse_solver_design,
-        None,
-        INTERCEPT_PAIR,
-        &active_sparse,
-    )
-    .expect("sparse cross tab should build");
+    let (ct_sparse, diag_sparse, _) =
+        CrossTab::build_for_pair(&sparse_solver_design, None, INTERCEPT_PAIR);
 
     // Dense reference: collapse levels so n_rows * n_cols <= 5M.
     let fa_small: Vec<u32> = fa.iter().map(|&x| x % 100).collect();
     let fb_small: Vec<u32> = fb.iter().map(|&x| x % 100).collect();
     let design_dense = design_of(vec![fa_small.clone(), fb_small.clone()]);
-    let active_dense = find_all_active_levels(&design_dense);
     let dense_solver_design = SolverDesign::new(&design_dense);
-    let (_ct_dense, diag_dense, _) = CrossTab::build_for_pair_with_active(
-        &dense_solver_design,
-        None,
-        INTERCEPT_PAIR,
-        &active_dense,
-    )
-    .expect("dense cross tab should build");
+    let (_ct_dense, diag_dense, _) =
+        CrossTab::build_for_pair(&dense_solver_design, None, INTERCEPT_PAIR);
 
     // Each observation appears exactly once in its row/col bucket.
     assert_eq!(
@@ -131,11 +118,8 @@ fn test_extract_component_two_components() {
     let fa = vec![0u32, 0, 1, 1, 2, 2, 3, 3];
     let fb = vec![0u32, 1, 0, 1, 2, 3, 2, 3];
     let design = design_of(vec![fa, fb]);
-    let all_active = find_all_active_levels(&design);
     let solver_design = SolverDesign::new(&design);
-    let (ct, parent_diag, _) =
-        CrossTab::build_for_pair_with_active(&solver_design, None, INTERCEPT_PAIR, &all_active)
-            .expect("cross tab should build");
+    let (ct, parent_diag, _) = CrossTab::build_for_pair(&solver_design, None, INTERCEPT_PAIR);
 
     let components = ct.bipartite_connected_components();
     assert_eq!(components.len(), 2, "should have 2 connected components");
@@ -244,15 +228,8 @@ proptest! {
         }
 
         let design = design_of(vec![fa, fb]);
-        let all_active = find_all_active_levels(&design);
         let solver_design = SolverDesign::new(&design);
-        let (ct, _, _) = CrossTab::build_for_pair_with_active(
-            &solver_design,
-            None,
-            INTERCEPT_PAIR,
-            &all_active,
-        )
-        .expect("cross tab should build");
+        let (ct, _, _) = CrossTab::build_for_pair(&solver_design, None, INTERCEPT_PAIR);
 
         let components = ct.bipartite_connected_components();
 
@@ -262,7 +239,7 @@ proptest! {
         all_rows.sort_unstable();
         all_cols.sort_unstable();
 
-        // Union should cover 0..n_rows (compact active levels).
+        // Union should cover every compact level position.
         let expected_rows: Vec<usize> = (0..ct.n_rows()).collect();
         let expected_cols: Vec<usize> = (0..ct.n_cols()).collect();
         prop_assert_eq!(&all_rows, &expected_rows, "row indices should cover 0..n_rows={}", ct.n_rows());
@@ -295,27 +272,6 @@ proptest! {
 }
 
 #[test]
-fn test_find_all_active_levels_after_label_compaction() {
-    // Caller labels 0, 2, and 4 become internal positions 0, 1, and 2.
-    let fa = vec![0u32, 2, 4, 0, 2, 4];
-    let fb = vec![0u32, 1, 2, 0, 1, 2];
-    let design = design_of(vec![fa, fb]);
-
-    let active = find_all_active_levels(&design);
-
-    assert_eq!(
-        active[0],
-        vec![true, true, true],
-        "factor 0 should contain only its three observed levels"
-    );
-    assert_eq!(
-        active[1],
-        vec![true, true, true],
-        "factor 1 should retain its identity encoding"
-    );
-}
-
-#[test]
 fn dense_and_sparse_paths_agree_on_signed_data() {
     // Cell (f=0,g=0) crosses 0.0 mid-row and (f=0,g=1) cancels to 0.0; both paths must drop it.
     let f = [0u32, 0, 0, 0, 0, 1];
@@ -330,14 +286,8 @@ fn dense_and_sparse_paths_agree_on_signed_data() {
         rows: Channel { term: 0, column: 1 },
         cols: Channel { term: 1, column: 0 },
     };
-    let all_active = find_all_active_levels(&design);
-    let active = build_compact_mapping(
-        &all_active[0],
-        &all_active[1],
-        design.terms[0].column_base(pair.rows.column),
-        design.terms[1].column_base(pair.cols.column),
-    )
-    .expect("both factors have active levels");
+    let n_rows = design.terms[pair.rows.term].n_levels();
+    let n_cols = design.terms[pair.cols.term].n_levels();
 
     let cols = PairColumns {
         row_levels: design.level_column(0),
@@ -346,8 +296,8 @@ fn dense_and_sparse_paths_agree_on_signed_data() {
         col_load: Unit,
         weights: None,
     };
-    let (c_dense, dq_dense, dr_dense) = accumulate_dense_cross_block(cols, &active);
-    let (c_sparse, dq_sparse, dr_sparse) = accumulate_sparse_cross_block(cols, &active);
+    let (c_dense, dq_dense, dr_dense) = accumulate_dense_cross_block(cols, n_rows, n_cols);
+    let (c_sparse, dq_sparse, dr_sparse) = accumulate_sparse_cross_block(cols, n_rows, n_cols);
 
     // Bit-exact parity: identical per-cell addition order in both paths.
     assert_eq!(c_dense.indptr, c_sparse.indptr);

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -12,7 +12,7 @@ use crate::channel::{Channel, ChannelPair};
 use crate::config::LocalSolverConfig;
 use crate::{BuildError, BuildWarning};
 
-use super::{find_all_active_levels, BlockDiagonals, CrossTab, SolverDesign};
+use super::{BlockDiagonals, CrossTab, SolverDesign};
 
 mod sddm;
 use crate::domain::Loading;
@@ -60,16 +60,10 @@ pub(crate) fn build_local_domains(
                 .map(move |&cols| ChannelPair { rows, cols })
         })
         .collect();
-    let all_active = find_all_active_levels(design);
-
     let per_pair: Vec<(Vec<LocalDomain>, Vec<BuildWarning>)> = pairs
         .par_iter()
         .map(|&pair| {
-            let Some((full_ct, full_diag, l2g)) =
-                CrossTab::build_for_pair_with_active(solver_design, weights, pair, &all_active)
-            else {
-                return Ok((Vec::new(), Vec::new()));
-            };
+            let (full_ct, full_diag, l2g) = CrossTab::build_for_pair(solver_design, weights, pair);
             let class = if matches!(design.loading(pair.rows), Loading::Constant)
                 && matches!(design.loading(pair.cols), Loading::Constant)
             {


### PR DESCRIPTION
Simplifies cross cross tabulations by directly using compact internal positions introduced in #333.