### PR TITLE
Prototype: PreparedDesign per weight vector over a shared Arc<Design>

### DIFF
--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -35,7 +35,7 @@ fn build_and_solve<'a>(
     let mut result = solver.solve(y, lsmr)?;
     result.time_setup += time_setup;
     result.time_total = t_start.elapsed().as_secs_f64();
-    Ok((result, solver.warnings()))
+    Ok((result, solver.warnings().to_vec()))
 }
 
 /// Batch counterpart to [`build_and_solve`], mirroring [`within::solve_batch`].
@@ -52,7 +52,7 @@ fn build_and_solve_batch<'a>(
     let mut result = solver.solve_batch(ys, lsmr)?;
     result.time_setup += time_setup;
     result.time_total = t_start.elapsed().as_secs_f64();
-    Ok((result, solver.warnings()))
+    Ok((result, solver.warnings().to_vec()))
 }
 
 #[pyfunction]
@@ -261,11 +261,7 @@ impl PySolver {
             DesignSource::Categories(categories) => {
                 let cats = categories.as_array();
                 py.detach(move || -> Result<Solver<'static>, BuildError> {
-                    Solver::new(
-                        Design::from_categories(cats)?.into_owned(),
-                        weights_vec,
-                        precond,
-                    )
+                    Solver::new(cats.into_design()?.into_owned(), weights_vec, precond)
                 })
             }
             DesignSource::Effects(terms) => {
@@ -279,7 +275,7 @@ impl PySolver {
         }
         .map_err(value_err)?;
 
-        emit_build_warnings(py, &solver.warnings())?;
+        emit_build_warnings(py, solver.warnings())?;
         Ok(Self { solver })
     }
 

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -35,7 +35,7 @@ fn build_and_solve<'a>(
     let mut result = solver.solve(y, lsmr)?;
     result.time_setup += time_setup;
     result.time_total = t_start.elapsed().as_secs_f64();
-    Ok((result, solver.warnings().to_vec()))
+    Ok((result, solver.warnings()))
 }
 
 /// Batch counterpart to [`build_and_solve`], mirroring [`within::solve_batch`].
@@ -52,7 +52,7 @@ fn build_and_solve_batch<'a>(
     let mut result = solver.solve_batch(ys, lsmr)?;
     result.time_setup += time_setup;
     result.time_total = t_start.elapsed().as_secs_f64();
-    Ok((result, solver.warnings().to_vec()))
+    Ok((result, solver.warnings()))
 }
 
 #[pyfunction]
@@ -261,7 +261,11 @@ impl PySolver {
             DesignSource::Categories(categories) => {
                 let cats = categories.as_array();
                 py.detach(move || -> Result<Solver<'static>, BuildError> {
-                    Solver::new(cats.into_design()?.into_owned(), weights_vec, precond)
+                    Solver::new(
+                        Design::from_categories(cats)?.into_owned(),
+                        weights_vec,
+                        precond,
+                    )
                 })
             }
             DesignSource::Effects(terms) => {
@@ -275,7 +279,7 @@ impl PySolver {
         }
         .map_err(value_err)?;
 
-        emit_build_warnings(py, solver.warnings())?;
+        emit_build_warnings(py, &solver.warnings())?;
         Ok(Self { solver })
     }
 

--- a/crates/within/src/channel.rs
+++ b/crates/within/src/channel.rs
@@ -30,3 +30,18 @@ impl std::fmt::Display for ChannelPair {
         write!(f, "{} and {}", self.rows, self.cols)
     }
 }
+
+/// One coefficient of the design: a [`Channel`] at one level of its term.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Coefficient<L> {
+    /// The coefficient column this address sits in.
+    pub channel: Channel,
+    /// The level, in whichever space `L` names.
+    pub level: L,
+}
+
+/// A coefficient addressed by the caller's own factor label.
+pub type CoefficientAddress = Coefficient<u32>;
+
+/// A coefficient addressed by its internal compact position.
+pub(crate) type CoefficientPosition = Coefficient<usize>;

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -8,7 +8,7 @@ pub(crate) mod level_moments;
 mod prepared;
 mod slope_basis;
 
-pub(crate) use cross_tab::{find_all_active_levels, BlockDiagonals, CrossTab};
+pub(crate) use cross_tab::{BlockDiagonals, CrossTab};
 pub(crate) use prepared::PreparedDesign;
 pub(crate) use slope_basis::SlopeBasis;
 
@@ -192,6 +192,8 @@ pub struct Design<'a> {
     pub(crate) n_dofs: usize,
     /// `obs_perm[k]` = caller's original index of the observation at internal position `k`.
     pub(crate) obs_perm: Option<Vec<u32>>,
+    /// `active_levels[term][level]`: whether any observation carries that level.
+    pub(crate) active_levels: Vec<Vec<bool>>,
 }
 
 impl<'a> Design<'a> {
@@ -296,12 +298,25 @@ impl<'a> Design<'a> {
             _ => (frame, None),
         };
 
+        let active_levels = terms
+            .iter()
+            .enumerate()
+            .map(|(q, t)| {
+                let mut active = vec![false; t.n_levels()];
+                for &v in frame.level_column(q) {
+                    active[v as usize] = true;
+                }
+                active
+            })
+            .collect();
+
         Ok(Design {
             frame,
             terms,
             n_obs,
             n_dofs: offset,
             obs_perm,
+            active_levels,
         })
     }
 
@@ -313,6 +328,7 @@ impl<'a> Design<'a> {
             n_obs: self.n_obs,
             n_dofs: self.n_dofs,
             obs_perm: self.obs_perm,
+            active_levels: self.active_levels,
         }
     }
 

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -8,7 +8,7 @@ pub(crate) mod level_moments;
 mod prepared;
 mod slope_basis;
 
-pub(crate) use cross_tab::{BlockDiagonals, CrossTab};
+pub(crate) use cross_tab::{find_all_active_levels, BlockDiagonals, CrossTab};
 pub(crate) use prepared::PreparedDesign;
 pub(crate) use slope_basis::SlopeBasis;
 
@@ -130,6 +130,19 @@ impl TermMeta {
         self.encoding.n_levels()
     }
 
+    /// Frame columns of the term's covariates, in coefficient-column order.
+    pub(crate) fn covariates(&self) -> impl Iterator<Item = u32> + '_ {
+        self.columns.iter().filter_map(|c| c.covariate().copied())
+    }
+
+    pub(crate) fn has_slopes(&self) -> bool {
+        self.covariates().next().is_some()
+    }
+
+    pub(crate) fn has_intercept(&self) -> bool {
+        self.columns.iter().any(|c| c.covariate().is_none())
+    }
+
     pub fn n_columns(&self) -> usize {
         self.columns.len()
     }
@@ -181,8 +194,7 @@ fn stable_argsort(key: &[u32], n_levels: usize) -> Vec<u32> {
     perm
 }
 
-/// Fixed-effects design: observation columns plus coefficient-space layout.
-/// Cloning shares the per-observation data, so solvers on one design share it.
+/// Fixed-effects design: observation columns plus coefficient-space layout; clones share rows.
 #[derive(Clone, Debug)]
 pub struct Design<'a> {
     /// Columns in internal row order (caller's, or an owned locality-sorted copy).
@@ -192,8 +204,6 @@ pub struct Design<'a> {
     pub(crate) n_dofs: usize,
     /// `obs_perm[k]` = caller's original index of the observation at internal position `k`.
     pub(crate) obs_perm: Option<Arc<[u32]>>,
-    /// `active_levels[term][level]`: whether any observation carries that level.
-    pub(crate) active_levels: Vec<Vec<bool>>,
 }
 
 impl<'a> Design<'a> {
@@ -283,39 +293,23 @@ impl<'a> Design<'a> {
             _ => (frame, None),
         };
 
-        let active_levels = terms
-            .iter()
-            .enumerate()
-            .map(|(q, t)| {
-                let mut active = vec![false; t.n_levels()];
-                for &v in frame.level_column(q) {
-                    active[v as usize] = true;
-                }
-                active
-            })
-            .collect();
-
         Ok(Design {
             frame: Arc::new(frame),
             terms,
             n_obs,
             n_dofs: offset,
             obs_perm,
-            active_levels,
         })
     }
 
     /// Convert the frame's columns to owned, dropping ties to caller buffers.
     pub fn into_owned(self) -> Design<'static> {
-        // A frame other clones still hold is copied; a sole owner converts in place.
-        let frame = Arc::try_unwrap(self.frame).unwrap_or_else(|shared| (*shared).clone());
         Design {
-            frame: Arc::new(frame.into_owned()),
+            frame: Arc::new(Arc::unwrap_or_clone(self.frame).into_owned()),
             terms: self.terms,
             n_obs: self.n_obs,
             n_dofs: self.n_dofs,
             obs_perm: self.obs_perm,
-            active_levels: self.active_levels,
         }
     }
 

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -20,8 +20,7 @@ pub(crate) use factor_pairs::{
 };
 
 use std::borrow::Cow;
-
-use ndarray::{ArrayView2, Axis};
+use std::sync::Arc;
 
 use crate::channel::Channel;
 use crate::observation::ObservationFrame;
@@ -183,15 +182,16 @@ fn stable_argsort(key: &[u32], n_levels: usize) -> Vec<u32> {
 }
 
 /// Fixed-effects design: observation columns plus coefficient-space layout.
+/// Cloning shares the per-observation data, so solvers on one design share it.
 #[derive(Clone, Debug)]
 pub struct Design<'a> {
     /// Columns in internal row order (caller's, or an owned locality-sorted copy).
-    frame: ObservationFrame<'a>,
+    frame: Arc<ObservationFrame<'a>>,
     pub(crate) terms: Vec<TermMeta>,
     pub(crate) n_obs: usize,
     pub(crate) n_dofs: usize,
     /// `obs_perm[k]` = caller's original index of the observation at internal position `k`.
-    pub(crate) obs_perm: Option<Vec<u32>>,
+    pub(crate) obs_perm: Option<Arc<[u32]>>,
     /// `active_levels[term][level]`: whether any observation carries that level.
     pub(crate) active_levels: Vec<Vec<bool>>,
 }
@@ -213,21 +213,6 @@ impl<'a> Design<'a> {
         }
         let frame = ObservationFrame::new(categorical, continuous)?;
         Self::build(frame, structure, true)
-    }
-
-    /// Intercept-only factors from an observation-major `(n_obs, n_factors)` categories array.
-    pub fn from_categories(categories: ArrayView2<'a, u32>) -> Result<Self, BuildError> {
-        // Gather strided (C-order) columns once so every downstream read is contiguous.
-        let categorical = (0..categories.ncols())
-            .map(|factor| {
-                let col = categories.index_axis_move(Axis(1), factor);
-                match col.to_slice() {
-                    Some(s) => Cow::Borrowed(s),
-                    None => Cow::Owned(col.to_vec()),
-                }
-            })
-            .collect();
-        Self::from_frame(ObservationFrame::new(categorical, Vec::new())?)
     }
 
     /// Intercept-only factors, level count `max + 1`; locality-sorts an unsorted dominant factor.
@@ -293,7 +278,7 @@ impl<'a> Design<'a> {
                 for (q, meta) in terms.iter_mut().enumerate() {
                     meta.sorted = sorted_frame.level_column(q).is_sorted();
                 }
-                (sorted_frame, Some(perm))
+                (sorted_frame, Some(perm.into()))
             }
             _ => (frame, None),
         };
@@ -311,7 +296,7 @@ impl<'a> Design<'a> {
             .collect();
 
         Ok(Design {
-            frame,
+            frame: Arc::new(frame),
             terms,
             n_obs,
             n_dofs: offset,
@@ -322,8 +307,10 @@ impl<'a> Design<'a> {
 
     /// Convert the frame's columns to owned, dropping ties to caller buffers.
     pub fn into_owned(self) -> Design<'static> {
+        // A frame other clones still hold is copied; a sole owner converts in place.
+        let frame = Arc::try_unwrap(self.frame).unwrap_or_else(|shared| (*shared).clone());
         Design {
-            frame: self.frame.into_owned(),
+            frame: Arc::new(frame.into_owned()),
             terms: self.terms,
             n_obs: self.n_obs,
             n_dofs: self.n_dofs,
@@ -332,9 +319,12 @@ impl<'a> Design<'a> {
         }
     }
 
-    /// Validate that an optional weight slice matches this design's observation count.
-    pub(crate) fn validate_weights(&self, weights: Option<&[f64]>) -> Result<(), BuildError> {
-        if let Some(w) = weights {
+    /// Validated weights in internal observation order.
+    pub(crate) fn permute_weights(
+        &self,
+        weights: Option<Vec<f64>>,
+    ) -> Result<Option<Vec<f64>>, BuildError> {
+        if let Some(w) = &weights {
             if w.len() != self.n_obs {
                 return Err(BuildError::WeightCountMismatch {
                     expected: self.n_obs,
@@ -350,15 +340,6 @@ impl<'a> Design<'a> {
                 return Err(BuildError::InvalidWeight { index, value });
             }
         }
-        Ok(())
-    }
-
-    /// Validated weights in internal observation order.
-    pub(crate) fn permute_weights(
-        &self,
-        weights: Option<Vec<f64>>,
-    ) -> Result<Option<Vec<f64>>, BuildError> {
-        self.validate_weights(weights.as_deref())?;
         // The match keeps the unpermuted arm a plain move rather than a borrow-and-copy.
         Ok(match &self.obs_perm {
             Some(_) => weights.map(|w| self.permute_obs_in(&w).into_owned()),
@@ -504,29 +485,26 @@ mod tests {
     }
 
     #[test]
-    fn validate_weights_checks_count_and_finiteness() {
+    fn permute_weights_checks_count_and_finiteness() {
         let design = Design::from_frame(frame(vec![vec![0, 0, 0, 0, 0]], vec![])).unwrap();
-        assert!(design.validate_weights(None).is_ok());
-        assert!(design
-            .validate_weights(Some(&[1.0, 2.0, 3.0, 4.0, 5.0]))
-            .is_ok());
+        let check = |w: &[f64]| design.permute_weights(Some(w.to_vec()));
+        assert!(design.permute_weights(None).is_ok());
+        assert!(check(&[1.0, 2.0, 3.0, 4.0, 5.0]).is_ok());
         // Zero weights are valid (an excluded observation).
-        assert!(design
-            .validate_weights(Some(&[0.0, 1.0, 2.0, 3.0, 4.0]))
-            .is_ok());
+        assert!(check(&[0.0, 1.0, 2.0, 3.0, 4.0]).is_ok());
         // Length mismatch.
-        assert!(design.validate_weights(Some(&[1.0, 2.0])).is_err());
+        assert!(check(&[1.0, 2.0]).is_err());
         // Negative / non-finite weights are rejected with the offending index.
         assert!(matches!(
-            design.validate_weights(Some(&[1.0, -2.0, 3.0, 4.0, 5.0])),
+            check(&[1.0, -2.0, 3.0, 4.0, 5.0]),
             Err(BuildError::InvalidWeight { index: 1, .. })
         ));
         assert!(matches!(
-            design.validate_weights(Some(&[1.0, 2.0, f64::NAN, 4.0, 5.0])),
+            check(&[1.0, 2.0, f64::NAN, 4.0, 5.0]),
             Err(BuildError::InvalidWeight { index: 2, .. })
         ));
         assert!(matches!(
-            design.validate_weights(Some(&[1.0, 2.0, 3.0, f64::INFINITY, 5.0])),
+            check(&[1.0, 2.0, 3.0, f64::INFINITY, 5.0]),
             Err(BuildError::InvalidWeight { index: 3, .. })
         ));
     }
@@ -575,8 +553,8 @@ mod tests {
         ))
         .unwrap();
 
-        let perm = design.obs_perm.as_ref().expect("permutation applied");
-        assert_eq!(perm, &[1, 3, 2, 0]);
+        let perm = design.obs_perm.as_deref().expect("permutation applied");
+        assert_eq!(perm, [1, 3, 2, 0]);
         assert_eq!(design.level_column(0), [0, 0, 1, 2]);
         assert_eq!(design.loading_column(0), [20.0, 40.0, 30.0, 10.0]);
     }

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -5,8 +5,12 @@ pub(crate) mod cross_tab;
 mod effect;
 pub(crate) mod factor_pairs;
 pub(crate) mod level_moments;
+mod prepared;
+mod slope_basis;
 
 pub(crate) use cross_tab::{find_all_active_levels, BlockDiagonals, CrossTab};
+pub(crate) use prepared::PreparedDesign;
+pub(crate) use slope_basis::SlopeBasis;
 
 pub use effect::Effect;
 
@@ -16,6 +20,8 @@ pub(crate) use factor_pairs::{
 };
 
 use std::borrow::Cow;
+
+use ndarray::{ArrayView2, Axis};
 
 use crate::channel::Channel;
 use crate::observation::ObservationFrame;
@@ -207,6 +213,21 @@ impl<'a> Design<'a> {
         Self::build(frame, structure, true)
     }
 
+    /// Intercept-only factors from an observation-major `(n_obs, n_factors)` categories array.
+    pub fn from_categories(categories: ArrayView2<'a, u32>) -> Result<Self, BuildError> {
+        // Gather strided (C-order) columns once so every downstream read is contiguous.
+        let categorical = (0..categories.ncols())
+            .map(|factor| {
+                let col = categories.index_axis_move(Axis(1), factor);
+                match col.to_slice() {
+                    Some(s) => Cow::Borrowed(s),
+                    None => Cow::Owned(col.to_vec()),
+                }
+            })
+            .collect();
+        Self::from_frame(ObservationFrame::new(categorical, Vec::new())?)
+    }
+
     /// Intercept-only factors, level count `max + 1`; locality-sorts an unsorted dominant factor.
     pub fn from_frame(frame: ObservationFrame<'a>) -> Result<Self, BuildError> {
         let structure = vec![NonEmpty::of(Loading::Constant); frame.n_factors()];
@@ -316,6 +337,19 @@ impl<'a> Design<'a> {
         Ok(())
     }
 
+    /// Validated weights in internal observation order.
+    pub(crate) fn permute_weights(
+        &self,
+        weights: Option<Vec<f64>>,
+    ) -> Result<Option<Vec<f64>>, BuildError> {
+        self.validate_weights(weights.as_deref())?;
+        // The match keeps the unpermuted arm a plain move rather than a borrow-and-copy.
+        Ok(match &self.obs_perm {
+            Some(_) => weights.map(|w| self.permute_obs_in(&w).into_owned()),
+            None => weights,
+        })
+    }
+
     /// Caller order → internal order: `out[k] = v[obs_perm[k]]`; borrows when unpermuted.
     pub(crate) fn permute_obs_in<'v>(&self, v: &'v [f64]) -> Cow<'v, [f64]> {
         debug_assert_eq!(v.len(), self.n_obs);
@@ -346,6 +380,10 @@ impl<'a> Design<'a> {
         self.terms.len()
     }
 
+    pub(crate) fn n_loading_columns(&self) -> usize {
+        self.frame.n_loading_columns()
+    }
+
     /// The term's coefficient columns in layout order.
     pub(crate) fn channels(&self, term: usize) -> impl Iterator<Item = Channel> + '_ {
         (0..self.terms[term].n_columns()).map(move |column| Channel { term, column })
@@ -364,11 +402,6 @@ impl<'a> Design<'a> {
     /// Continuous loading column in internal observation order.
     pub(crate) fn loading_column(&self, column: usize) -> &[f64] {
         self.frame.loading_column(column)
-    }
-
-    /// Replace one loading column during solver-local preparation.
-    pub(crate) fn replace_loading_column(&mut self, column: usize, values: Vec<f64>) {
-        self.frame.set_loading_column(column, values);
     }
 
     /// Number of observations (rows of D).

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -5,8 +5,7 @@ use std::ops::Range;
 
 use rayon::prelude::*;
 
-use super::level_moments::{BasisScratch, LevelMoments, TermMoments};
-use super::Design;
+use super::{Design, SlopeBasis};
 use crate::channel::Channel;
 use crate::BuildWarning;
 
@@ -22,7 +21,7 @@ const ROWS_PER_TASK: usize = 1 << 16;
 pub(crate) fn detect_collinear_slopes(
     design: &Design<'_>,
     weights: Option<&[f64]>,
-    moments: &TermMoments,
+    basis: &SlopeBasis,
 ) -> Vec<BuildWarning> {
     if design.n_factors() < 2 {
         return Vec::new();
@@ -32,7 +31,7 @@ pub(crate) fn detect_collinear_slopes(
         .into_par_iter()
         .flat_map_iter(move |term| {
             let targets = screened_covariates(design, term);
-            residual_shares(design, weights, moments, term, &targets, budget)
+            residual_shares(design, weights, basis, term, &targets, budget)
                 .into_iter()
                 .zip(targets)
                 .filter(|&(share, _)| share <= COLLINEARITY_TOL)
@@ -57,10 +56,14 @@ fn screened_covariates(design: &Design<'_>, term: usize) -> Vec<(Channel, u32)> 
 }
 
 /// Two passes, so the share resolves below the `1e-16` a subtraction floors at.
+///
+/// The term's span is read in the solve basis: its whitened columns are
+/// weight-orthonormal within each level, so a target's fit is `Σw·c·u` per
+/// column with no decomposition of its own.
 fn residual_shares(
     design: &Design<'_>,
     weights: Option<&[f64]>,
-    moments: &TermMoments,
+    basis: &SlopeBasis,
     term: usize,
     targets: &[(Channel, u32)],
     budget: usize,
@@ -69,36 +72,38 @@ fn residual_shares(
     if m == 0 {
         return Vec::new();
     }
-    let moments = &moments[term];
+    let meta = &design.terms[term];
     let levels = design.level_column(term);
-    let zs: Vec<&[f64]> = moments
-        .covariates()
+    let us: Vec<&[f64]> = meta
+        .columns
         .iter()
-        .map(|&c| design.loading_column(c as usize))
+        .filter_map(|c| c.covariate())
+        .map(|&c| basis.loading_column(c as usize))
         .collect();
+    let intercept = us.len() < meta.columns.len();
     let columns: Vec<&[f64]> = targets
         .iter()
         .map(|&(_, c)| design.loading_column(c as usize))
         .collect();
-    let stride = columns.len() * (zs.len() + 1);
-    let n_levels = moments.n_levels();
+    let stride = columns.len() * (us.len() + 1);
+    let n_levels = meta.n_levels();
     let plan = ScreenPlan::new(budget, n_levels, stride);
     let screen = Screen {
         levels,
         weights,
-        zs,
+        us,
         columns,
-        zeros: vec![0.0; moments.n_slopes()],
-        moments,
+        intercept,
         stride,
         // Grouping gathers every column, so it must buy back more than the one block.
-        order: match design.terms[term].sorted || plan.per_block == n_levels {
+        order: match meta.sorted || plan.per_block == n_levels {
             true => RowOrder::AsIs,
             false => RowOrder::Grouped(super::stable_argsort(levels, n_levels)),
         },
     };
 
     let mut table = vec![0.0f64; plan.per_block * stride];
+    let mut level_weight = vec![0.0f64; plan.per_block];
     let mut residual = vec![0.0f64; m];
     let mut variations = Variations {
         w_sum: 0.0,
@@ -110,13 +115,14 @@ fn residual_shares(
             levels: levels_block,
         };
         let table = &mut table[..block.levels.len() * stride];
+        let level_weight = &mut level_weight[..block.levels.len()];
         table.fill(0.0);
-        screen.accumulate_cross(&block, table, &mut variations);
-        screen.to_coefficients(&block, table);
+        level_weight.fill(0.0);
+        screen.accumulate_cross(&block, table, level_weight, &mut variations);
+        screen.to_coefficients(table, level_weight);
         screen.accumulate_residual(&block, table, &mut residual);
     }
 
-    let intercept = moments.intercept();
     residual
         .iter()
         .zip(&variations.stats)
@@ -133,12 +139,12 @@ fn residual_shares(
 struct Screen<'a> {
     levels: &'a [u32],
     weights: Option<&'a [f64]>,
-    zs: Vec<&'a [f64]>,
+    /// The term's slope columns in the solve basis.
+    us: Vec<&'a [f64]>,
     columns: Vec<&'a [f64]>,
-    zeros: Vec<f64>,
-    moments: &'a LevelMoments,
+    intercept: bool,
     order: RowOrder,
-    /// One level's row of the table: `[Σw·c, Σw·z·c]` per target.
+    /// One level's row of the table: `[Σw·c, Σw·u·c]` per target.
     stride: usize,
 }
 
@@ -156,22 +162,21 @@ impl Screen<'_> {
         })
     }
 
-    /// Without an intercept the level's span holds no constant, so `z` enters uncentered.
-    fn center(&self, level: usize) -> &[f64] {
-        match self.moments.intercept() {
-            true => self.moments.mean(level),
-            false => &self.zeros,
-        }
-    }
-
     /// Each target's total variation rides this pass, since the rows are already loaded.
-    fn accumulate_cross(&self, block: &Block, table: &mut [f64], variations: &mut Variations) {
-        let v = self.zs.len();
+    fn accumulate_cross(
+        &self,
+        block: &Block,
+        table: &mut [f64],
+        level_weight: &mut [f64],
+        variations: &mut Variations,
+    ) {
+        let v = self.us.len();
         let stride = self.stride;
         let Variations { w_sum, stats } = variations;
         let mut running = *w_sum;
         for (obs, w, row) in self.active_rows(block.levels.start, block.rows.clone()) {
             running += w;
+            level_weight[row] += w;
             // Every target shares the running weight, so the Welford ratio is taken once.
             let ratio = w / running;
             for ((slot, column), stat) in table[row * stride..][..stride]
@@ -183,58 +188,26 @@ impl Screen<'_> {
                 stat.observe(c, w, ratio);
                 let wc = w * c;
                 slot[0] += wc;
-                for (s, z) in slot[1..].iter_mut().zip(&self.zs) {
-                    *s += wc * z[obs];
+                for (s, u) in slot[1..].iter_mut().zip(&self.us) {
+                    *s += wc * u[obs];
                 }
             }
         }
         *w_sum = running;
     }
 
-    /// Rewrites a level's cross moments as the coefficients `[c̄, β]` of `c`'s fit on its span.
-    fn to_coefficients(&self, block: &Block, table: &mut [f64]) {
-        let v = self.zs.len();
-        let intercept = self.moments.intercept();
-        table
-            .par_chunks_exact_mut(self.stride)
-            .enumerate()
-            .for_each_init(
-                || (BasisScratch::new(v), vec![0.0f64; v]),
-                |(scratch, d), (offset, row)| {
-                    let level = block.levels.start + offset;
-                    let w_sum = self.moments.w_sum(level);
-                    if w_sum <= 0.0 {
-                        debug_assert!(
-                            row.iter().all(|&x| x == 0.0),
-                            "level {level} carries cross moments the term's weights deny"
-                        );
-                        return;
-                    }
-                    if v > 0 {
-                        self.moments.basis(level, scratch);
-                    }
-                    let center = self.center(level);
-                    for slot in row.chunks_exact_mut(v + 1) {
-                        let sum_wc = slot[0];
-                        for ((dj, &xj), &cj) in d.iter_mut().zip(&slot[1..]).zip(center) {
-                            *dj = xj - sum_wc * cj;
-                        }
-                        slot[0] = match intercept {
-                            true => sum_wc / w_sum,
-                            false => 0.0,
-                        };
-                        slot[1..].fill(0.0);
-                        if v > 0 {
-                            for q in scratch.basis.chunks_exact(v) {
-                                let projection = crate::linalg::dot(q, d);
-                                for (b, &qj) in slot[1..].iter_mut().zip(q) {
-                                    *b += projection * qj;
-                                }
-                            }
-                        }
-                    }
-                },
-            );
+    /// Rewrites each level's `Σw·c` as the constant `c̄` of `c`'s fit; the `Σw·u·c`
+    /// beside it already are the slope coefficients, `u` being orthonormal.
+    fn to_coefficients(&self, table: &mut [f64], level_weight: &[f64]) {
+        let v = self.us.len();
+        for (row, &w_sum) in table.chunks_exact_mut(self.stride).zip(level_weight) {
+            for slot in row.chunks_exact_mut(v + 1) {
+                slot[0] = match self.intercept && w_sum > 0.0 {
+                    true => slot[0] / w_sum,
+                    false => 0.0,
+                };
+            }
+        }
     }
 
     /// Adds each target's `Σw·(c − ĉ)²` from the coefficients left in `table`.
@@ -244,7 +217,7 @@ impl Screen<'_> {
         if block.rows.is_empty() {
             return;
         }
-        let v = self.zs.len();
+        let v = self.us.len();
         let stride = self.stride;
         let first = block.levels.start;
         let tasks = block.rows.len().div_ceil(ROWS_PER_TASK);
@@ -252,23 +225,20 @@ impl Screen<'_> {
             .into_par_iter()
             .map_init(
                 || vec![0.0f64; v],
-                |dz, task| {
+                |u_row, task| {
                     let mut totals = vec![0.0f64; self.columns.len()];
                     let start = block.rows.start + task * ROWS_PER_TASK;
                     let rows = start..(start + ROWS_PER_TASK).min(block.rows.end);
                     for (obs, w, row) in self.active_rows(first, rows) {
-                        for (dzj, (z, &cj)) in dz
-                            .iter_mut()
-                            .zip(self.zs.iter().zip(self.center(first + row)))
-                        {
-                            *dzj = z[obs] - cj;
+                        for (uj, u) in u_row.iter_mut().zip(&self.us) {
+                            *uj = u[obs];
                         }
                         for ((slot, column), total) in table[row * stride..][..stride]
                             .chunks_exact(v + 1)
                             .zip(&self.columns)
                             .zip(&mut totals)
                         {
-                            let r = column[obs] - slot[0] - crate::linalg::dot(&slot[1..], dz);
+                            let r = column[obs] - slot[0] - crate::linalg::dot(&slot[1..], u_row);
                             *total += w * r * r;
                         }
                     }

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 
 use rayon::prelude::*;
 
-use super::{Design, SlopeBasis};
+use super::{Design, PreparedDesign, SlopeBasis};
 use crate::channel::Channel;
 use crate::BuildWarning;
 
@@ -18,11 +18,12 @@ const TABLE_BUDGET_BYTES: usize = 64 << 20;
 /// Rows one residual task claims; small enough that work stealing balances the tail.
 const ROWS_PER_TASK: usize = 1 << 16;
 
-pub(crate) fn detect_collinear_slopes(
-    design: &Design<'_>,
-    weights: Option<&[f64]>,
-    basis: &SlopeBasis,
-) -> Vec<BuildWarning> {
+pub(crate) fn detect_collinear_slopes(prepared: &PreparedDesign<'_>) -> Vec<BuildWarning> {
+    let (design, weights, basis) = (
+        &prepared.design,
+        prepared.weights.as_deref(),
+        &prepared.basis,
+    );
     if design.n_factors() < 2 {
         return Vec::new();
     }

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -56,10 +56,6 @@ fn screened_covariates(design: &Design<'_>, term: usize) -> Vec<(Channel, u32)> 
 }
 
 /// Two passes, so the share resolves below the `1e-16` a subtraction floors at.
-///
-/// The term's span is read in the solve basis: its whitened columns are
-/// weight-orthonormal within each level, so a target's fit is `Σw·c·u` per
-/// column with no decomposition of its own.
 fn residual_shares(
     design: &Design<'_>,
     weights: Option<&[f64]>,
@@ -196,8 +192,7 @@ impl Screen<'_> {
         *w_sum = running;
     }
 
-    /// Rewrites each level's `Σw·c` as the constant `c̄` of `c`'s fit; the `Σw·u·c`
-    /// beside it already are the slope coefficients, `u` being orthonormal.
+    /// `Σw·c` becomes the fit's constant `c̄`; `Σw·u·c` already is its slope, `u` being orthonormal.
     fn to_coefficients(&self, table: &mut [f64], level_weight: &[f64]) {
         let v = self.us.len();
         for (row, &w_sum) in table.chunks_exact_mut(self.stride).zip(level_weight) {

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 
 use rayon::prelude::*;
 
-use super::{Design, PreparedDesign, SlopeBasis};
+use super::{Design, PreparedDesign};
 use crate::channel::Channel;
 use crate::BuildWarning;
 
@@ -19,12 +19,8 @@ const TABLE_BUDGET_BYTES: usize = 64 << 20;
 const ROWS_PER_TASK: usize = 1 << 16;
 
 pub(crate) fn detect_collinear_slopes(prepared: &PreparedDesign<'_>) -> Vec<BuildWarning> {
-    let (design, weights, basis) = (
-        &prepared.design,
-        prepared.weights.as_deref(),
-        &prepared.basis,
-    );
-    if design.n_factors() < 2 {
+    let design = &prepared.design;
+    if design.n_factors() < 2 || design.n_loading_columns() == 0 {
         return Vec::new();
     }
     let budget = TABLE_BUDGET_BYTES / std::mem::size_of::<f64>() / design.n_factors();
@@ -32,7 +28,7 @@ pub(crate) fn detect_collinear_slopes(prepared: &PreparedDesign<'_>) -> Vec<Buil
         .into_par_iter()
         .flat_map_iter(move |term| {
             let targets = screened_covariates(design, term);
-            residual_shares(design, weights, basis, term, &targets, budget)
+            residual_shares(prepared, term, &targets, budget)
                 .into_iter()
                 .zip(targets)
                 .filter(|&(share, _)| share <= COLLINEARITY_TOL)
@@ -58,9 +54,7 @@ fn screened_covariates(design: &Design<'_>, term: usize) -> Vec<(Channel, u32)> 
 
 /// Two passes, so the share resolves below the `1e-16` a subtraction floors at.
 fn residual_shares(
-    design: &Design<'_>,
-    weights: Option<&[f64]>,
-    basis: &SlopeBasis,
+    prepared: &PreparedDesign<'_>,
     term: usize,
     targets: &[(Channel, u32)],
     budget: usize,
@@ -69,15 +63,14 @@ fn residual_shares(
     if m == 0 {
         return Vec::new();
     }
+    let (design, weights) = (&prepared.design, prepared.weights.as_deref());
     let meta = &design.terms[term];
     let levels = design.level_column(term);
     let us: Vec<&[f64]> = meta
-        .columns
-        .iter()
-        .filter_map(|c| c.covariate())
-        .map(|&c| basis.loading_column(c as usize))
+        .covariates()
+        .map(|c| prepared.basis.loading_column(c as usize))
         .collect();
-    let intercept = us.len() < meta.columns.len();
+    let intercept = meta.has_intercept();
     let columns: Vec<&[f64]> = targets
         .iter()
         .map(|&(_, c)| design.loading_column(c as usize))

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -5,8 +5,8 @@ use crate::Effect;
 const FULL_TABLE: usize = 1 << 24;
 
 fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usize)> {
-    let moments = TermMoments::build(design, weights).expect("design carries slopes");
-    detect_collinear_slopes(design, weights, &moments)
+    let basis = SlopeBasis::build(design, weights);
+    detect_collinear_slopes(design, weights, &basis)
         .into_iter()
         .map(|w| match w {
             BuildWarning::CollinearSlopeCovariate { slope, term, .. } => (slope, term),
@@ -17,9 +17,9 @@ fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usi
 
 /// The shares `term`'s screen reports, in target-channel order.
 fn shares(design: &Design<'_>, term: usize, budget: usize) -> Vec<f64> {
-    let moments = TermMoments::build(design, None).expect("design carries slopes");
+    let basis = SlopeBasis::build(design, None);
     let targets = screened_covariates(design, term);
-    residual_shares(design, None, &moments, term, &targets, budget)
+    residual_shares(design, None, &basis, term, &targets, budget)
 }
 
 fn two_factor_levels(n: usize) -> (Vec<u32>, Vec<u32>) {

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -5,8 +5,13 @@ use crate::Effect;
 const FULL_TABLE: usize = 1 << 24;
 
 fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usize)> {
-    let basis = SlopeBasis::build(design, weights);
-    detect_collinear_slopes(design, weights, &basis)
+    // Built directly: these weights are already in the design's internal order.
+    let prepared = PreparedDesign {
+        design: design.clone(),
+        weights: weights.map(<[f64]>::to_vec),
+        basis: SlopeBasis::build(design, weights),
+    };
+    detect_collinear_slopes(&prepared)
         .into_iter()
         .map(|w| match w {
             BuildWarning::CollinearSlopeCovariate { slope, term, .. } => (slope, term),

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -5,12 +5,8 @@ use crate::Effect;
 const FULL_TABLE: usize = 1 << 24;
 
 fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usize)> {
-    // Built directly: these weights are already in the design's internal order.
-    let prepared = PreparedDesign {
-        design: design.clone(),
-        weights: weights.map(<[f64]>::to_vec),
-        basis: SlopeBasis::build(design, weights),
-    };
+    let prepared =
+        PreparedDesign::new(design.clone(), weights.map(<[f64]>::to_vec)).expect("valid weights");
     detect_collinear_slopes(&prepared)
         .into_iter()
         .map(|w| match w {
@@ -22,9 +18,13 @@ fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usi
 
 /// The shares `term`'s screen reports, in target-channel order.
 fn shares(design: &Design<'_>, term: usize, budget: usize) -> Vec<f64> {
-    let basis = SlopeBasis::build(design, None);
     let targets = screened_covariates(design, term);
-    residual_shares(design, None, &basis, term, &targets, budget)
+    residual_shares(
+        &PreparedDesign::unweighted_for_test(design.clone()),
+        term,
+        &targets,
+        budget,
+    )
 }
 
 fn two_factor_levels(n: usize) -> (Vec<u32>, Vec<u32>) {
@@ -169,8 +169,6 @@ fn zero_weight_rows_are_excluded_from_the_screen() {
         Effect::new(&b, true, [&spoiled[..]]).unwrap(),
     ])
     .unwrap();
-    // The screen reads frame order, so caller weights go through the locality permutation.
-    let weights = design.permute_obs_in(&weights).into_owned();
     assert!(!warn_pairs(&design, Some(&weights)).is_empty());
     assert_eq!(warn_pairs(&design, None), Vec::new());
 }

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -7,7 +7,7 @@
 
 use crate::channel::ChannelPair;
 use crate::csr_block::{to_u32, CsrBlock};
-use crate::domain::PreparedDesign;
+use crate::domain::{Design, PreparedDesign};
 
 mod accumulate;
 use accumulate::accumulate_cross_block;
@@ -19,6 +19,22 @@ struct ActiveLevels {
     col_map: Vec<u32>,
     n_cols: usize,
     local_to_global: Vec<u32>,
+}
+
+/// Scan observations once, marking `active[f][level]` for every level any observation uses.
+pub(crate) fn find_all_active_levels(design: &Design<'_>) -> Vec<Vec<bool>> {
+    let mut active: Vec<Vec<bool>> = design
+        .terms
+        .iter()
+        .map(|f| vec![false; f.n_levels()])
+        .collect();
+    // Factor-outer/obs-inner: all writes for a factor land in one `active[f]` buffer.
+    for (f, col) in active.iter_mut().enumerate() {
+        for &v in design.level_column(f) {
+            col[v as usize] = true;
+        }
+    }
+    active
 }
 
 /// Compact-index each active level, returning the global-to-compact map and active count.

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -7,7 +7,7 @@
 
 use crate::channel::ChannelPair;
 use crate::csr_block::{to_u32, CsrBlock};
-use crate::domain::Design;
+use crate::domain::{Design, PreparedDesign};
 
 mod accumulate;
 use accumulate::accumulate_cross_block;
@@ -138,11 +138,11 @@ impl CrossTab {
 
     /// Reuses pre-computed active flags instead of rescanning; diagonals come back separately.
     pub(crate) fn build_for_pair_with_active(
-        design: &Design<'_>,
-        weights: Option<&[f64]>,
+        prepared: &PreparedDesign<'_>,
         pair: ChannelPair,
         all_active: &[Vec<bool>],
     ) -> Option<(Self, BlockDiagonals, Vec<u32>)> {
+        let design = &prepared.design;
         let active = build_compact_mapping(
             &all_active[pair.rows.term],
             &all_active[pair.cols.term],
@@ -150,7 +150,7 @@ impl CrossTab {
             design.terms[pair.cols.term].column_base(pair.cols.column),
         )?;
 
-        let (c, row_diag, col_diag) = accumulate_cross_block(design, weights, pair, &active);
+        let (c, row_diag, col_diag) = accumulate_cross_block(prepared, pair, &active);
         let ct = c.transpose();
         let cross_tab = CrossTab { c, ct };
         let diagonals = BlockDiagonals {

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -7,7 +7,7 @@
 
 use crate::channel::ChannelPair;
 use crate::csr_block::{to_u32, CsrBlock};
-use crate::domain::{Design, PreparedDesign};
+use crate::domain::PreparedDesign;
 
 mod accumulate;
 use accumulate::accumulate_cross_block;
@@ -19,22 +19,6 @@ struct ActiveLevels {
     col_map: Vec<u32>,
     n_cols: usize,
     local_to_global: Vec<u32>,
-}
-
-/// Scan observations once, marking `active[f][level]` for every level any observation uses.
-pub(crate) fn find_all_active_levels(design: &Design<'_>) -> Vec<Vec<bool>> {
-    let mut active: Vec<Vec<bool>> = design
-        .terms
-        .iter()
-        .map(|f| vec![false; f.n_levels()])
-        .collect();
-    // Factor-outer/obs-inner: all writes for a factor land in one `active[f]` buffer.
-    for (f, col) in active.iter_mut().enumerate() {
-        for &v in design.level_column(f) {
-            col[v as usize] = true;
-        }
-    }
-    active
 }
 
 /// Compact-index each active level, returning the global-to-compact map and active count.

--- a/crates/within/src/domain/cross_tab/accumulate.rs
+++ b/crates/within/src/domain/cross_tab/accumulate.rs
@@ -10,7 +10,7 @@
 
 use crate::channel::ChannelPair;
 use crate::csr_block::CsrBlock;
-use crate::domain::Design;
+use crate::domain::PreparedDesign;
 
 use super::{to_u32, ActiveLevels};
 use crate::domain::Loading as ColumnLoading;
@@ -84,11 +84,12 @@ impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
 
 /// Accumulate into `C` plus diagonals, dispatching dense or sparse by peak transient memory.
 pub(super) fn accumulate_cross_block(
-    design: &Design<'_>,
-    weights: Option<&[f64]>,
+    prepared: &PreparedDesign<'_>,
     pair: ChannelPair,
     active: &ActiveLevels,
 ) -> (CsrBlock, Vec<f64>, Vec<f64>) {
+    let design = &prepared.design;
+    let weights = prepared.weights.as_deref();
     // Dispatching on cell count alone would pick sparse where it uses MORE memory.
     let table_size = active.n_rows.saturating_mul(active.n_cols);
     let dense_cost = table_size.saturating_mul(8);
@@ -97,8 +98,10 @@ pub(super) fn accumulate_cross_block(
 
     let row_levels = design.level_column(pair.rows.term);
     let col_levels = design.level_column(pair.cols.term);
-    let load =
-        |col: ColumnLoading<u32>| col.covariate().map(|&c| design.loading_column(c as usize));
+    let load = |col: ColumnLoading<u32>| {
+        col.covariate()
+            .map(|&c| prepared.basis.loading_column(c as usize))
+    };
     // One arm per loading combination; closures aren't generic, so the literals repeat.
     match (
         load(design.loading(pair.rows)),

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -7,7 +7,7 @@ use super::{build_compact_mapping, CrossTab};
 use crate::channel::{Channel, ChannelPair};
 use crate::csr_block::CsrBlock;
 use crate::domain::find_all_active_levels;
-use crate::domain::{Design, Effect};
+use crate::domain::{Design, Effect, PreparedDesign};
 use crate::observation::ObservationFrame;
 
 impl CrossTab {
@@ -24,10 +24,10 @@ const INTERCEPT_PAIR: ChannelPair = ChannelPair {
     cols: Channel { term: 1, column: 0 },
 };
 
-fn design_of(columns: Vec<Vec<u32>>) -> Design<'static> {
+fn design_of(columns: Vec<Vec<u32>>) -> PreparedDesign<'static> {
     let frame = ObservationFrame::new(columns.into_iter().map(Into::into).collect(), Vec::new())
         .expect("valid frame");
-    Design::from_frame(frame).expect("valid design")
+    PreparedDesign::unweighted_for_test(Design::from_frame(frame).expect("valid design"))
 }
 
 #[test]
@@ -45,18 +45,18 @@ fn test_cross_tab_sparse_accumulation_path() {
 
     // Sparse path (large level counts)
     let design_sparse = design_of(vec![fa.clone(), fb.clone()]);
-    let active_sparse = find_all_active_levels(&design_sparse);
+    let active_sparse = find_all_active_levels(&design_sparse.design);
     let (ct_sparse, diag_sparse, _) =
-        CrossTab::build_for_pair_with_active(&design_sparse, None, INTERCEPT_PAIR, &active_sparse)
+        CrossTab::build_for_pair_with_active(&design_sparse, INTERCEPT_PAIR, &active_sparse)
             .expect("sparse cross tab should build");
 
     // Dense reference: collapse levels so n_rows * n_cols <= 5M.
     let fa_small: Vec<u32> = fa.iter().map(|&x| x % 100).collect();
     let fb_small: Vec<u32> = fb.iter().map(|&x| x % 100).collect();
     let design_dense = design_of(vec![fa_small.clone(), fb_small.clone()]);
-    let active_dense = find_all_active_levels(&design_dense);
+    let active_dense = find_all_active_levels(&design_dense.design);
     let (_ct_dense, diag_dense, _) =
-        CrossTab::build_for_pair_with_active(&design_dense, None, INTERCEPT_PAIR, &active_dense)
+        CrossTab::build_for_pair_with_active(&design_dense, INTERCEPT_PAIR, &active_dense)
             .expect("dense cross tab should build");
 
     // Each observation appears exactly once in its row/col bucket.
@@ -121,9 +121,9 @@ fn test_extract_component_two_components() {
     let fa = vec![0u32, 0, 1, 1, 2, 2, 3, 3];
     let fb = vec![0u32, 1, 0, 1, 2, 3, 2, 3];
     let design = design_of(vec![fa, fb]);
-    let all_active = find_all_active_levels(&design);
+    let all_active = find_all_active_levels(&design.design);
     let (ct, parent_diag, _) =
-        CrossTab::build_for_pair_with_active(&design, None, INTERCEPT_PAIR, &all_active)
+        CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
     let components = ct.bipartite_connected_components();
@@ -233,8 +233,8 @@ proptest! {
         }
 
         let design = design_of(vec![fa, fb]);
-        let all_active = find_all_active_levels(&design);
-        let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, None, INTERCEPT_PAIR, &all_active)
+        let all_active = find_all_active_levels(&design.design);
+        let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
         let components = ct.bipartite_connected_components();
@@ -284,7 +284,7 @@ fn test_find_all_active_levels_with_gaps() {
     let fb = vec![0u32, 1, 2, 0, 1, 2];
     let design = design_of(vec![fa, fb]);
 
-    let active = find_all_active_levels(&design);
+    let active = find_all_active_levels(&design.design);
 
     // Factor 0: 5 levels, only 0, 2, 4 active.
     assert_eq!(active[0].len(), 5, "factor 0 should have 5 levels");

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -3,7 +3,7 @@ use proptest::prelude::*;
 use super::accumulate::{
     accumulate_dense_cross_block, accumulate_sparse_cross_block, PairColumns, Unit,
 };
-use super::{build_compact_mapping, CrossTab};
+use super::{build_compact_mapping, find_all_active_levels, CrossTab};
 use crate::channel::{Channel, ChannelPair};
 use crate::csr_block::CsrBlock;
 use crate::domain::{Design, Effect, PreparedDesign};
@@ -44,7 +44,7 @@ fn test_cross_tab_sparse_accumulation_path() {
 
     // Sparse path (large level counts)
     let design_sparse = design_of(vec![fa.clone(), fb.clone()]);
-    let active_sparse = design_sparse.design.active_levels.clone();
+    let active_sparse = find_all_active_levels(&design_sparse.design);
     let (ct_sparse, diag_sparse, _) =
         CrossTab::build_for_pair_with_active(&design_sparse, INTERCEPT_PAIR, &active_sparse)
             .expect("sparse cross tab should build");
@@ -53,7 +53,7 @@ fn test_cross_tab_sparse_accumulation_path() {
     let fa_small: Vec<u32> = fa.iter().map(|&x| x % 100).collect();
     let fb_small: Vec<u32> = fb.iter().map(|&x| x % 100).collect();
     let design_dense = design_of(vec![fa_small.clone(), fb_small.clone()]);
-    let active_dense = design_dense.design.active_levels.clone();
+    let active_dense = find_all_active_levels(&design_dense.design);
     let (_ct_dense, diag_dense, _) =
         CrossTab::build_for_pair_with_active(&design_dense, INTERCEPT_PAIR, &active_dense)
             .expect("dense cross tab should build");
@@ -120,7 +120,7 @@ fn test_extract_component_two_components() {
     let fa = vec![0u32, 0, 1, 1, 2, 2, 3, 3];
     let fb = vec![0u32, 1, 0, 1, 2, 3, 2, 3];
     let design = design_of(vec![fa, fb]);
-    let all_active = design.design.active_levels.clone();
+    let all_active = find_all_active_levels(&design.design);
     let (ct, parent_diag, _) =
         CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
@@ -232,7 +232,7 @@ proptest! {
         }
 
         let design = design_of(vec![fa, fb]);
-        let all_active = design.design.active_levels.clone();
+        let all_active = find_all_active_levels(&design.design);
         let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
@@ -277,13 +277,13 @@ proptest! {
 }
 
 #[test]
-fn active_levels_mark_gaps() {
+fn test_find_all_active_levels_with_gaps() {
     // Factor 0 has 5 levels but only 0, 2, 4 appear; factor 1 uses all 3.
     let fa = vec![0u32, 2, 4, 0, 2, 4];
     let fb = vec![0u32, 1, 2, 0, 1, 2];
     let design = design_of(vec![fa, fb]);
 
-    let active = design.design.active_levels.clone();
+    let active = find_all_active_levels(&design.design);
 
     // Factor 0: 5 levels, only 0, 2, 4 active.
     assert_eq!(active[0].len(), 5, "factor 0 should have 5 levels");
@@ -317,7 +317,7 @@ fn dense_and_sparse_paths_agree_on_signed_data() {
         rows: Channel { term: 0, column: 1 },
         cols: Channel { term: 1, column: 0 },
     };
-    let all_active = design.active_levels.clone();
+    let all_active = find_all_active_levels(&design);
     let active = build_compact_mapping(
         &all_active[0],
         &all_active[1],

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -6,7 +6,6 @@ use super::accumulate::{
 use super::{build_compact_mapping, CrossTab};
 use crate::channel::{Channel, ChannelPair};
 use crate::csr_block::CsrBlock;
-use crate::domain::find_all_active_levels;
 use crate::domain::{Design, Effect, PreparedDesign};
 use crate::observation::ObservationFrame;
 
@@ -45,7 +44,7 @@ fn test_cross_tab_sparse_accumulation_path() {
 
     // Sparse path (large level counts)
     let design_sparse = design_of(vec![fa.clone(), fb.clone()]);
-    let active_sparse = find_all_active_levels(&design_sparse.design);
+    let active_sparse = design_sparse.design.active_levels.clone();
     let (ct_sparse, diag_sparse, _) =
         CrossTab::build_for_pair_with_active(&design_sparse, INTERCEPT_PAIR, &active_sparse)
             .expect("sparse cross tab should build");
@@ -54,7 +53,7 @@ fn test_cross_tab_sparse_accumulation_path() {
     let fa_small: Vec<u32> = fa.iter().map(|&x| x % 100).collect();
     let fb_small: Vec<u32> = fb.iter().map(|&x| x % 100).collect();
     let design_dense = design_of(vec![fa_small.clone(), fb_small.clone()]);
-    let active_dense = find_all_active_levels(&design_dense.design);
+    let active_dense = design_dense.design.active_levels.clone();
     let (_ct_dense, diag_dense, _) =
         CrossTab::build_for_pair_with_active(&design_dense, INTERCEPT_PAIR, &active_dense)
             .expect("dense cross tab should build");
@@ -121,7 +120,7 @@ fn test_extract_component_two_components() {
     let fa = vec![0u32, 0, 1, 1, 2, 2, 3, 3];
     let fb = vec![0u32, 1, 0, 1, 2, 3, 2, 3];
     let design = design_of(vec![fa, fb]);
-    let all_active = find_all_active_levels(&design.design);
+    let all_active = design.design.active_levels.clone();
     let (ct, parent_diag, _) =
         CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
@@ -233,7 +232,7 @@ proptest! {
         }
 
         let design = design_of(vec![fa, fb]);
-        let all_active = find_all_active_levels(&design.design);
+        let all_active = design.design.active_levels.clone();
         let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
@@ -278,13 +277,13 @@ proptest! {
 }
 
 #[test]
-fn test_find_all_active_levels_with_gaps() {
+fn active_levels_mark_gaps() {
     // Factor 0 has 5 levels but only 0, 2, 4 appear; factor 1 uses all 3.
     let fa = vec![0u32, 2, 4, 0, 2, 4];
     let fb = vec![0u32, 1, 2, 0, 1, 2];
     let design = design_of(vec![fa, fb]);
 
-    let active = find_all_active_levels(&design.design);
+    let active = design.design.active_levels.clone();
 
     // Factor 0: 5 levels, only 0, 2, 4 active.
     assert_eq!(active[0].len(), 5, "factor 0 should have 5 levels");
@@ -318,7 +317,7 @@ fn dense_and_sparse_paths_agree_on_signed_data() {
         rows: Channel { term: 0, column: 1 },
         cols: Channel { term: 1, column: 0 },
     };
-    let all_active = find_all_active_levels(&design);
+    let all_active = design.active_levels.clone();
     let active = build_compact_mapping(
         &all_active[0],
         &all_active[1],

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -12,7 +12,7 @@ use crate::channel::{Channel, ChannelPair};
 use crate::config::LocalSolverConfig;
 use crate::{BuildError, BuildWarning};
 
-use super::{find_all_active_levels, BlockDiagonals, CrossTab, Design};
+use super::{find_all_active_levels, BlockDiagonals, CrossTab, PreparedDesign};
 
 mod sddm;
 use crate::domain::Loading;
@@ -34,11 +34,12 @@ pub(crate) struct LocalDomain {
 
 /// Same-factor channel pairs are exactly orthogonal after whitening, so never enumerated.
 pub(crate) fn build_local_domains(
-    design: &Design<'_>,
-    weights: Option<&[f64]>,
+    prepared: &PreparedDesign<'_>,
     config: &LocalSolverConfig,
 ) -> Result<(Vec<LocalDomain>, Vec<BuildWarning>), BuildError> {
     use rayon::prelude::*;
+
+    let design = &prepared.design;
 
     if !config.ridge.is_finite() || config.ridge < 0.0 {
         return Err(BuildError::InvalidRidge {
@@ -65,7 +66,7 @@ pub(crate) fn build_local_domains(
         .par_iter()
         .map(|&pair| {
             let Some((full_ct, full_diag, l2g)) =
-                CrossTab::build_for_pair_with_active(design, weights, pair, &all_active)
+                CrossTab::build_for_pair_with_active(prepared, pair, &all_active)
             else {
                 return Ok((Vec::new(), Vec::new()));
             };
@@ -205,11 +206,11 @@ fn compute_partition_weights(domain_pairs: &mut [LocalDomain], n_dofs: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::Design;
+    use crate::domain::{Design, PreparedDesign};
     use crate::observation::ObservationFrame;
     use crate::Effect;
 
-    fn make_test_design() -> Design<'static> {
+    fn make_test_design() -> PreparedDesign<'static> {
         let frame = ObservationFrame::new(
             vec![
                 vec![0u32, 1, 2, 0, 1, 2].into(),
@@ -219,14 +220,14 @@ mod tests {
             Vec::new(),
         )
         .expect("valid frame");
-        Design::from_frame(frame).expect("valid test design")
+        PreparedDesign::unweighted_for_test(Design::from_frame(frame).expect("valid test design"))
     }
 
     #[test]
     fn test_full_cover_domain_count() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
+        let (domain_pairs, _) =
+            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
         // 3 factor pairs; each pair may produce multiple components
         assert!(domain_pairs.len() >= 3);
     }
@@ -234,9 +235,9 @@ mod tests {
     #[test]
     fn test_partition_of_unity() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
-        let n_dofs = dm.n_dofs;
+        let (domain_pairs, _) =
+            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
+        let n_dofs = dm.design.n_dofs;
         // Two-sided PoU: squared weights must sum to 1 at every DOF.
         let mut weight_sq_sum = vec![0.0; n_dofs];
         for ld in &domain_pairs {
@@ -265,8 +266,10 @@ mod tests {
             Effect::new(&levels_c, true, []).expect("effect c"),
         ])
         .expect("valid slope design");
+        let n_dofs = design.n_dofs;
+        let design = PreparedDesign::with_caller_loadings_for_test(design);
 
-        let (domain_pairs, _) = build_local_domains(&design, None, &LocalSolverConfig::default())
+        let (domain_pairs, _) = build_local_domains(&design, &LocalSolverConfig::default())
             .expect("slope domains build");
 
         for ld in &domain_pairs {
@@ -280,7 +283,7 @@ mod tests {
         }
 
         // Non-vacuity: without a shared DOF, uniform vs 1/√c weights are indistinguishable.
-        let mut counts = vec![0u32; design.n_dofs];
+        let mut counts = vec![0u32; n_dofs];
         for ld in &domain_pairs {
             for &idx in ld.core.global_indices() {
                 counts[idx as usize] += 1;
@@ -295,9 +298,9 @@ mod tests {
     #[test]
     fn test_domains_cover_all_dofs() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
-        let mut covered = vec![false; dm.n_dofs];
+        let (domain_pairs, _) =
+            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
+        let mut covered = vec![false; dm.design.n_dofs];
         for ld in &domain_pairs {
             for &idx in ld.core.global_indices() {
                 covered[idx as usize] = true;

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -12,7 +12,7 @@ use crate::channel::{Channel, ChannelPair};
 use crate::config::LocalSolverConfig;
 use crate::{BuildError, BuildWarning};
 
-use super::{find_all_active_levels, BlockDiagonals, CrossTab, PreparedDesign};
+use super::{BlockDiagonals, CrossTab, PreparedDesign};
 
 mod sddm;
 use crate::domain::Loading;
@@ -60,13 +60,12 @@ pub(crate) fn build_local_domains(
                 .map(move |&cols| ChannelPair { rows, cols })
         })
         .collect();
-    let all_active = find_all_active_levels(design);
 
     let per_pair: Vec<(Vec<LocalDomain>, Vec<BuildWarning>)> = pairs
         .par_iter()
         .map(|&pair| {
             let Some((full_ct, full_diag, l2g)) =
-                CrossTab::build_for_pair_with_active(prepared, pair, &all_active)
+                CrossTab::build_for_pair_with_active(prepared, pair, &design.active_levels)
             else {
                 return Ok((Vec::new(), Vec::new()));
             };

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -12,7 +12,7 @@ use crate::channel::{Channel, ChannelPair};
 use crate::config::LocalSolverConfig;
 use crate::{BuildError, BuildWarning};
 
-use super::{BlockDiagonals, CrossTab, PreparedDesign};
+use super::{find_all_active_levels, BlockDiagonals, CrossTab, PreparedDesign};
 
 mod sddm;
 use crate::domain::Loading;
@@ -61,11 +61,12 @@ pub(crate) fn build_local_domains(
         })
         .collect();
 
+    let all_active = find_all_active_levels(design);
     let per_pair: Vec<(Vec<LocalDomain>, Vec<BuildWarning>)> = pairs
         .par_iter()
         .map(|&pair| {
             let Some((full_ct, full_diag, l2g)) =
-                CrossTab::build_for_pair_with_active(prepared, pair, &design.active_levels)
+                CrossTab::build_for_pair_with_active(prepared, pair, &all_active)
             else {
                 return Ok((Vec::new(), Vec::new()));
             };
@@ -266,7 +267,7 @@ mod tests {
         ])
         .expect("valid slope design");
         let n_dofs = design.n_dofs;
-        let design = PreparedDesign::with_caller_loadings_for_test(design);
+        let design = PreparedDesign::unweighted_for_test(design);
 
         let (domain_pairs, _) = build_local_domains(&design, &LocalSolverConfig::default())
             .expect("slope domains build");

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -2,7 +2,7 @@
 
 use rayon::prelude::*;
 
-use super::Design;
+use super::{Design, TermMeta};
 
 /// Relative rank tolerance: a slope direction drops once its remaining
 /// within-level variance falls to `RANK_TOL` × its own initial variance.
@@ -14,11 +14,7 @@ pub(crate) struct TermMoments(Vec<LevelMoments>);
 impl TermMoments {
     /// `None` when no term carries a covariate, so nothing downstream has work.
     pub(crate) fn build(design: &Design<'_>, weights: Option<&[f64]>) -> Option<Self> {
-        let has_slopes = design
-            .terms
-            .iter()
-            .any(|t| t.columns.iter().any(|c| c.covariate().is_some()));
-        has_slopes.then(|| {
+        design.terms.iter().any(TermMeta::has_slopes).then(|| {
             Self(
                 (0..design.terms.len())
                     .into_par_iter()
@@ -61,14 +57,10 @@ fn tri_len(v: usize) -> usize {
 impl LevelMoments {
     fn build(design: &Design<'_>, term: usize, weights: Option<&[f64]>) -> Self {
         let meta = &design.terms[term];
-        let covariates: Box<[u32]> = meta
-            .columns
-            .iter()
-            .filter_map(|c| c.covariate().copied())
-            .collect();
+        let covariates: Box<[u32]> = meta.covariates().collect();
         let v = covariates.len();
         let mut moments = Self {
-            intercept: v < meta.columns.len(),
+            intercept: meta.has_intercept(),
             w_sum: vec![0.0; meta.n_levels()],
             mean: vec![0.0; meta.n_levels() * v],
             comoment: vec![0.0; meta.n_levels() * tri_len(v)],

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -1,5 +1,4 @@
-//! Per-level weighted moments of a term's loading columns, built once and read
-//! by both the collinearity screen and the slope whitening.
+//! Per-level weighted moments of a term's loading columns, the input to slope whitening.
 
 use rayon::prelude::*;
 
@@ -120,14 +119,6 @@ impl LevelMoments {
     /// Frame columns of the term's covariates, in coefficient-column order.
     pub(crate) fn covariates(&self) -> &[u32] {
         &self.covariates
-    }
-
-    pub(crate) fn intercept(&self) -> bool {
-        self.intercept
-    }
-
-    pub(crate) fn n_levels(&self) -> usize {
-        self.w_sum.len()
     }
 
     pub(crate) fn w_sum(&self, level: usize) -> f64 {

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -6,9 +6,7 @@ use super::collinearity::detect_collinear_slopes;
 use super::{Design, SlopeBasis};
 use crate::{BuildError, BuildWarning};
 
-/// A [`Design`] plus everything one weight vector determines about it: the
-/// weights in internal observation order, the slope basis the solve runs in,
-/// and the screening warnings. Solvers on the same weights share one.
+/// A [`Design`] plus everything one weight vector determines: weights, slope basis, screening.
 pub(crate) struct PreparedDesign<'a> {
     pub(crate) design: Arc<Design<'a>>,
     /// Raw weights in internal observation order; `None` is unweighted.
@@ -46,8 +44,7 @@ mod tests {
     use super::*;
 
     impl<'a> PreparedDesign<'a> {
-        /// Unweighted, on the caller's own loading columns; see
-        /// [`SlopeBasis::with_caller_loadings_for_test`].
+        /// Unweighted, on the caller's own loading columns.
         pub(crate) fn with_caller_loadings_for_test(design: Design<'a>) -> Self {
             let basis = SlopeBasis::with_caller_loadings_for_test(&design);
             Self {

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -1,0 +1,66 @@
+//! A design fixed to one weight vector: the state every solve on it shares.
+
+use std::sync::Arc;
+
+use super::collinearity::detect_collinear_slopes;
+use super::{Design, SlopeBasis};
+use crate::{BuildError, BuildWarning};
+
+/// A [`Design`] plus everything one weight vector determines about it: the
+/// weights in internal observation order, the slope basis the solve runs in,
+/// and the screening warnings. Solvers on the same weights share one.
+pub(crate) struct PreparedDesign<'a> {
+    pub(crate) design: Arc<Design<'a>>,
+    /// Raw weights in internal observation order; `None` is unweighted.
+    pub(crate) weights: Option<Vec<f64>>,
+    pub(crate) basis: SlopeBasis,
+    pub(crate) warnings: Vec<BuildWarning>,
+}
+
+impl<'a> PreparedDesign<'a> {
+    pub(crate) fn new(
+        design: Arc<Design<'a>>,
+        weights: Option<Vec<f64>>,
+    ) -> Result<Self, BuildError> {
+        let weights = design.permute_weights(weights)?;
+        let basis = SlopeBasis::build(&design, weights.as_deref());
+        let warnings = detect_collinear_slopes(&design, weights.as_deref(), &basis);
+        Ok(Self {
+            design,
+            weights,
+            basis,
+            warnings,
+        })
+    }
+
+    /// `W^{1/2}` in internal observation order, the operator's row scaling.
+    pub(crate) fn sqrt_weights(&self) -> Option<Vec<f64>> {
+        self.weights
+            .as_ref()
+            .map(|w| w.iter().map(|wi| wi.sqrt()).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl<'a> PreparedDesign<'a> {
+        /// Unweighted, on the caller's own loading columns; see
+        /// [`SlopeBasis::with_caller_loadings_for_test`].
+        pub(crate) fn with_caller_loadings_for_test(design: Design<'a>) -> Self {
+            let basis = SlopeBasis::with_caller_loadings_for_test(&design);
+            Self {
+                design: Arc::new(design),
+                weights: None,
+                basis,
+                warnings: Vec::new(),
+            }
+        }
+
+        /// Unweighted, whitened like a solver would.
+        pub(crate) fn unweighted_for_test(design: Design<'a>) -> Self {
+            Self::new(Arc::new(design), None).expect("unweighted preparation cannot fail")
+        }
+    }
+}

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -1,33 +1,24 @@
 //! A design fixed to one weight vector: the state every solve on it shares.
 
-use std::sync::Arc;
-
-use super::collinearity::detect_collinear_slopes;
 use super::{Design, SlopeBasis};
-use crate::{BuildError, BuildWarning};
+use crate::BuildError;
 
-/// A [`Design`] plus everything one weight vector determines: weights, slope basis, screening.
+/// A [`Design`] plus what one weight vector determines: the weights and the slope basis.
 pub(crate) struct PreparedDesign<'a> {
-    pub(crate) design: Arc<Design<'a>>,
+    pub(crate) design: Design<'a>,
     /// Raw weights in internal observation order; `None` is unweighted.
     pub(crate) weights: Option<Vec<f64>>,
     pub(crate) basis: SlopeBasis,
-    pub(crate) warnings: Vec<BuildWarning>,
 }
 
 impl<'a> PreparedDesign<'a> {
-    pub(crate) fn new(
-        design: Arc<Design<'a>>,
-        weights: Option<Vec<f64>>,
-    ) -> Result<Self, BuildError> {
+    pub(crate) fn new(design: Design<'a>, weights: Option<Vec<f64>>) -> Result<Self, BuildError> {
         let weights = design.permute_weights(weights)?;
         let basis = SlopeBasis::build(&design, weights.as_deref());
-        let warnings = detect_collinear_slopes(&design, weights.as_deref(), &basis);
         Ok(Self {
             design,
             weights,
             basis,
-            warnings,
         })
     }
 
@@ -48,16 +39,15 @@ mod tests {
         pub(crate) fn with_caller_loadings_for_test(design: Design<'a>) -> Self {
             let basis = SlopeBasis::with_caller_loadings_for_test(&design);
             Self {
-                design: Arc::new(design),
+                design,
                 weights: None,
                 basis,
-                warnings: Vec::new(),
             }
         }
 
         /// Unweighted, whitened like a solver would.
         pub(crate) fn unweighted_for_test(design: Design<'a>) -> Self {
-            Self::new(Arc::new(design), None).expect("unweighted preparation cannot fail")
+            Self::new(design, None).expect("unweighted preparation cannot fail")
         }
     }
 }

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -8,6 +8,8 @@ pub(crate) struct PreparedDesign<'a> {
     pub(crate) design: Design<'a>,
     /// Raw weights in internal observation order; `None` is unweighted.
     pub(crate) weights: Option<Vec<f64>>,
+    /// `W^{1/2}`, the operator's row scaling; kept beside `weights` since `s·s` is not bitwise `w`.
+    pub(crate) sqrt_weights: Option<Vec<f64>>,
     pub(crate) basis: SlopeBasis,
 }
 
@@ -15,18 +17,15 @@ impl<'a> PreparedDesign<'a> {
     pub(crate) fn new(design: Design<'a>, weights: Option<Vec<f64>>) -> Result<Self, BuildError> {
         let weights = design.permute_weights(weights)?;
         let basis = SlopeBasis::build(&design, weights.as_deref());
+        let sqrt_weights = weights
+            .as_ref()
+            .map(|w| w.iter().map(|wi| wi.sqrt()).collect());
         Ok(Self {
             design,
             weights,
+            sqrt_weights,
             basis,
         })
-    }
-
-    /// `W^{1/2}` in internal observation order, the operator's row scaling.
-    pub(crate) fn sqrt_weights(&self) -> Option<Vec<f64>> {
-        self.weights
-            .as_ref()
-            .map(|w| w.iter().map(|wi| wi.sqrt()).collect())
     }
 }
 
@@ -35,19 +34,15 @@ mod tests {
     use super::*;
 
     impl<'a> PreparedDesign<'a> {
-        /// Unweighted, on the caller's own loading columns.
-        pub(crate) fn with_caller_loadings_for_test(design: Design<'a>) -> Self {
-            let basis = SlopeBasis::with_caller_loadings_for_test(&design);
-            Self {
-                design,
-                weights: None,
-                basis,
-            }
-        }
-
         /// Unweighted, whitened like a solver would.
         pub(crate) fn unweighted_for_test(design: Design<'a>) -> Self {
             Self::new(design, None).expect("unweighted preparation cannot fail")
+        }
+    }
+
+    impl PreparedDesign<'static> {
+        pub(crate) fn from_levels_for_test(columns: Vec<Vec<u32>>) -> Self {
+            Self::unweighted_for_test(Design::from_levels_for_test(columns))
         }
     }
 }

--- a/crates/within/src/domain/slope_basis.rs
+++ b/crates/within/src/domain/slope_basis.rs
@@ -42,14 +42,7 @@ impl SlopeBasis {
         let mut terms = Vec::new();
         let mut unidentified = Vec::new();
         if let Some(moments) = TermMoments::build(design, weights) {
-            for term in 0..design.terms.len() {
-                if !design.terms[term]
-                    .columns
-                    .iter()
-                    .any(|c| c.covariate().is_some())
-                {
-                    continue;
-                }
+            for term in (0..design.terms.len()).filter(|&t| design.terms[t].has_slopes()) {
                 terms.push(TermBasis::build(
                     design,
                     term,

--- a/crates/within/src/domain/slope_basis.rs
+++ b/crates/within/src/domain/slope_basis.rs
@@ -8,11 +8,7 @@ use crate::linalg::dot;
 #[cfg(test)]
 mod tests;
 
-/// Per-level change of basis making each slope-bearing term's within-level
-/// Gram the identity, holding every loading column in that basis;
-/// [`Self::back_transform`] restores the user's parametrization. Unidentified
-/// directions become exact-zero columns, so the minimal-norm solve leaves
-/// exact-`0` coefficients. A slope-free design gets an empty basis.
+/// Per-level basis making each slope term's within-level Gram the identity; empty without slopes.
 pub(crate) struct SlopeBasis {
     terms: Vec<TermBasis>,
     /// The frame's loading columns in the solve basis, indexed like the frame's.
@@ -86,8 +82,7 @@ impl SlopeBasis {
 }
 
 impl TermBasis {
-    /// Whiten one term's loading columns into `loadings`, appending its unidentified
-    /// directions ascending in `(level, column)`.
+    /// Whiten one term into `loadings`; unidentified directions append ascending in `(level, column)`.
     fn build(
         design: &Design<'_>,
         term: usize,

--- a/crates/within/src/domain/slope_basis.rs
+++ b/crates/within/src/domain/slope_basis.rs
@@ -1,26 +1,28 @@
-//! Within-level reparametrization of a design's varying-slope terms.
+//! Within-level orthonormal basis of a design's varying-slope terms.
 
-use crate::domain::level_moments::{BasisScratch, TermMoments};
-use crate::domain::Design;
-
-use super::CoefficientPosition;
-use crate::channel::Channel;
+use super::level_moments::{BasisScratch, TermMoments};
+use super::Design;
+use crate::channel::{Channel, CoefficientPosition};
 use crate::linalg::dot;
 
 #[cfg(test)]
 mod tests;
 
 /// Per-level change of basis making each slope-bearing term's within-level
-/// Gram the identity; [`Self::back_transform`] restores the user's
-/// parametrization.
-pub(crate) struct SlopeReparam {
-    terms: Vec<TermReparam>,
+/// Gram the identity, holding every loading column in that basis;
+/// [`Self::back_transform`] restores the user's parametrization. Unidentified
+/// directions become exact-zero columns, so the minimal-norm solve leaves
+/// exact-`0` coefficients. A slope-free design gets an empty basis.
+pub(crate) struct SlopeBasis {
+    terms: Vec<TermBasis>,
+    /// The frame's loading columns in the solve basis, indexed like the frame's.
+    loadings: Vec<Vec<f64>>,
     /// Directions the data cannot identify, ascending in `(term, level, column)`.
-    pub(super) unidentified: Vec<CoefficientPosition>,
+    pub(crate) unidentified: Vec<CoefficientPosition>,
 }
 
 /// One slope-bearing term's whitening state.
-struct TermReparam {
+struct TermBasis {
     offset: usize,
     n_levels: usize,
     /// Coefficient column of the term's constant, if it has one.
@@ -38,28 +40,41 @@ struct LevelTransform {
     center: Box<[f64]>,
 }
 
-impl SlopeReparam {
-    /// Orthonormalize every slope-bearing term's loading columns in place;
-    /// `None` for slope-free designs. Unidentified directions become
-    /// exact-zero columns, so the minimal-norm solve leaves exact-`0`
-    /// coefficients.
-    pub(crate) fn build(design: &mut Design<'_>, moments: &TermMoments) -> Option<Self> {
+impl SlopeBasis {
+    pub(crate) fn build(design: &Design<'_>, weights: Option<&[f64]>) -> Self {
+        let mut loadings = vec![Vec::new(); design.n_loading_columns()];
         let mut terms = Vec::new();
         let mut unidentified = Vec::new();
-        for term in 0..design.terms.len() {
-            if !design.terms[term]
-                .columns
-                .iter()
-                .any(|c| c.covariate().is_some())
-            {
-                continue;
+        if let Some(moments) = TermMoments::build(design, weights) {
+            for term in 0..design.terms.len() {
+                if !design.terms[term]
+                    .columns
+                    .iter()
+                    .any(|c| c.covariate().is_some())
+                {
+                    continue;
+                }
+                terms.push(TermBasis::build(
+                    design,
+                    term,
+                    &moments,
+                    &mut loadings,
+                    &mut unidentified,
+                ));
             }
-            terms.push(TermReparam::build(design, term, moments, &mut unidentified));
         }
-        (!terms.is_empty()).then_some(Self {
+        // `Design::new` claims every loading column, so whitening leaves none unwritten.
+        debug_assert!(loadings.iter().all(|l| l.len() == design.n_obs));
+        Self {
             terms,
+            loadings,
             unidentified,
-        })
+        }
+    }
+
+    /// Loading column `column` in the solve basis.
+    pub(crate) fn loading_column(&self, column: usize) -> &[f64] {
+        &self.loadings[column]
     }
 
     /// Map solve-basis coefficients back to the user's parametrization.
@@ -70,13 +85,14 @@ impl SlopeReparam {
     }
 }
 
-impl TermReparam {
-    /// Whiten one term's loading columns in place, appending its unidentified
+impl TermBasis {
+    /// Whiten one term's loading columns into `loadings`, appending its unidentified
     /// directions ascending in `(level, column)`.
     fn build(
-        design: &mut Design<'_>,
+        design: &Design<'_>,
         term: usize,
         moments: &TermMoments,
+        loadings: &mut [Vec<f64>],
         unidentified: &mut Vec<CoefficientPosition>,
     ) -> Self {
         let meta = &design.terms[term];
@@ -141,7 +157,7 @@ impl TermReparam {
             }
         }
         for (out, &c) in u_cols.into_iter().zip(&z_cols) {
-            design.replace_loading_column(c, out);
+            loadings[c] = out;
         }
 
         Self {

--- a/crates/within/src/domain/slope_basis/tests.rs
+++ b/crates/within/src/domain/slope_basis/tests.rs
@@ -7,8 +7,7 @@ use crate::domain::Effect;
 use super::*;
 
 impl SlopeBasis {
-    /// The caller's own loading columns, for tests that drive a consumer
-    /// without the whitening a solver always runs.
+    /// The caller's own loading columns, unwhitened.
     pub(crate) fn with_caller_loadings_for_test(design: &Design<'_>) -> Self {
         Self {
             terms: Vec::new(),

--- a/crates/within/src/domain/slope_basis/tests.rs
+++ b/crates/within/src/domain/slope_basis/tests.rs
@@ -6,19 +6,6 @@ use crate::domain::Effect;
 
 use super::*;
 
-impl SlopeBasis {
-    /// The caller's own loading columns, unwhitened.
-    pub(crate) fn with_caller_loadings_for_test(design: &Design<'_>) -> Self {
-        Self {
-            terms: Vec::new(),
-            loadings: (0..design.n_loading_columns())
-                .map(|c| design.loading_column(c).to_vec())
-                .collect(),
-            unidentified: Vec::new(),
-        }
-    }
-}
-
 const F0: [u32; 6] = [0, 0, 0, 1, 1, 1];
 const Z0: [f64; 6] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
 const Z1: [f64; 6] = [1.0, 4.0, 9.0, 16.0, 25.0, 36.0];

--- a/crates/within/src/domain/slope_basis/tests.rs
+++ b/crates/within/src/domain/slope_basis/tests.rs
@@ -2,10 +2,23 @@
 //! not reachable through the public API.
 
 use crate::channel::Channel;
-use crate::domain::level_moments::TermMoments;
 use crate::domain::Effect;
 
 use super::*;
+
+impl SlopeBasis {
+    /// The caller's own loading columns, for tests that drive a consumer
+    /// without the whitening a solver always runs.
+    pub(crate) fn with_caller_loadings_for_test(design: &Design<'_>) -> Self {
+        Self {
+            terms: Vec::new(),
+            loadings: (0..design.n_loading_columns())
+                .map(|c| design.loading_column(c).to_vec())
+                .collect(),
+            unidentified: Vec::new(),
+        }
+    }
+}
 
 const F0: [u32; 6] = [0, 0, 0, 1, 1, 1];
 const Z0: [f64; 6] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
@@ -26,10 +39,9 @@ fn three_term_effects() -> Vec<Effect<'static>> {
 
 #[test]
 fn build_whitens_each_slope_bearing_term() {
-    let mut design = Design::new(three_term_effects()).unwrap();
-    let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
-    assert!(rp.unidentified.is_empty());
+    let design = Design::new(three_term_effects()).unwrap();
+    let basis = SlopeBasis::build(&design, None);
+    assert!(basis.unidentified.is_empty());
 
     for term in [0, 2] {
         let meta = &design.terms[term];
@@ -38,7 +50,7 @@ fn build_whitens_each_slope_bearing_term() {
             .columns
             .iter()
             .filter_map(|c| c.covariate())
-            .map(|&k| design.loading_column(k as usize))
+            .map(|&k| basis.loading_column(k as usize))
             .collect();
         for level in 0..meta.n_levels() {
             let obs: Vec<usize> = (0..levels.len())
@@ -61,6 +73,15 @@ fn build_whitens_each_slope_bearing_term() {
 }
 
 #[test]
+fn slope_free_design_gets_an_empty_basis() {
+    let design = Design::from_levels_for_test(vec![vec![0, 1, 0], vec![0, 0, 1]]);
+    let basis = SlopeBasis::build(&design, None);
+    assert!(basis.terms.is_empty());
+    assert!(basis.loadings.is_empty());
+    assert!(basis.unidentified.is_empty());
+}
+
+#[test]
 fn unidentified_directions_ascend_across_terms() {
     // Index-order term iteration keeps the list ascending without any sort.
     let f0 = [0u32, 0, 1, 1, 2, 2];
@@ -71,11 +92,10 @@ fn unidentified_directions_ascend_across_terms() {
         Effect::new(&f0, true, [&z0[..]]).unwrap(),
         Effect::new(&f1, true, [&z1[..]]).unwrap(),
     ];
-    let mut design = Design::new(effects).unwrap();
-    let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
+    let design = Design::new(effects).unwrap();
+    let basis = SlopeBasis::build(&design, None);
     assert_eq!(
-        rp.unidentified,
+        basis.unidentified,
         vec![
             CoefficientPosition {
                 channel: Channel { term: 0, column: 1 },
@@ -91,13 +111,12 @@ fn unidentified_directions_ascend_across_terms() {
 
 #[test]
 fn back_transform_leaves_other_terms_untouched() {
-    let mut design = Design::new(three_term_effects()).unwrap();
-    let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
+    let design = Design::new(three_term_effects()).unwrap();
+    let basis = SlopeBasis::build(&design, None);
 
     let mut x: Vec<f64> = (0..design.n_dofs).map(|i| 1.0 + i as f64).collect();
     let before = x.clone();
-    rp.back_transform(&mut x);
+    basis.back_transform(&mut x);
 
     // Plain term 1 sits between the two slope-bearing blocks.
     let (t1, t2) = (design.terms[1].offset, design.terms[2].offset);

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -37,7 +37,7 @@ pub(crate) mod linalg;
 pub(crate) mod operator;
 pub(crate) mod solver;
 
-pub use channel::{Channel, ChannelPair};
+pub use channel::{Channel, ChannelPair, CoefficientAddress};
 pub use config::{
     ApproxCholConfig, ApproxSchurConfig, LocalSolverConfig, LsmrOptions, PreconditionerConfig,
     ReductionStrategy, ScalingConfig, ScalingFailure, SchurMode,
@@ -46,6 +46,6 @@ pub use domain::{Design, Effect};
 pub use error::{BuildError, BuildWarning, SolveError, WithinError};
 pub use operator::schwarz::Preconditioner;
 pub use solver::{
-    solve, solve_batch, BatchSolveResult, CoefficientAddress, CoefficientLayout, IntoDesign,
-    PreconditionerInput, SolveResult, Solver,
+    solve, solve_batch, BatchSolveResult, CoefficientLayout, IntoDesign, PreconditionerInput,
+    SolveResult, Solver,
 };

--- a/crates/within/src/observation.rs
+++ b/crates/within/src/observation.rs
@@ -59,6 +59,10 @@ impl<'a> ObservationFrame<'a> {
         self.categorical.len()
     }
 
+    pub(crate) fn n_loading_columns(&self) -> usize {
+        self.continuous.len()
+    }
+
     /// Level codes of factor `factor`.
     pub fn level_column(&self, factor: usize) -> &[u32] {
         &self.categorical[factor]
@@ -67,12 +71,6 @@ impl<'a> ObservationFrame<'a> {
     /// Loadings of continuous column `k`.
     pub fn loading_column(&self, k: usize) -> &[f64] {
         &self.continuous[k]
-    }
-
-    /// Replace loading column `i` with an owned column of matching row count.
-    pub(crate) fn set_loading_column(&mut self, i: usize, column: Vec<f64>) {
-        debug_assert_eq!(column.len(), self.n_obs);
-        self.continuous[i] = Cow::Owned(column);
     }
 
     /// Convert every column to owned, dropping ties to caller buffers.

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use portable_atomic::AtomicF64;
 use schwarz_precond::Operator;
 
-use crate::domain::Design;
+use crate::domain::PreparedDesign;
 
 mod gather;
 mod scatter;
@@ -21,7 +21,7 @@ const PAR_THRESHOLD: usize = 10_000;
 
 /// Design operator `D` or `W^{1/2} D`, whose normal equations `AᵀA = DᵀWD` recover the Gramian.
 pub(crate) struct DesignOperator<'a> {
-    design: &'a Design<'a>,
+    prepared: &'a PreparedDesign<'a>,
     sqrt_weights: Option<&'a [f64]>,
     /// Sized once to the largest term's block, so it allocates per operator, not per iteration.
     scatter_scratch: Vec<AtomicF64>,
@@ -32,7 +32,8 @@ pub(crate) struct DesignOperator<'a> {
 
 impl<'a> DesignOperator<'a> {
     /// `sqrt_weights` must be pre-square-rooted and `design.n_obs` long.
-    pub(crate) fn new(design: &'a Design<'a>, sqrt_weights: Option<&'a [f64]>) -> Self {
+    pub(crate) fn new(prepared: &'a PreparedDesign<'a>, sqrt_weights: Option<&'a [f64]>) -> Self {
+        let design = &prepared.design;
         if let Some(sw) = sqrt_weights {
             assert_eq!(
                 sw.len(),
@@ -44,7 +45,7 @@ impl<'a> DesignOperator<'a> {
         }
         let max_block = design.terms.iter().map(|t| t.n_dofs()).max().unwrap_or(0);
         Self {
-            design,
+            prepared,
             sqrt_weights,
             scatter_scratch: (0..max_block).map(|_| AtomicF64::new(0.0)).collect(),
             #[cfg(debug_assertions)]
@@ -87,30 +88,30 @@ impl Drop for ReentryGuard<'_> {
 
 impl Operator for DesignOperator<'_> {
     fn nrows(&self) -> usize {
-        self.design.n_obs
+        self.prepared.design.n_obs
     }
 
     fn ncols(&self) -> usize {
-        self.design.n_dofs
+        self.prepared.design.n_dofs
     }
 
     fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
-        debug_assert_eq!(x.len(), self.design.n_dofs);
-        debug_assert_eq!(y.len(), self.design.n_obs);
-        gather_apply(self.design, x, y, self.sqrt_weights);
+        debug_assert_eq!(x.len(), self.ncols());
+        debug_assert_eq!(y.len(), self.nrows());
+        gather_apply(self.prepared, x, y, self.sqrt_weights);
         Ok(())
     }
 
     fn apply_adjoint(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
         #[cfg(debug_assertions)]
         let _guard = ReentryGuard::acquire(&self.adjoint_active);
-        debug_assert_eq!(x.len(), self.design.n_obs);
-        debug_assert_eq!(y.len(), self.design.n_dofs);
+        debug_assert_eq!(x.len(), self.nrows());
+        debug_assert_eq!(y.len(), self.ncols());
         y.fill(0.0);
         // No lock needed: `solve_batch` builds one operator per RHS, so calls are sequential.
         match self.sqrt_weights {
-            Some(sw) => scatter_apply(self.design, &self.scatter_scratch, y, &|i| sw[i] * x[i]),
-            None => scatter_apply(self.design, &self.scatter_scratch, y, &|i| x[i]),
+            Some(sw) => scatter_apply(self.prepared, &self.scatter_scratch, y, &|i| sw[i] * x[i]),
+            None => scatter_apply(self.prepared, &self.scatter_scratch, y, &|i| x[i]),
         }
         Ok(())
     }
@@ -124,29 +125,17 @@ mod reentry_guard_tests {
     use schwarz_precond::Operator;
 
     use super::DesignOperator;
-    use crate::domain::Design;
-    use crate::observation::ObservationFrame;
-
-    fn one_factor_design() -> Design<'static> {
-        let frame = ObservationFrame::new(
-            vec![vec![0u32, 1, 0]].into_iter().map(Into::into).collect(),
-            Vec::new(),
-        )
-        .expect("valid frame");
-        Design::from_frame(frame).expect("valid design")
-    }
+    use crate::domain::{Design, PreparedDesign};
 
     #[test]
     #[should_panic(expected = "concurrently")]
     fn apply_adjoint_detects_in_flight_reentry() {
-        let design = one_factor_design();
-        let op = DesignOperator::new(&design, None);
+        let design = Design::from_levels_for_test(vec![vec![0, 1, 0]]);
+        let prepared = PreparedDesign::unweighted_for_test(design);
+        let op = DesignOperator::new(&prepared, None);
         // Simulate a sibling `apply_adjoint` already in flight on this operator.
         op.adjoint_active.store(true, Ordering::Release);
-        op.apply_adjoint(
-            &vec![0.0; op.design.n_obs],
-            &mut vec![0.0; op.design.n_dofs],
-        )
-        .expect("unreachable: the guard panics before returning");
+        op.apply_adjoint(&vec![0.0; op.nrows()], &mut vec![0.0; op.ncols()])
+            .expect("unreachable: the guard panics before returning");
     }
 }

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -22,7 +22,6 @@ const PAR_THRESHOLD: usize = 10_000;
 /// Design operator `D` or `W^{1/2} D`, whose normal equations `AᵀA = DᵀWD` recover the Gramian.
 pub(crate) struct DesignOperator<'a> {
     prepared: &'a PreparedDesign<'a>,
-    sqrt_weights: Option<&'a [f64]>,
     /// Sized once to the largest term's block, so it allocates per operator, not per iteration.
     scatter_scratch: Vec<AtomicF64>,
     /// Debug-only reentry sentinel: a concurrent `apply_adjoint` would race the scratch writes.
@@ -31,22 +30,11 @@ pub(crate) struct DesignOperator<'a> {
 }
 
 impl<'a> DesignOperator<'a> {
-    /// `sqrt_weights` must be pre-square-rooted and `design.n_obs` long.
-    pub(crate) fn new(prepared: &'a PreparedDesign<'a>, sqrt_weights: Option<&'a [f64]>) -> Self {
+    pub(crate) fn new(prepared: &'a PreparedDesign<'a>) -> Self {
         let design = &prepared.design;
-        if let Some(sw) = sqrt_weights {
-            assert_eq!(
-                sw.len(),
-                design.n_obs,
-                "sqrt-weights length {} does not match design.n_obs {}",
-                sw.len(),
-                design.n_obs
-            );
-        }
         let max_block = design.terms.iter().map(|t| t.n_dofs()).max().unwrap_or(0);
         Self {
             prepared,
-            sqrt_weights,
             scatter_scratch: (0..max_block).map(|_| AtomicF64::new(0.0)).collect(),
             #[cfg(debug_assertions)]
             adjoint_active: AtomicBool::new(false),
@@ -55,7 +43,7 @@ impl<'a> DesignOperator<'a> {
 
     /// Observation-space RHS `b = W^{1/2} y`; borrows unweighted, owns weighted.
     pub(crate) fn weighted_rhs<'y>(&self, y: &'y [f64]) -> Cow<'y, [f64]> {
-        match self.sqrt_weights {
+        match self.prepared.sqrt_weights.as_deref() {
             None => Cow::Borrowed(y),
             Some(sw) => Cow::Owned(y.iter().zip(sw).map(|(&yi, &swi)| swi * yi).collect()),
         }
@@ -98,7 +86,7 @@ impl Operator for DesignOperator<'_> {
     fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
         debug_assert_eq!(x.len(), self.ncols());
         debug_assert_eq!(y.len(), self.nrows());
-        gather_apply(self.prepared, x, y, self.sqrt_weights);
+        gather_apply(self.prepared, x, y, self.prepared.sqrt_weights.as_deref());
         Ok(())
     }
 
@@ -109,7 +97,7 @@ impl Operator for DesignOperator<'_> {
         debug_assert_eq!(y.len(), self.ncols());
         y.fill(0.0);
         // No lock needed: `solve_batch` builds one operator per RHS, so calls are sequential.
-        match self.sqrt_weights {
+        match self.prepared.sqrt_weights.as_deref() {
             Some(sw) => scatter_apply(self.prepared, &self.scatter_scratch, y, &|i| sw[i] * x[i]),
             None => scatter_apply(self.prepared, &self.scatter_scratch, y, &|i| x[i]),
         }
@@ -125,14 +113,13 @@ mod reentry_guard_tests {
     use schwarz_precond::Operator;
 
     use super::DesignOperator;
-    use crate::domain::{Design, PreparedDesign};
+    use crate::domain::PreparedDesign;
 
     #[test]
     #[should_panic(expected = "concurrently")]
     fn apply_adjoint_detects_in_flight_reentry() {
-        let design = Design::from_levels_for_test(vec![vec![0, 1, 0]]);
-        let prepared = PreparedDesign::unweighted_for_test(design);
-        let op = DesignOperator::new(&prepared, None);
+        let prepared = PreparedDesign::from_levels_for_test(vec![vec![0, 1, 0]]);
+        let op = DesignOperator::new(&prepared);
         // Simulate a sibling `apply_adjoint` already in flight on this operator.
         op.adjoint_active.store(true, Ordering::Release);
         op.apply_adjoint(&vec![0.0; op.nrows()], &mut vec![0.0; op.ncols()])

--- a/crates/within/src/operator/design/gather.rs
+++ b/crates/within/src/operator/design/gather.rs
@@ -3,16 +3,17 @@
 use rayon::prelude::*;
 
 use super::PAR_THRESHOLD;
-use crate::domain::Design;
 use crate::domain::Loading;
+use crate::domain::PreparedDesign;
 
 /// Gather-apply `dst[i] = Σ_t Σ_c src[…] · loading_c(i)`, times `scale[i]` when given.
 pub(crate) fn gather_apply(
-    design: &Design<'_>,
+    prepared: &PreparedDesign<'_>,
     src: &[f64],
     dst: &mut [f64],
     scale: Option<&[f64]>,
 ) {
+    let design = &prepared.design;
     debug_assert!(scale.is_none_or(|s| s.len() == design.n_obs));
     debug_assert_eq!(src.len(), design.n_dofs);
     debug_assert_eq!(dst.len(), design.n_obs);
@@ -27,25 +28,25 @@ pub(crate) fn gather_apply(
             match &*t.columns {
                 [Loading::Constant] => gather_term(chunk, row_start, levels, [col(0)], |_| [1.0]),
                 [Loading::Constant, Loading::Covariate(c0)] => {
-                    let z0 = design.loading_column(*c0 as usize);
+                    let z0 = prepared.basis.loading_column(*c0 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1)], |i| [1.0, z0[i]])
                 }
                 [Loading::Constant, Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                    let z0 = design.loading_column(*c0 as usize);
-                    let z1 = design.loading_column(*c1 as usize);
+                    let z0 = prepared.basis.loading_column(*c0 as usize);
+                    let z1 = prepared.basis.loading_column(*c1 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1), col(2)], |i| {
                         [1.0, z0[i], z1[i]]
                     })
                 }
                 [Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                    let z0 = design.loading_column(*c0 as usize);
-                    let z1 = design.loading_column(*c1 as usize);
+                    let z0 = prepared.basis.loading_column(*c0 as usize);
+                    let z1 = prepared.basis.loading_column(*c1 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1)], |i| {
                         [z0[i], z1[i]]
                     })
                 }
                 [Loading::Covariate(c0)] => {
-                    let z0 = design.loading_column(*c0 as usize);
+                    let z0 = prepared.basis.loading_column(*c0 as usize);
                     gather_term(chunk, row_start, levels, [col(0)], |i| [z0[i]])
                 }
                 columns => {
@@ -59,7 +60,7 @@ pub(crate) fn gather_apply(
                             acc += match loading {
                                 Loading::Constant => coef,
                                 Loading::Covariate(k) => {
-                                    coef * design.loading_column(*k as usize)[i]
+                                    coef * prepared.basis.loading_column(*k as usize)[i]
                                 }
                             };
                         }

--- a/crates/within/src/operator/design/scatter.rs
+++ b/crates/within/src/operator/design/scatter.rs
@@ -8,15 +8,16 @@ use rayon::prelude::*;
 
 use super::PAR_THRESHOLD;
 use crate::domain::Loading;
-use crate::domain::{Design, TermMeta};
+use crate::domain::{PreparedDesign, TermMeta};
 
 /// Adjoint scatter over all terms; `base(i)` is the row value each column scales by its loading.
 pub(super) fn scatter_apply(
-    design: &Design<'_>,
+    prepared: &PreparedDesign<'_>,
     scratch: &[AtomicF64],
     dst: &mut [f64],
     base: &(impl Fn(usize) -> f64 + Sync),
 ) {
+    let design = &prepared.design;
     debug_assert_eq!(dst.len(), design.n_dofs);
     let parallel = design.n_obs > PAR_THRESHOLD;
 
@@ -28,23 +29,23 @@ pub(super) fn scatter_apply(
                 scatter_term::<1>(block, t, levels, parallel, scratch, |i| [base(i)])
             }
             [Loading::Constant, Loading::Covariate(c0)] => {
-                let z0 = design.loading_column(*c0 as usize);
+                let z0 = prepared.basis.loading_column(*c0 as usize);
                 scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [b, z0[i] * b]
                 })
             }
             [Loading::Constant, Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                let z0 = design.loading_column(*c0 as usize);
-                let z1 = design.loading_column(*c1 as usize);
+                let z0 = prepared.basis.loading_column(*c0 as usize);
+                let z1 = prepared.basis.loading_column(*c1 as usize);
                 scatter_term::<3>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [b, z0[i] * b, z1[i] * b]
                 })
             }
             [Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                let z0 = design.loading_column(*c0 as usize);
-                let z1 = design.loading_column(*c1 as usize);
+                let z0 = prepared.basis.loading_column(*c0 as usize);
+                let z1 = prepared.basis.loading_column(*c1 as usize);
                 scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [z0[i] * b, z1[i] * b]
@@ -59,7 +60,7 @@ pub(super) fn scatter_apply(
                             scatter_term::<1>(slot, t, levels, parallel, scratch, |i| [base(i)]);
                         }
                         Loading::Covariate(k) => {
-                            let z = design.loading_column(*k as usize);
+                            let z = prepared.basis.loading_column(*k as usize);
                             scatter_term::<1>(slot, t, levels, parallel, scratch, move |i| {
                                 [z[i] * base(i)]
                             });

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -1,12 +1,15 @@
 mod design_tests {
-    use crate::domain::Design;
+    use crate::domain::{Design, PreparedDesign};
     use crate::linalg::dot;
     use crate::operator::DesignOperator;
     use schwarz_precond::Operator;
 
-    fn make_test_design() -> Design<'static> {
+    fn make_test_design() -> PreparedDesign<'static> {
         // Sorted on the dominant factor, so construction applies no locality permutation.
-        Design::from_levels_for_test(vec![vec![0, 1, 1, 2, 0], vec![0, 0, 1, 2, 3]])
+        PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![
+            vec![0, 1, 1, 2, 0],
+            vec![0, 0, 1, 2, 3],
+        ]))
     }
 
     #[test]
@@ -57,18 +60,20 @@ mod design_tests {
         assert_eq!(x, vec![6.0, 5.0, 4.0, 3.0, 3.0, 4.0, 5.0]);
     }
 
-    fn make_single_factor_design() -> Design<'static> {
+    fn make_single_factor_design() -> PreparedDesign<'static> {
         // Sorted: a single-factor store is always dominated by its only factor.
-        Design::from_levels_for_test(vec![vec![0u32, 0, 1, 1, 2]])
+        PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![vec![
+            0u32, 0, 1, 1, 2,
+        ]]))
     }
 
-    fn make_large_design() -> Design<'static> {
+    fn make_large_design() -> PreparedDesign<'static> {
         // Sorted on both factors, so there is no construction-time permutation.
         let n_obs = 15_000;
         let block = 300u32;
         let fa: Vec<u32> = (0..n_obs).map(|i| i as u32 / block).collect();
         let fb = fa.clone();
-        Design::from_levels_for_test(vec![fa, fb])
+        PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![fa, fb]))
     }
 
     /// Verify <D·x, r> == <x, D^T·r> on a large design exercising the parallel
@@ -76,8 +81,8 @@ mod design_tests {
     #[test]
     fn test_large_design_adjoint_property() {
         let dm = make_large_design();
-        let n_dofs = dm.n_dofs;
-        let n_rows = dm.n_obs;
+        let n_dofs = dm.design.n_dofs;
+        let n_rows = dm.design.n_obs;
         let op = DesignOperator::new(&dm, None);
 
         let x: Vec<f64> = (0..n_dofs).map(|i| (i as f64 * 0.17 + 1.0).sin()).collect();
@@ -110,20 +115,23 @@ mod design_tests {
         let n_obs = 15_000;
         let fa: Vec<u32> = (0..n_obs as u32).collect();
         let fb: Vec<u32> = (0..n_obs).map(|i| (i % 50) as u32).collect();
-        let dm = Design::from_levels_for_test(vec![fa, fb]);
-        assert!(dm.obs_perm.is_none(), "dominant factor is sorted; no perm");
+        let dm = PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![fa, fb]));
+        assert!(
+            dm.design.obs_perm.is_none(),
+            "dominant factor is sorted; no perm"
+        );
 
         let op = DesignOperator::new(&dm, None);
-        let x: Vec<f64> = (0..dm.n_dofs)
+        let x: Vec<f64> = (0..dm.design.n_dofs)
             .map(|i| (i as f64 * 0.17 + 1.0).sin())
             .collect();
-        let r: Vec<f64> = (0..dm.n_obs)
+        let r: Vec<f64> = (0..dm.design.n_obs)
             .map(|i| (i as f64 * 0.23 + 2.0).cos())
             .collect();
 
-        let mut dx = vec![0.0f64; dm.n_obs];
+        let mut dx = vec![0.0f64; dm.design.n_obs];
         op.apply(&x, &mut dx).expect("apply succeeds");
-        let mut dtr = vec![0.0f64; dm.n_dofs];
+        let mut dtr = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&r, &mut dtr)
             .expect("apply_adjoint succeeds");
 
@@ -142,9 +150,9 @@ mod design_tests {
         let dm = make_large_design();
         let op = DesignOperator::new(&dm, None);
 
-        let mut ej = vec![0.0f64; dm.n_dofs];
+        let mut ej = vec![0.0f64; dm.design.n_dofs];
         ej[0] = 1.0;
-        let mut y = vec![0.0f64; dm.n_obs];
+        let mut y = vec![0.0f64; dm.design.n_obs];
         op.apply(&ej, &mut y).expect("apply succeeds");
 
         for (i, &yi) in y.iter().enumerate() {
@@ -161,12 +169,12 @@ mod design_tests {
         let dm = make_large_design();
         let op = DesignOperator::new(&dm, None);
 
-        let ones = vec![1.0f64; dm.n_obs];
-        let mut x = vec![0.0f64; dm.n_dofs];
+        let ones = vec![1.0f64; dm.design.n_obs];
+        let mut x = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&ones, &mut x)
             .expect("apply_adjoint succeeds");
 
-        let expected_count = (dm.n_obs / 50) as f64;
+        let expected_count = (dm.design.n_obs / 50) as f64;
         for (j, &xj) in x.iter().enumerate() {
             assert!(
                 (xj - expected_count).abs() < 1e-10,
@@ -183,10 +191,10 @@ mod design_tests {
         let x: Vec<f64> = vec![1.0, 2.0, 3.0];
         let r: Vec<f64> = vec![0.5, 1.5, -0.5, 2.0, -1.0];
 
-        let mut dx = vec![0.0f64; dm.n_obs];
+        let mut dx = vec![0.0f64; dm.design.n_obs];
         op.apply(&x, &mut dx).expect("apply succeeds");
 
-        let mut dtr = vec![0.0f64; dm.n_dofs];
+        let mut dtr = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&r, &mut dtr)
             .expect("apply_adjoint succeeds");
 
@@ -223,9 +231,9 @@ mod design_tests {
     /// Single-factor design with `level(i) = i % n_levels`; when
     /// `n_obs >= n_levels` every level is populated so the inferred level count
     /// is exactly `n_levels` (which selects the scatter strategy).
-    fn make_strategy_design(n_obs: usize, n_levels: usize) -> Design<'static> {
+    fn make_strategy_design(n_obs: usize, n_levels: usize) -> PreparedDesign<'static> {
         let f: Vec<u32> = (0..n_obs).map(|i| (i % n_levels) as u32).collect();
-        Design::from_levels_for_test(vec![f])
+        PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![f]))
     }
 
     fn assert_all_close(actual: &[f64], expected: &[f64], ctx: &str) {
@@ -252,8 +260,11 @@ mod design_tests {
         let n_obs = 150_000usize;
         let fa: Vec<u32> = (0..n_obs as u32).collect();
         let fb: Vec<u32> = (0..n_obs).map(|i| ((i * 7919) % 100_000) as u32).collect();
-        let dm = Design::from_levels_for_test(vec![fa, fb]);
-        assert!(dm.obs_perm.is_none(), "dominant factor is sorted; no perm");
+        let dm = PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![fa, fb]));
+        assert!(
+            dm.design.obs_perm.is_none(),
+            "dominant factor is sorted; no perm"
+        );
         assert_scratch_reuse_matches_fresh(&dm, "atomic: non-dominant unsorted 100K levels");
     }
 
@@ -261,24 +272,24 @@ mod design_tests {
     /// calls (cf. the removed `SCATTER_FOLD_POOL` leak): a second call on the
     /// *same* operator must match a freshly built operator — stale values from
     /// the first call must not bleed into the second.
-    fn assert_scratch_reuse_matches_fresh(dm: &Design<'_>, ctx: &str) {
-        let r: Vec<f64> = (0..dm.n_obs)
+    fn assert_scratch_reuse_matches_fresh(dm: &PreparedDesign<'_>, ctx: &str) {
+        let r: Vec<f64> = (0..dm.design.n_obs)
             .map(|i| (i as f64 * 0.37 + 1.0).sin())
             .collect();
 
         // Baseline: a fresh operator that has never applied before.
         let fresh = DesignOperator::new(dm, None);
-        let mut baseline = vec![0.0f64; dm.n_dofs];
+        let mut baseline = vec![0.0f64; dm.design.n_dofs];
         fresh
             .apply_adjoint(&r, &mut baseline)
             .expect("apply_adjoint succeeds");
 
         // The second apply on a dirtied operator must equal the fresh baseline.
         let op = DesignOperator::new(dm, None);
-        let mut warmup = vec![0.0f64; dm.n_dofs];
+        let mut warmup = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&r, &mut warmup)
             .expect("apply_adjoint succeeds");
-        let mut reused = vec![0.0f64; dm.n_dofs];
+        let mut reused = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&r, &mut reused)
             .expect("apply_adjoint succeeds");
 
@@ -287,7 +298,7 @@ mod design_tests {
 }
 
 mod slope_design_tests {
-    use crate::domain::{Design, Effect, Loading};
+    use crate::domain::{Design, Effect, Loading, PreparedDesign};
     use crate::operator::DesignOperator;
     use schwarz_precond::Operator;
 
@@ -350,10 +361,13 @@ mod slope_design_tests {
         ];
         let design = Design::new(effects).unwrap();
         let dense = dense_matrix(&design);
-        let op = DesignOperator::new(&design, None);
+        let prepared = PreparedDesign::with_caller_loadings_for_test(design);
+        let op = DesignOperator::new(&prepared, None);
 
-        let x: Vec<f64> = (0..design.n_dofs).map(|j| noise(7_000 + j)).collect();
-        let mut got = vec![0.0; design.n_obs];
+        let x: Vec<f64> = (0..prepared.design.n_dofs)
+            .map(|j| noise(7_000 + j))
+            .collect();
+        let mut got = vec![0.0; prepared.design.n_obs];
         op.apply(&x, &mut got).unwrap();
         let expect: Vec<f64> = dense
             .iter()
@@ -361,10 +375,12 @@ mod slope_design_tests {
             .collect();
         assert_close(&got, &expect);
 
-        let r: Vec<f64> = (0..design.n_obs).map(|i| noise(9_000 + i)).collect();
-        let mut got_t = vec![0.0; design.n_dofs];
+        let r: Vec<f64> = (0..prepared.design.n_obs)
+            .map(|i| noise(9_000 + i))
+            .collect();
+        let mut got_t = vec![0.0; prepared.design.n_dofs];
         op.apply_adjoint(&r, &mut got_t).unwrap();
-        let mut expect_t = vec![0.0; design.n_dofs];
+        let mut expect_t = vec![0.0; prepared.design.n_dofs];
         for (row, &ri) in dense.iter().zip(&r) {
             for (e, d) in expect_t.iter_mut().zip(row) {
                 *e += d * ri;
@@ -393,16 +409,18 @@ mod slope_design_tests {
             Effect::new(&unsorted, true, [&z[1][..]]).unwrap(),
             Effect::new(&small, true, [&z[2][..], &z[3][..]]).unwrap(),
         ];
-        let design = Design::new(effects).unwrap();
+        let prepared = PreparedDesign::with_caller_loadings_for_test(Design::new(effects).unwrap());
         let sqrt_weights: Vec<f64> = (0..n).map(|i| (0.5 + noise(i).abs()).sqrt()).collect();
-        let op = DesignOperator::new(&design, Some(&sqrt_weights));
+        let op = DesignOperator::new(&prepared, Some(&sqrt_weights));
 
-        let x: Vec<f64> = (0..design.n_dofs).map(|j| noise(13 * j + 1)).collect();
+        let x: Vec<f64> = (0..prepared.design.n_dofs)
+            .map(|j| noise(13 * j + 1))
+            .collect();
         let r: Vec<f64> = (0..n).map(|i| noise(29 * i + 5)).collect();
 
         let mut dx = vec![0.0; n];
         op.apply(&x, &mut dx).unwrap();
-        let mut dtr = vec![0.0; design.n_dofs];
+        let mut dtr = vec![0.0; prepared.design.n_dofs];
         op.apply_adjoint(&r, &mut dtr).unwrap();
 
         let lhs: f64 = dx.iter().zip(&r).map(|(a, b)| a * b).sum();
@@ -415,7 +433,7 @@ mod slope_design_tests {
 }
 
 mod weighted_adjoint_proptests {
-    use crate::domain::Design;
+    use crate::domain::{Design, PreparedDesign};
     use crate::operator::DesignOperator;
     use proptest::prelude::*;
     use schwarz_precond::Operator;
@@ -444,10 +462,10 @@ mod weighted_adjoint_proptests {
                 .map(|i| 0.5 + (i as f64 * 0.13 + seed as f64 * 0.41).sin().abs())
                 .collect();
 
-            let dm = Design::from_levels_for_test(vec![fa, fb]);
+            let dm = PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![fa, fb]));
 
-            let n_dofs = dm.n_dofs;
-            let n_rows = dm.n_obs;
+            let n_dofs = dm.design.n_dofs;
+            let n_rows = dm.design.n_obs;
 
             let x: Vec<f64> = (0..n_dofs)
                 .map(|i| (i as f64 * 0.37 + seed as f64 * 0.13).sin())

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -1,21 +1,18 @@
 mod design_tests {
-    use crate::domain::{Design, PreparedDesign};
+    use crate::domain::PreparedDesign;
     use crate::linalg::dot;
     use crate::operator::DesignOperator;
     use schwarz_precond::Operator;
 
     fn make_test_design() -> PreparedDesign<'static> {
         // Sorted on the dominant factor, so construction applies no locality permutation.
-        PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![
-            vec![0, 1, 1, 2, 0],
-            vec![0, 0, 1, 2, 3],
-        ]))
+        PreparedDesign::from_levels_for_test(vec![vec![0, 1, 1, 2, 0], vec![0, 0, 1, 2, 3]])
     }
 
     #[test]
     fn test_design_operator_dimensions() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
         assert_eq!(op.nrows(), 5);
         assert_eq!(op.ncols(), 7);
     }
@@ -23,7 +20,7 @@ mod design_tests {
     #[test]
     fn test_design_operator_adjoint() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
 
         let x = vec![1.0, -0.5, 2.0, 0.3, -1.0, 0.7, 1.5];
         let r = vec![0.1, 0.2, -0.3, 0.4, -0.5];
@@ -42,7 +39,7 @@ mod design_tests {
     #[test]
     fn test_apply_unweighted_values() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
         let x = vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 40.0];
         let mut y = vec![0.0; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
@@ -52,7 +49,7 @@ mod design_tests {
     #[test]
     fn test_apply_adjoint_unweighted_values() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0; 7];
         op.apply_adjoint(&r, &mut x)
@@ -62,9 +59,7 @@ mod design_tests {
 
     fn make_single_factor_design() -> PreparedDesign<'static> {
         // Sorted: a single-factor store is always dominated by its only factor.
-        PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![vec![
-            0u32, 0, 1, 1, 2,
-        ]]))
+        PreparedDesign::from_levels_for_test(vec![vec![0u32, 0, 1, 1, 2]])
     }
 
     fn make_large_design() -> PreparedDesign<'static> {
@@ -73,7 +68,7 @@ mod design_tests {
         let block = 300u32;
         let fa: Vec<u32> = (0..n_obs).map(|i| i as u32 / block).collect();
         let fb = fa.clone();
-        PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![fa, fb]))
+        PreparedDesign::from_levels_for_test(vec![fa, fb])
     }
 
     /// Verify <D·x, r> == <x, D^T·r> on a large design exercising the parallel
@@ -83,7 +78,7 @@ mod design_tests {
         let dm = make_large_design();
         let n_dofs = dm.design.n_dofs;
         let n_rows = dm.design.n_obs;
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
         let x: Vec<f64> = (0..n_dofs).map(|i| (i as f64 * 0.17 + 1.0).sin()).collect();
         let r: Vec<f64> = (0..n_rows).map(|i| (i as f64 * 0.23 + 2.0).cos()).collect();
@@ -115,13 +110,13 @@ mod design_tests {
         let n_obs = 15_000;
         let fa: Vec<u32> = (0..n_obs as u32).collect();
         let fb: Vec<u32> = (0..n_obs).map(|i| (i % 50) as u32).collect();
-        let dm = PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![fa, fb]));
+        let dm = PreparedDesign::from_levels_for_test(vec![fa, fb]);
         assert!(
             dm.design.obs_perm.is_none(),
             "dominant factor is sorted; no perm"
         );
 
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
         let x: Vec<f64> = (0..dm.design.n_dofs)
             .map(|i| (i as f64 * 0.17 + 1.0).sin())
             .collect();
@@ -148,7 +143,7 @@ mod design_tests {
     #[test]
     fn test_large_design_matvec_correctness() {
         let dm = make_large_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
         let mut ej = vec![0.0f64; dm.design.n_dofs];
         ej[0] = 1.0;
@@ -167,7 +162,7 @@ mod design_tests {
     #[test]
     fn test_large_design_apply_adjoint_correctness() {
         let dm = make_large_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
         let ones = vec![1.0f64; dm.design.n_obs];
         let mut x = vec![0.0f64; dm.design.n_dofs];
@@ -186,7 +181,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_design_adjoint_property() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
         let x: Vec<f64> = vec![1.0, 2.0, 3.0];
         let r: Vec<f64> = vec![0.5, 1.5, -0.5, 2.0, -1.0];
@@ -210,7 +205,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_values() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
         let x = vec![10.0, 20.0, 30.0];
         let mut y = vec![0.0f64; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
@@ -220,7 +215,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_adjoint_values() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0f64; 3];
         op.apply_adjoint(&r, &mut x)
@@ -233,7 +228,7 @@ mod design_tests {
     /// is exactly `n_levels` (which selects the scatter strategy).
     fn make_strategy_design(n_obs: usize, n_levels: usize) -> PreparedDesign<'static> {
         let f: Vec<u32> = (0..n_obs).map(|i| (i % n_levels) as u32).collect();
-        PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![f]))
+        PreparedDesign::from_levels_for_test(vec![f])
     }
 
     fn assert_all_close(actual: &[f64], expected: &[f64], ctx: &str) {
@@ -260,7 +255,7 @@ mod design_tests {
         let n_obs = 150_000usize;
         let fa: Vec<u32> = (0..n_obs as u32).collect();
         let fb: Vec<u32> = (0..n_obs).map(|i| ((i * 7919) % 100_000) as u32).collect();
-        let dm = PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![fa, fb]));
+        let dm = PreparedDesign::from_levels_for_test(vec![fa, fb]);
         assert!(
             dm.design.obs_perm.is_none(),
             "dominant factor is sorted; no perm"
@@ -278,14 +273,14 @@ mod design_tests {
             .collect();
 
         // Baseline: a fresh operator that has never applied before.
-        let fresh = DesignOperator::new(dm, None);
+        let fresh = DesignOperator::new(dm);
         let mut baseline = vec![0.0f64; dm.design.n_dofs];
         fresh
             .apply_adjoint(&r, &mut baseline)
             .expect("apply_adjoint succeeds");
 
         // The second apply on a dirtied operator must equal the fresh baseline.
-        let op = DesignOperator::new(dm, None);
+        let op = DesignOperator::new(dm);
         let mut warmup = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&r, &mut warmup)
             .expect("apply_adjoint succeeds");
@@ -310,10 +305,9 @@ mod slope_design_tests {
         (z >> 11) as f64 / (1u64 << 52) as f64 - 1.0
     }
 
-    /// Dense design matrix from the design's internal (post-sort) columns —
-    /// the reference the operator must agree with regardless of the locality
-    /// permutation.
-    fn dense_matrix(design: &Design<'_>) -> Vec<Vec<f64>> {
+    /// Dense design matrix in the solve basis and internal row order, the operator's reference.
+    fn dense_matrix(prepared: &PreparedDesign<'_>) -> Vec<Vec<f64>> {
+        let design = &prepared.design;
         let mut d = vec![vec![0.0; design.n_dofs]; design.n_obs];
         for (q, t) in design.terms.iter().enumerate() {
             let levels = design.level_column(q);
@@ -322,7 +316,7 @@ mod slope_design_tests {
                 for (i, &lev) in levels.iter().enumerate() {
                     d[i][base + lev as usize] = match loading {
                         Loading::Constant => 1.0,
-                        Loading::Covariate(k) => design.loading_column(*k as usize)[i],
+                        Loading::Covariate(k) => prepared.basis.loading_column(*k as usize)[i],
                     };
                 }
             }
@@ -341,14 +335,15 @@ mod slope_design_tests {
 
     /// Covers every kernel arm on the sequential path: plain, fused V=1/V=2,
     /// slope-only, and the generic V=3 fallback — against the dense reference.
+    /// Four rows per level keep every whitened column nonzero, so each arm's addressing counts.
     #[test]
     fn slope_matvec_and_adjoint_match_dense_reference() {
-        let n = 6;
-        let f0 = [0u32, 1, 2, 0, 1, 2];
-        let f1 = [0u32, 0, 1, 1, 2, 2];
-        let f2 = [0u32, 1, 0, 1, 0, 1];
-        let f3 = [0u32, 0, 0, 1, 1, 1];
-        let f4 = [1u32, 0, 2, 1, 0, 2];
+        let n = 12;
+        let f0: Vec<u32> = (0..n).map(|i| (i % 3) as u32).collect();
+        let f1: Vec<u32> = (0..n).map(|i| ((i / 2) % 3) as u32).collect();
+        let f2: Vec<u32> = (0..n).map(|i| (i % 2) as u32).collect();
+        let f3: Vec<u32> = (0..n).map(|i| (i / 6) as u32).collect();
+        let f4: Vec<u32> = (0..n).map(|i| [1u32, 0, 2, 1, 0, 2][i % 6]).collect();
         let zs: Vec<Vec<f64>> = (0..6)
             .map(|k| (0..n).map(|i| noise(k * 100 + i)).collect())
             .collect();
@@ -359,10 +354,13 @@ mod slope_design_tests {
             Effect::new(&f3, true, []).unwrap(),
             Effect::new(&f4, true, [&zs[5][..], &zs[4][..]]).unwrap(),
         ];
-        let design = Design::new(effects).unwrap();
-        let dense = dense_matrix(&design);
-        let prepared = PreparedDesign::with_caller_loadings_for_test(design);
-        let op = DesignOperator::new(&prepared, None);
+        let prepared = PreparedDesign::unweighted_for_test(Design::new(effects).unwrap());
+        let dense = dense_matrix(&prepared);
+        assert!(
+            (0..prepared.design.n_dofs).all(|j| dense.iter().any(|row| row[j] != 0.0)),
+            "whitening zeroed a column; the arm's addressing would go untested"
+        );
+        let op = DesignOperator::new(&prepared);
 
         let x: Vec<f64> = (0..prepared.design.n_dofs)
             .map(|j| noise(7_000 + j))
@@ -409,9 +407,9 @@ mod slope_design_tests {
             Effect::new(&unsorted, true, [&z[1][..]]).unwrap(),
             Effect::new(&small, true, [&z[2][..], &z[3][..]]).unwrap(),
         ];
-        let prepared = PreparedDesign::with_caller_loadings_for_test(Design::new(effects).unwrap());
-        let sqrt_weights: Vec<f64> = (0..n).map(|i| (0.5 + noise(i).abs()).sqrt()).collect();
-        let op = DesignOperator::new(&prepared, Some(&sqrt_weights));
+        let weights: Vec<f64> = (0..n).map(|i| 0.5 + noise(i).abs()).collect();
+        let prepared = PreparedDesign::new(Design::new(effects).unwrap(), Some(weights)).unwrap();
+        let op = DesignOperator::new(&prepared);
 
         let x: Vec<f64> = (0..prepared.design.n_dofs)
             .map(|j| noise(13 * j + 1))
@@ -433,7 +431,7 @@ mod slope_design_tests {
 }
 
 mod weighted_adjoint_proptests {
-    use crate::domain::{Design, PreparedDesign};
+    use crate::domain::PreparedDesign;
     use crate::operator::DesignOperator;
     use proptest::prelude::*;
     use schwarz_precond::Operator;
@@ -462,7 +460,10 @@ mod weighted_adjoint_proptests {
                 .map(|i| 0.5 + (i as f64 * 0.13 + seed as f64 * 0.41).sin().abs())
                 .collect();
 
-            let dm = PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![fa, fb]));
+            let dm = PreparedDesign::from_levels_for_test(vec![fa, fb]);
+            let dm_weighted = PreparedDesign::new(dm.design.clone(), Some(weights)).unwrap();
+            // Internal row order, like `dx` and `r` below.
+            let weights = dm_weighted.weights.as_deref().unwrap();
 
             let n_dofs = dm.design.n_dofs;
             let n_rows = dm.design.n_obs;
@@ -474,7 +475,7 @@ mod weighted_adjoint_proptests {
                 .map(|i| (i as f64 * 0.29 + seed as f64 * 0.07).cos())
                 .collect();
 
-            let op_unweighted = DesignOperator::new(&dm, None);
+            let op_unweighted = DesignOperator::new(&dm);
             let mut dx = vec![0.0f64; n_rows];
             op_unweighted.apply(&x, &mut dx).unwrap();
             let lhs: f64 = dx
@@ -484,8 +485,7 @@ mod weighted_adjoint_proptests {
                 .map(|(i, (dxi, ri))| weights[i] * dxi * ri)
                 .sum();
 
-            let sqrt_weights: Vec<f64> = weights.iter().map(|w| w.sqrt()).collect();
-            let op_weighted = DesignOperator::new(&dm, Some(&sqrt_weights));
+            let op_weighted = DesignOperator::new(&dm_weighted);
             let wr = op_weighted.weighted_rhs(&r);
             let mut wdtr = vec![0.0f64; n_dofs];
             op_weighted.apply_adjoint(&wr, &mut wdtr).unwrap();

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use crate::block_elim::BlockElimSolver;
 use crate::config::{LocalSolverConfig, PreconditionerConfig};
 use crate::domain::Loading;
-use crate::domain::{Design, LocalDomain};
+use crate::domain::{LocalDomain, PreparedDesign};
 use crate::{BuildError, BuildWarning};
 
 #[cfg(test)]
@@ -210,10 +210,9 @@ impl Operator for Preconditioner {
     }
 }
 
-fn build_diagonal(
-    design: &Design<'_>,
-    weights: Option<&[f64]>,
-) -> Result<DiagonalPreconditioner, BuildError> {
+fn build_diagonal(prepared: &PreparedDesign<'_>) -> Result<DiagonalPreconditioner, BuildError> {
+    let design = &prepared.design;
+    let weights = prepared.weights.as_deref();
     let mut diag = vec![0.0; design.n_dofs];
 
     for (factor_idx, term) in design.terms.iter().enumerate() {
@@ -229,7 +228,7 @@ fn build_diagonal(
                     }
                 }
                 Loading::Covariate(z_col) => {
-                    let z = design.loading_column(*z_col as usize);
+                    let z = prepared.basis.loading_column(*z_col as usize);
                     for (uid, &level) in levels.iter().enumerate() {
                         // Keep `w * z * z` left-to-right: a zero weight kills a huge `z` first.
                         slice[level as usize] += w(uid) * z[uid] * z[uid];
@@ -256,15 +255,14 @@ fn build_diagonal(
     })
 }
 
-/// Build a [`Preconditioner`] from a design and optional weights, plus any warnings.
+/// Build a [`Preconditioner`] for a prepared design, plus any warnings.
 pub(crate) fn build_preconditioner(
-    design: &Design<'_>,
-    weights: Option<&[f64]>,
+    prepared: &PreparedDesign<'_>,
     config: Option<&PreconditionerConfig>,
 ) -> Result<(Option<Preconditioner>, Vec<BuildWarning>), BuildError> {
     use crate::domain::build_local_domains;
 
-    // Weights are pre-validated by the sole caller, whose permutation preserves length and sign.
+    let design = &prepared.design;
     let default_cfg = PreconditionerConfig::default();
     let resolved = config.unwrap_or(&default_cfg);
     // Measure preconditioner build time
@@ -277,7 +275,7 @@ pub(crate) fn build_preconditioner(
             local_solver,
             reduction,
         } => {
-            let (domains, warnings) = build_local_domains(design, weights, local_solver)?;
+            let (domains, warnings) = build_local_domains(prepared, local_solver)?;
             if domains.is_empty() {
                 // No factor-pair subdomains means no useful Schwarz; fall back to plain LSMR.
                 return Ok((None, warnings));
@@ -287,7 +285,7 @@ pub(crate) fn build_preconditioner(
             (Variant::Additive(preconditioner), warnings)
         }
         PreconditionerConfig::Diagonal => {
-            let preconditioner = build_diagonal(design, weights)?;
+            let preconditioner = build_diagonal(prepared)?;
             (Variant::Diagonal(preconditioner), Vec::new())
         }
     };

--- a/crates/within/src/operator/schwarz/tests.rs
+++ b/crates/within/src/operator/schwarz/tests.rs
@@ -10,17 +10,20 @@ use crate::config::{
 use schwarz_precond::SubdomainCore;
 
 use crate::csr_block::CsrBlock;
-use crate::domain::{build_local_domains, Design, LocalDomain};
+use crate::domain::{build_local_domains, Design, LocalDomain, PreparedDesign};
 use crate::domain::{CrossTab, LocalComponent};
 use crate::operator::schwarz::build_additive_with_strategy;
 use schwarz_precond::{LocalSolver, Operator, ReductionStrategy};
 
 const BLOCK_ELIM_NESTED_RAYON_CHILD_ENV: &str = "WITHIN_TEST_BLOCK_ELIM_NESTED_RAYON_CHILD";
 
-fn make_test_data() -> (Design<'static>, Vec<LocalDomain>) {
-    let design = Design::from_levels_for_test(vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]);
-    let (domain_pairs, _) = build_local_domains(&design, None, &LocalSolverConfig::default())
-        .expect("plain domains build");
+fn make_test_data() -> (PreparedDesign<'static>, Vec<LocalDomain>) {
+    let design = PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![
+        vec![0, 1, 0, 1, 2],
+        vec![0, 0, 1, 1, 0],
+    ]));
+    let (domain_pairs, _) =
+        build_local_domains(&design, &LocalSolverConfig::default()).expect("plain domains build");
     (design, domain_pairs)
 }
 
@@ -205,10 +208,11 @@ fn test_build_additive_with_strategy() {
     let (design, domain_pairs) = make_test_data();
     let config = LocalSolverConfig::default();
     let strategy = schwarz_precond::ReductionStrategy::default();
-    let schwarz = build_additive_with_strategy(domain_pairs, &config, strategy, design.n_dofs)
+    let n_dofs = design.design.n_dofs;
+    let schwarz = build_additive_with_strategy(domain_pairs, &config, strategy, n_dofs)
         .expect("build schwarz with explicit domains");
-    let r = vec![1.0; design.n_dofs];
-    let mut z = vec![0.0; design.n_dofs];
+    let r = vec![1.0; n_dofs];
+    let mut z = vec![0.0; n_dofs];
     schwarz.apply(&r, &mut z).expect("schwarz apply succeeds");
 }
 

--- a/crates/within/src/operator/schwarz/tests.rs
+++ b/crates/within/src/operator/schwarz/tests.rs
@@ -10,7 +10,7 @@ use crate::config::{
 use schwarz_precond::SubdomainCore;
 
 use crate::csr_block::CsrBlock;
-use crate::domain::{build_local_domains, Design, LocalDomain, PreparedDesign};
+use crate::domain::{build_local_domains, LocalDomain, PreparedDesign};
 use crate::domain::{CrossTab, LocalComponent};
 use crate::operator::schwarz::build_additive_with_strategy;
 use schwarz_precond::{LocalSolver, Operator, ReductionStrategy};
@@ -18,10 +18,8 @@ use schwarz_precond::{LocalSolver, Operator, ReductionStrategy};
 const BLOCK_ELIM_NESTED_RAYON_CHILD_ENV: &str = "WITHIN_TEST_BLOCK_ELIM_NESTED_RAYON_CHILD";
 
 fn make_test_data() -> (PreparedDesign<'static>, Vec<LocalDomain>) {
-    let design = PreparedDesign::unweighted_for_test(Design::from_levels_for_test(vec![
-        vec![0, 1, 0, 1, 2],
-        vec![0, 0, 1, 1, 0],
-    ]));
+    let design =
+        PreparedDesign::from_levels_for_test(vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]);
     let (domain_pairs, _) =
         build_local_domains(&design, &LocalSolverConfig::default()).expect("plain domains build");
     (design, domain_pairs)

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -20,9 +20,7 @@ use crate::{BuildError, BuildWarning, SolveError, WithinError};
 #[cfg(test)]
 mod tests;
 
-/// Fallible conversion into a shared [`Design`] for [`Solver::new`]: a
-/// categories matrix (`ArrayView2<u32>`), a list of [`Effect`] terms, a
-/// [`Design`], or an `Arc<Design>` already shared with other solvers.
+/// Fallible conversion into a shared [`Design`] for [`Solver::new`].
 pub trait IntoDesign<'a> {
     /// Build the [`Design`], validating inputs along the way.
     fn into_design(self) -> Result<Arc<Design<'a>>, BuildError>;

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -2,16 +2,18 @@
 //! multiple solves on the same design) and the one-shot [`solve`] / [`solve_batch`]
 //! convenience wrappers built on top of it.
 
-use std::sync::Arc;
+use std::borrow::Cow;
 use std::time::Instant;
 
-use ndarray::ArrayView2;
+use ndarray::{ArrayView2, Axis};
 use rayon::prelude::*;
 use schwarz_precond::{lsmr as lsmr_solve, mlsmr, MlsmrOptions};
 
 use crate::channel::{Channel, CoefficientAddress, CoefficientPosition};
 use crate::config::{LsmrOptions, PreconditionerConfig};
+use crate::domain::collinearity::detect_collinear_slopes;
 use crate::domain::{Design, Effect, FactorEncoding, PreparedDesign};
+use crate::observation::ObservationFrame;
 use crate::operator::design::gather_apply;
 use crate::operator::schwarz::{build_preconditioner, Preconditioner};
 use crate::operator::DesignOperator;
@@ -20,33 +22,39 @@ use crate::{BuildError, BuildWarning, SolveError, WithinError};
 #[cfg(test)]
 mod tests;
 
-/// Fallible conversion into a shared [`Design`] for [`Solver::new`].
+/// Fallible conversion into a [`Design`] for [`Solver::new`]: a categories
+/// matrix (`ArrayView2<u32>`), a list of [`Effect`] terms, or a pass-through
+/// [`Design`].
 pub trait IntoDesign<'a> {
     /// Build the [`Design`], validating inputs along the way.
-    fn into_design(self) -> Result<Arc<Design<'a>>, BuildError>;
+    fn into_design(self) -> Result<Design<'a>, BuildError>;
 }
 
 impl<'a> IntoDesign<'a> for ArrayView2<'a, u32> {
-    fn into_design(self) -> Result<Arc<Design<'a>>, BuildError> {
-        Design::from_categories(self).map(Arc::new)
+    fn into_design(self) -> Result<Design<'a>, BuildError> {
+        // Gather strided (C-order) columns once so every downstream read is contiguous.
+        let categorical = (0..self.ncols())
+            .map(|factor| {
+                let col = self.index_axis_move(Axis(1), factor);
+                match col.to_slice() {
+                    Some(s) => Cow::Borrowed(s),
+                    None => Cow::Owned(col.to_vec()),
+                }
+            })
+            .collect();
+        Design::from_frame(ObservationFrame::new(categorical, Vec::new())?)
     }
 }
 
 impl<'a> IntoDesign<'a> for Design<'a> {
-    fn into_design(self) -> Result<Arc<Design<'a>>, BuildError> {
-        Ok(Arc::new(self))
-    }
-}
-
-impl<'a> IntoDesign<'a> for Arc<Design<'a>> {
-    fn into_design(self) -> Result<Arc<Design<'a>>, BuildError> {
+    fn into_design(self) -> Result<Design<'a>, BuildError> {
         Ok(self)
     }
 }
 
 impl<'a> IntoDesign<'a> for Vec<Effect<'a>> {
-    fn into_design(self) -> Result<Arc<Design<'a>>, BuildError> {
-        Design::new(self).map(Arc::new)
+    fn into_design(self) -> Result<Design<'a>, BuildError> {
+        Design::new(self)
     }
 }
 
@@ -313,8 +321,7 @@ impl BatchSolveResult {
 pub struct Solver<'a> {
     prepared: PreparedDesign<'a>,
     preconditioner: Option<Preconditioner>,
-    /// From the preconditioner build; a reused pre-built one contributes none.
-    preconditioner_warnings: Vec<BuildWarning>,
+    warnings: Vec<BuildWarning>,
 }
 
 impl std::fmt::Debug for Solver<'_> {
@@ -368,8 +375,9 @@ impl<'a> Solver<'a> {
     ) -> Result<Self, BuildError> {
         let prepared = PreparedDesign::new(design.into_design()?, weights)?;
         let n_dofs = prepared.design.n_dofs;
+        let mut warnings = detect_collinear_slopes(&prepared);
 
-        let (preconditioner, preconditioner_warnings) = match preconditioner.into() {
+        let (preconditioner, build_warnings) = match preconditioner.into() {
             PreconditionerInput::Default => build_preconditioner(&prepared, None)?,
             PreconditionerInput::Config(c) => build_preconditioner(&prepared, Some(&c))?,
             PreconditionerInput::Prebuilt(p) => {
@@ -384,22 +392,19 @@ impl<'a> Solver<'a> {
             }
         };
 
+        warnings.extend(build_warnings);
+
         Ok(Self {
             prepared,
             preconditioner,
-            preconditioner_warnings,
+            warnings,
         })
     }
 
     /// Non-fatal events from design screening and the preconditioner build; a reused
     /// pre-built preconditioner contributes none (its own were reported when built).
-    pub fn warnings(&self) -> Vec<BuildWarning> {
-        self.prepared
-            .warnings
-            .iter()
-            .chain(&self.preconditioner_warnings)
-            .cloned()
-            .collect()
+    pub fn warnings(&self) -> &[BuildWarning] {
+        &self.warnings
     }
 
     /// Shared per-RHS solve: validate `y`, run (m)lsmr, demean, and
@@ -507,7 +512,7 @@ impl<'a> Solver<'a> {
         Ok(SolveResult {
             x: solution.x,
             unidentified: self.unidentified(),
-            warnings: self.warnings(),
+            warnings: self.warnings.clone(),
             layout: CoefficientLayout::from_design(&self.prepared.design),
             demeaned: solution.demeaned,
             converged: solution.converged,
@@ -558,7 +563,7 @@ impl<'a> Solver<'a> {
         Ok(BatchSolveResult {
             x,
             unidentified: self.unidentified(),
-            warnings: self.warnings(),
+            warnings: self.warnings.clone(),
             layout: CoefficientLayout::from_design(design),
             demeaned,
             converged,

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -411,12 +411,7 @@ impl<'a> Solver<'a> {
     /// back-transform slopes. Excludes the design-level `layout` / `warnings` /
     /// `unidentified`, which the public entry points attach once (see
     /// [`RhsSolution`]).
-    fn solve_rhs(
-        &self,
-        y: &[f64],
-        sqrt_weights: Option<&[f64]>,
-        lsmr: &LsmrOptions,
-    ) -> Result<RhsSolution, SolveError> {
+    fn solve_rhs(&self, y: &[f64], lsmr: &LsmrOptions) -> Result<RhsSolution, SolveError> {
         let design = &self.prepared.design;
         // `weighted_rhs` zips y with sqrt-weights, silently truncating when `y.len() > n_rows`.
         if y.len() != design.n_obs {
@@ -442,7 +437,7 @@ impl<'a> Solver<'a> {
         let y_internal = design.permute_obs_in(y);
         let y: &[f64] = &y_internal;
 
-        let rect_op = DesignOperator::new(&self.prepared, sqrt_weights);
+        let rect_op = DesignOperator::new(&self.prepared);
         let b = rect_op.weighted_rhs(y);
         let b: &[f64] = &b;
 
@@ -506,8 +501,7 @@ impl<'a> Solver<'a> {
         let lsmr = lsmr.into().unwrap_or(&default);
 
         let t_start = Instant::now();
-        let sqrt_weights = self.prepared.sqrt_weights();
-        let solution = self.solve_rhs(y, sqrt_weights.as_deref(), lsmr)?;
+        let solution = self.solve_rhs(y, lsmr)?;
 
         Ok(SolveResult {
             x: solution.x,
@@ -535,12 +529,10 @@ impl<'a> Solver<'a> {
         let lsmr = lsmr.into().unwrap_or(&default);
         let n_rhs = ys.len();
 
-        // One `W^{1/2}` shared by every RHS's operator, computed once per batch.
-        let sqrt_weights = self.prepared.sqrt_weights();
         // Collecting into `Result` fails fast on the first per-RHS error, not during the fold.
         let solutions: Vec<RhsSolution> = ys
             .par_iter()
-            .map(|y| self.solve_rhs(y, sqrt_weights.as_deref(), lsmr))
+            .map(|y| self.solve_rhs(y, lsmr))
             .collect::<Result<Vec<_>, _>>()?;
 
         let design = &self.prepared.design;

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -2,62 +2,53 @@
 //! multiple solves on the same design) and the one-shot [`solve`] / [`solve_batch`]
 //! convenience wrappers built on top of it.
 
-use std::borrow::Cow;
+use std::sync::Arc;
 use std::time::Instant;
 
-use ndarray::{ArrayView2, Axis};
+use ndarray::ArrayView2;
 use rayon::prelude::*;
 use schwarz_precond::{lsmr as lsmr_solve, mlsmr, MlsmrOptions};
 
-use crate::channel::Channel;
+use crate::channel::{Channel, CoefficientAddress, CoefficientPosition};
 use crate::config::{LsmrOptions, PreconditionerConfig};
-use crate::domain::collinearity::detect_collinear_slopes;
-use crate::domain::level_moments::TermMoments;
-use crate::domain::{Design, Effect, FactorEncoding};
-use crate::observation::ObservationFrame;
+use crate::domain::{Design, Effect, FactorEncoding, PreparedDesign};
 use crate::operator::design::gather_apply;
 use crate::operator::schwarz::{build_preconditioner, Preconditioner};
 use crate::operator::DesignOperator;
 use crate::{BuildError, BuildWarning, SolveError, WithinError};
 
-mod reparam;
 #[cfg(test)]
 mod tests;
-use reparam::SlopeReparam;
 
-/// Fallible conversion into a [`Design`] for [`Solver::new`]: a categories
-/// matrix (`ArrayView2<u32>`), a list of [`Effect`] terms, or a pass-through
-/// [`Design`].
+/// Fallible conversion into a shared [`Design`] for [`Solver::new`]: a
+/// categories matrix (`ArrayView2<u32>`), a list of [`Effect`] terms, a
+/// [`Design`], or an `Arc<Design>` already shared with other solvers.
 pub trait IntoDesign<'a> {
     /// Build the [`Design`], validating inputs along the way.
-    fn into_design(self) -> Result<Design<'a>, BuildError>;
+    fn into_design(self) -> Result<Arc<Design<'a>>, BuildError>;
 }
 
 impl<'a> IntoDesign<'a> for ArrayView2<'a, u32> {
-    fn into_design(self) -> Result<Design<'a>, BuildError> {
-        // Gather strided (C-order) columns once so every downstream read is contiguous.
-        let categorical = (0..self.ncols())
-            .map(|factor| {
-                let col = self.index_axis_move(Axis(1), factor);
-                match col.to_slice() {
-                    Some(s) => Cow::Borrowed(s),
-                    None => Cow::Owned(col.to_vec()),
-                }
-            })
-            .collect();
-        Design::from_frame(ObservationFrame::new(categorical, Vec::new())?)
+    fn into_design(self) -> Result<Arc<Design<'a>>, BuildError> {
+        Design::from_categories(self).map(Arc::new)
     }
 }
 
 impl<'a> IntoDesign<'a> for Design<'a> {
-    fn into_design(self) -> Result<Design<'a>, BuildError> {
+    fn into_design(self) -> Result<Arc<Design<'a>>, BuildError> {
+        Ok(Arc::new(self))
+    }
+}
+
+impl<'a> IntoDesign<'a> for Arc<Design<'a>> {
+    fn into_design(self) -> Result<Arc<Design<'a>>, BuildError> {
         Ok(self)
     }
 }
 
 impl<'a> IntoDesign<'a> for Vec<Effect<'a>> {
-    fn into_design(self) -> Result<Design<'a>, BuildError> {
-        Design::new(self)
+    fn into_design(self) -> Result<Arc<Design<'a>>, BuildError> {
+        Design::new(self).map(Arc::new)
     }
 }
 
@@ -111,22 +102,7 @@ impl From<&Preconditioner> for PreconditionerInput {
     }
 }
 
-/// One coefficient of the design: a [`Channel`] at one level of its term.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Coefficient<L> {
-    /// The coefficient column this address sits in.
-    pub channel: Channel,
-    /// The level, in whichever space `L` names.
-    pub level: L,
-}
-
-/// A coefficient addressed by the caller's own factor label.
-pub type CoefficientAddress = Coefficient<u32>;
-
-/// A coefficient addressed by its internal compact position.
-type CoefficientPosition = Coefficient<usize>;
-
-impl Coefficient<usize> {
+impl CoefficientPosition {
     fn to_caller_address(self, design: &Design) -> CoefficientAddress {
         let level = design.terms[self.channel.term]
             .encoding
@@ -337,22 +313,18 @@ impl BatchSolveResult {
 /// Python boundary — uses owned columns. Weights are always owned; for a
 /// one-shot weighted solve from a borrowed slice, use the free [`solve`] function.
 pub struct Solver<'a> {
-    design: Design<'a>,
-    /// `sqrt(W)` in the design's internal observation order, computed once and
-    /// borrowed by the per-RHS [`DesignOperator`]s (raw weights are needed only
-    /// during construction).
-    sqrt_weights: Option<Vec<f64>>,
+    prepared: PreparedDesign<'a>,
     preconditioner: Option<Preconditioner>,
-    reparam: Option<SlopeReparam>,
-    warnings: Vec<BuildWarning>,
+    /// From the preconditioner build; a reused pre-built one contributes none.
+    preconditioner_warnings: Vec<BuildWarning>,
 }
 
 impl std::fmt::Debug for Solver<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Solver")
-            .field("n_obs", &self.design.n_obs)
-            .field("n_dofs", &self.design.n_dofs)
-            .field("has_weights", &self.sqrt_weights.is_some())
+            .field("n_obs", &self.prepared.design.n_obs)
+            .field("n_dofs", &self.prepared.design.n_dofs)
+            .field("has_weights", &self.prepared.weights.is_some())
             .field("has_preconditioner", &self.preconditioner.is_some())
             .finish()
     }
@@ -396,38 +368,16 @@ impl<'a> Solver<'a> {
         weights: Option<Vec<f64>>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
-        let mut design = design.into_design()?;
-        design.validate_weights(weights.as_deref())?;
+        let prepared = PreparedDesign::new(design.into_design()?, weights)?;
+        let n_dofs = prepared.design.n_dofs;
 
-        // The match keeps the unpermuted arm a plain move rather than a borrow-and-copy.
-        let weights = match &design.obs_perm {
-            Some(_) => weights.map(|w| design.permute_obs_in(&w).into_owned()),
-            None => weights,
-        };
-
-        // Both readers below need the raw loadings, so the moments precede whitening.
-        let moments = TermMoments::build(&design, weights.as_deref());
-        let mut warnings = moments
-            .as_ref()
-            .map(|m| detect_collinear_slopes(&design, weights.as_deref(), m))
-            .unwrap_or_default();
-
-        // Reparametrize the slope columns (if any) before the preconditioner reads the frame.
-        let reparam = moments
-            .as_ref()
-            .and_then(|m| SlopeReparam::build(&mut design, m));
-
-        let (preconditioner, build_warnings) = match preconditioner.into() {
-            PreconditionerInput::Default => {
-                build_preconditioner(&design, weights.as_deref(), None)?
-            }
-            PreconditionerInput::Config(c) => {
-                build_preconditioner(&design, weights.as_deref(), Some(&c))?
-            }
+        let (preconditioner, preconditioner_warnings) = match preconditioner.into() {
+            PreconditionerInput::Default => build_preconditioner(&prepared, None)?,
+            PreconditionerInput::Config(c) => build_preconditioner(&prepared, Some(&c))?,
             PreconditionerInput::Prebuilt(p) => {
-                if p.nrows() != design.n_dofs || p.ncols() != design.n_dofs {
+                if p.nrows() != n_dofs || p.ncols() != n_dofs {
                     return Err(BuildError::PreconditionerDimensionMismatch {
-                        expected: design.n_dofs,
+                        expected: n_dofs,
                         actual_rows: p.nrows(),
                         actual_cols: p.ncols(),
                     });
@@ -436,43 +386,43 @@ impl<'a> Solver<'a> {
             }
         };
 
-        warnings.extend(build_warnings);
-
-        let sqrt_weights = weights.map(|mut w| {
-            for wi in &mut w {
-                *wi = wi.sqrt();
-            }
-            w
-        });
-
         Ok(Self {
-            design,
-            sqrt_weights,
+            prepared,
             preconditioner,
-            reparam,
-            warnings,
+            preconditioner_warnings,
         })
     }
 
     /// Non-fatal events from design screening and the preconditioner build; a reused
     /// pre-built preconditioner contributes none (its own were reported when built).
-    pub fn warnings(&self) -> &[BuildWarning] {
-        &self.warnings
+    pub fn warnings(&self) -> Vec<BuildWarning> {
+        self.prepared
+            .warnings
+            .iter()
+            .chain(&self.preconditioner_warnings)
+            .cloned()
+            .collect()
     }
 
     /// Shared per-RHS solve: validate `y`, run (m)lsmr, demean, and
     /// back-transform slopes. Excludes the design-level `layout` / `warnings` /
     /// `unidentified`, which the public entry points attach once (see
     /// [`RhsSolution`]).
-    fn solve_rhs(&self, y: &[f64], lsmr: &LsmrOptions) -> Result<RhsSolution, SolveError> {
+    fn solve_rhs(
+        &self,
+        y: &[f64],
+        sqrt_weights: Option<&[f64]>,
+        lsmr: &LsmrOptions,
+    ) -> Result<RhsSolution, SolveError> {
+        let design = &self.prepared.design;
         // `weighted_rhs` zips y with sqrt-weights, silently truncating when `y.len() > n_rows`.
-        if y.len() != self.design.n_obs {
+        if y.len() != design.n_obs {
             return Err(SolveError::InvalidInput {
                 context: "Solver::solve",
                 message: format!(
                     "response vector length ({}) does not match number of observations ({})",
                     y.len(),
-                    self.design.n_obs
+                    design.n_obs
                 ),
             });
         }
@@ -486,10 +436,10 @@ impl<'a> Solver<'a> {
         let t_start = Instant::now();
 
         // The gather is a recurring per-solve cost of the locality sort, so it counts as setup.
-        let y_internal = self.design.permute_obs_in(y);
+        let y_internal = design.permute_obs_in(y);
         let y: &[f64] = &y_internal;
 
-        let rect_op = DesignOperator::new(&self.design, self.sqrt_weights.as_deref());
+        let rect_op = DesignOperator::new(&self.prepared, sqrt_weights);
         let b = rect_op.weighted_rhs(y);
         let b: &[f64] = &b;
 
@@ -510,21 +460,19 @@ impl<'a> Solver<'a> {
         let time_solve = t_solve_start.elapsed().as_secs_f64();
 
         // Shapes are guaranteed here, so the bare `D x` matvec is infallible.
-        let mut demeaned = vec![0.0; self.design.n_obs];
-        gather_apply(&self.design, &r.x, &mut demeaned, None);
+        let mut demeaned = vec![0.0; design.n_obs];
+        gather_apply(&self.prepared, &r.x, &mut demeaned, None);
         for (d, &yi) in demeaned.iter_mut().zip(y.iter()) {
             *d = yi - *d;
         }
 
         let mut x = r.x;
-        if let Some(rp) = &self.reparam {
-            rp.back_transform(&mut x);
-        }
+        self.prepared.basis.back_transform(&mut x);
 
         Ok(RhsSolution {
             x,
             // Back to the caller's observation order (no-op if not reordered).
-            demeaned: self.design.permute_obs_out(demeaned),
+            demeaned: design.permute_obs_out(demeaned),
             converged: r.converged,
             iterations: r.iterations,
             // Read from the LSMR recurrence at no extra cost; see `SolveResult::residual`.
@@ -537,14 +485,11 @@ impl<'a> Solver<'a> {
     /// Per-level directions the data cannot identify, shared across all RHS:
     /// identification depends only on the design and weights, never on `y`.
     fn unidentified(&self) -> Vec<CoefficientAddress> {
-        let Some(reparam) = &self.reparam else {
-            return Vec::new();
-        };
-        reparam
+        self.prepared
+            .basis
             .unidentified
             .iter()
-            .copied()
-            .map(|position| position.to_caller_address(&self.design))
+            .map(|position| position.to_caller_address(&self.prepared.design))
             .collect()
     }
 
@@ -558,13 +503,14 @@ impl<'a> Solver<'a> {
         let lsmr = lsmr.into().unwrap_or(&default);
 
         let t_start = Instant::now();
-        let solution = self.solve_rhs(y, lsmr)?;
+        let sqrt_weights = self.prepared.sqrt_weights();
+        let solution = self.solve_rhs(y, sqrt_weights.as_deref(), lsmr)?;
 
         Ok(SolveResult {
             x: solution.x,
             unidentified: self.unidentified(),
-            warnings: self.warnings.clone(),
-            layout: CoefficientLayout::from_design(&self.design),
+            warnings: self.warnings(),
+            layout: CoefficientLayout::from_design(&self.prepared.design),
             demeaned: solution.demeaned,
             converged: solution.converged,
             iterations: solution.iterations,
@@ -586,14 +532,17 @@ impl<'a> Solver<'a> {
         let lsmr = lsmr.into().unwrap_or(&default);
         let n_rhs = ys.len();
 
+        // One `W^{1/2}` shared by every RHS's operator, computed once per batch.
+        let sqrt_weights = self.prepared.sqrt_weights();
         // Collecting into `Result` fails fast on the first per-RHS error, not during the fold.
         let solutions: Vec<RhsSolution> = ys
             .par_iter()
-            .map(|y| self.solve_rhs(y, lsmr))
+            .map(|y| self.solve_rhs(y, sqrt_weights.as_deref(), lsmr))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut x = Vec::with_capacity(self.design.n_dofs * n_rhs);
-        let mut demeaned = Vec::with_capacity(self.design.n_obs * n_rhs);
+        let design = &self.prepared.design;
+        let mut x = Vec::with_capacity(design.n_dofs * n_rhs);
+        let mut demeaned = Vec::with_capacity(design.n_obs * n_rhs);
         let mut converged = Vec::with_capacity(n_rhs);
         let mut iterations = Vec::with_capacity(n_rhs);
         let mut residual = Vec::with_capacity(n_rhs);
@@ -611,8 +560,8 @@ impl<'a> Solver<'a> {
         Ok(BatchSolveResult {
             x,
             unidentified: self.unidentified(),
-            warnings: self.warnings.clone(),
-            layout: CoefficientLayout::from_design(&self.design),
+            warnings: self.warnings(),
+            layout: CoefficientLayout::from_design(design),
             demeaned,
             converged,
             iterations,
@@ -620,8 +569,8 @@ impl<'a> Solver<'a> {
             time_solve,
             time_setup: 0.0,
             time_total: t_start.elapsed().as_secs_f64(),
-            n_dofs: self.design.n_dofs,
-            n_obs: self.design.n_obs,
+            n_dofs: design.n_dofs,
+            n_obs: design.n_obs,
         })
     }
 
@@ -632,12 +581,12 @@ impl<'a> Solver<'a> {
 
     /// Number of DOFs (coefficients).
     pub fn n_dofs(&self) -> usize {
-        self.design.n_dofs
+        self.prepared.design.n_dofs
     }
 
     /// Number of observations.
     pub fn n_obs(&self) -> usize {
-        self.design.n_obs
+        self.prepared.design.n_obs
     }
 }
 

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -1,9 +1,7 @@
-use super::reparam::SlopeReparam;
 use super::{CoefficientAddress, CoefficientLayout};
 use crate::channel::Channel;
 use crate::config::{LocalSolverConfig, DEFAULT_DENSE_SCHUR_THRESHOLD};
-use crate::domain::level_moments::TermMoments;
-use crate::domain::{build_local_domains, Design, Grounding, MatrixForm};
+use crate::domain::{build_local_domains, Design, Grounding, MatrixForm, PreparedDesign};
 use crate::Effect;
 
 /// DGP kept in lockstep with `surplus_component_sampled_matches_exact_reduction`
@@ -34,11 +32,9 @@ fn positive_slope_only_pair_grounds_beyond_dense_threshold() {
         Effect::new(&f, false, [&z[..]]).expect("slope effect"),
         Effect::new(&g, true, []).expect("plain effect"),
     ];
-    let mut design = Design::new(effects).expect("design");
-    let moments = TermMoments::build(&design, None).expect("slopes");
-    let _reparam = SlopeReparam::build(&mut design, &moments);
+    let prepared = PreparedDesign::unweighted_for_test(Design::new(effects).expect("design"));
     let (domains, warnings) =
-        build_local_domains(&design, None, &LocalSolverConfig::default()).expect("domains");
+        build_local_domains(&prepared, &LocalSolverConfig::default()).expect("domains");
     assert!(
         domains.iter().any(|ld| {
             let ct = &ld.component.matrix.cross_tab;


### PR DESCRIPTION
Prototype alternative to #318 (which now covers #323 and #324), branched from the same base. No public API change.

- `Design` (structure, layout, permutation, active levels) shares its per-observation data on clone (`Arc` frame and permutation), the way `Preconditioner` already does. `Solver::new(design.clone(), …)` is the sharing API; `IntoDesign` is unchanged.
- `PreparedDesign { design, weights, basis: SlopeBasis }` holds what one weight vector determines. `SlopeBasis` owns the whitened loading columns, so `replace_loading_column` and the frame mutation are gone.
- The collinearity screen reads the term's span from the whitened basis (weight-orthonormal per level), removing its own per-level decomposition.
- `Solver { prepared, preconditioner, warnings }`; `CoefficientAddress` moves to `channel.rs` (crate-root path unchanged).

Verification: 216 Rust and 106 Python tests pass, clippy clean. A/B at 5M obs with 2 slopes against the base: setup, solve and RSS within noise.

Open: `from_frame` still ignores unclaimed continuous columns (needs a `BuildError` variant).