### PR TITLE
Add PreparedDesign per weight vector over a shared Design

### DIFF
--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -253,10 +253,10 @@ impl PySolver {
             }
             DesignSource::Effects(terms) => {
                 py.detach(move || -> Result<Solver<'static>, BuildError> {
+                    let w_cow = w_view.as_ref().map(coerce_to_slice);
                     let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                     // The solver outlives the terms' buffers, so lower to owned columns first.
                     let design = Design::new(effects)?.into_owned();
-                    let w_cow = w_view.as_ref().map(coerce_to_slice);
                     Solver::new(design, w_cow.as_deref(), precond)
                 })
             }

--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -25,7 +25,7 @@ use crate::results::{
 fn build_and_solve<'a>(
     design: impl IntoDesign<'a>,
     y: &[f64],
-    weights: Option<Vec<f64>>,
+    weights: Option<&[f64]>,
     lsmr: &LsmrOptions,
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(SolveResult, Vec<BuildWarning>), WithinError> {
@@ -42,7 +42,7 @@ fn build_and_solve<'a>(
 fn build_and_solve_batch<'a>(
     design: impl IntoDesign<'a>,
     ys: &[&[f64]],
-    weights: Option<Vec<f64>>,
+    weights: Option<&[f64]>,
     lsmr: &LsmrOptions,
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(BatchSolveResult, Vec<BuildWarning>), WithinError> {
@@ -79,19 +79,15 @@ pub fn solve<'py>(
             let cats = categories.as_array();
             run_solve_with_warnings(py, move || {
                 let y_cow = coerce_to_slice(&y_arr);
-                build_and_solve(cats, &y_cow, w_view.map(|w| w.to_vec()), &params, precond)
+                let w_cow = w_view.as_ref().map(coerce_to_slice);
+                build_and_solve(cats, &y_cow, w_cow.as_deref(), &params, precond)
             })
         }
         DesignSource::Effects(terms) => run_solve_with_warnings(py, move || {
             let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
             let y_cow = coerce_to_slice(&y_arr);
-            build_and_solve(
-                effects,
-                &y_cow,
-                w_view.map(|w| w.to_vec()),
-                &params,
-                precond,
-            )
+            let w_cow = w_view.as_ref().map(coerce_to_slice);
+            build_and_solve(effects, &y_cow, w_cow.as_deref(), &params, precond)
         }),
     }
 }
@@ -121,13 +117,8 @@ pub fn solve_batch<'py>(
             run_batch_with_warnings(py, move || {
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
-                build_and_solve_batch(
-                    cats,
-                    &col_refs,
-                    w_view.map(|w| w.to_vec()),
-                    &params,
-                    precond,
-                )
+                let w_cow = w_view.as_ref().map(coerce_to_slice);
+                build_and_solve_batch(cats, &col_refs, w_cow.as_deref(), &params, precond)
             })
         }
         DesignSource::Effects(terms) => {
@@ -138,13 +129,8 @@ pub fn solve_batch<'py>(
                 let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
-                build_and_solve_batch(
-                    effects,
-                    &col_refs,
-                    w_view.map(|w| w.to_vec()),
-                    &params,
-                    precond,
-                )
+                let w_cow = w_view.as_ref().map(coerce_to_slice);
+                build_and_solve_batch(effects, &col_refs, w_cow.as_deref(), &params, precond)
             })
         }
     }
@@ -253,7 +239,7 @@ impl PySolver {
         preconditioner: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Self> {
         let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
-        let weights_vec: Option<Vec<f64>> = weights.as_ref().map(|w| w.as_array().to_vec());
+        let w_view = weights.as_ref().map(|w| w.as_array());
         let precond = resolve_precond_input(preconditioner)?;
 
         // `BuildError` carries no Python types, so it maps to an exception once the GIL is back.
@@ -261,7 +247,8 @@ impl PySolver {
             DesignSource::Categories(categories) => {
                 let cats = categories.as_array();
                 py.detach(move || -> Result<Solver<'static>, BuildError> {
-                    Solver::new(cats.into_design()?.into_owned(), weights_vec, precond)
+                    let w_cow = w_view.as_ref().map(coerce_to_slice);
+                    Solver::new(cats.into_design()?.into_owned(), w_cow.as_deref(), precond)
                 })
             }
             DesignSource::Effects(terms) => {
@@ -269,7 +256,8 @@ impl PySolver {
                     let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                     // The solver outlives the terms' buffers, so lower to owned columns first.
                     let design = Design::new(effects)?.into_owned();
-                    Solver::new(design, weights_vec, precond)
+                    let w_cow = w_view.as_ref().map(coerce_to_slice);
+                    Solver::new(design, w_cow.as_deref(), precond)
                 })
             }
         }

--- a/crates/within/src/channel.rs
+++ b/crates/within/src/channel.rs
@@ -30,3 +30,12 @@ impl std::fmt::Display for ChannelPair {
         write!(f, "{} and {}", self.rows, self.cols)
     }
 }
+
+/// One coefficient of the design: a [`Channel`] at one level of its term.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CoefficientAddress {
+    /// The coefficient column this address sits in.
+    pub channel: Channel,
+    /// Level index within the term (`0..n_levels`).
+    pub level: usize,
+}

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -4,13 +4,13 @@ pub(crate) mod collinearity;
 pub(crate) mod cross_tab;
 mod effect;
 pub(crate) mod factor_pairs;
-mod level_moments;
+pub(crate) mod level_moments;
 mod prepared;
-mod slope_basis;
+mod reparam;
 
 pub(crate) use cross_tab::{find_all_active_levels, BlockDiagonals, CrossTab};
-pub(crate) use prepared::{row_weight, PreparedDesign};
-use slope_basis::SlopeBasis;
+pub(crate) use prepared::PreparedDesign;
+use reparam::SlopeReparam;
 
 pub use effect::Effect;
 
@@ -95,19 +95,6 @@ pub(crate) struct TermMeta {
 }
 
 impl TermMeta {
-    /// Frame columns of the term's covariates, in coefficient-column order.
-    pub(crate) fn covariates(&self) -> impl Iterator<Item = u32> + '_ {
-        self.columns.iter().filter_map(|c| c.covariate().copied())
-    }
-
-    pub(crate) fn has_slopes(&self) -> bool {
-        self.covariates().next().is_some()
-    }
-
-    pub(crate) fn has_intercept(&self) -> bool {
-        self.columns.iter().any(|c| c.covariate().is_none())
-    }
-
     pub fn n_columns(&self) -> usize {
         self.columns.len()
     }
@@ -120,6 +107,11 @@ impl TermMeta {
     pub fn column_base(&self, column: usize) -> usize {
         self.offset + column * self.n_levels
     }
+}
+
+/// The Gram weight of row `obs`: the operator applies `s`, so its normal matrix carries `s²`.
+pub(crate) fn row_weight(sqrt_weights: Option<&[f64]>, obs: usize) -> f64 {
+    sqrt_weights.map_or(1.0, |s| s[obs] * s[obs])
 }
 
 /// Stable argsort of observations by a level column, ascending.
@@ -237,7 +229,11 @@ impl<'a> Design<'a> {
             terms.push(meta);
         }
 
-        let claimed: usize = terms.iter().map(|t| t.covariates().count()).sum();
+        let claimed: usize = terms
+            .iter()
+            .flat_map(|t| t.columns.iter())
+            .filter(|c| c.covariate().is_some())
+            .count();
         if claimed != frame.n_loading_columns() {
             return Err(BuildError::UnclaimedLoadingColumns {
                 claimed,
@@ -283,6 +279,27 @@ impl<'a> Design<'a> {
             n_dofs: self.n_dofs,
             obs_perm: self.obs_perm,
         }
+    }
+
+    /// Validate that an optional weight slice matches this design's observation count.
+    pub(crate) fn validate_weights(&self, weights: Option<&[f64]>) -> Result<(), BuildError> {
+        if let Some(w) = weights {
+            if w.len() != self.n_obs {
+                return Err(BuildError::WeightCountMismatch {
+                    expected: self.n_obs,
+                    got: w.len(),
+                });
+            }
+            // `wi >= 0.0` already rejects NaN; `is_finite` additionally rejects `+∞`.
+            if let Some((index, &value)) = w
+                .iter()
+                .enumerate()
+                .find(|&(_, &wi)| !(wi >= 0.0 && wi.is_finite()))
+            {
+                return Err(BuildError::InvalidWeight { index, value });
+            }
+        }
+        Ok(())
     }
 
     /// Caller order → internal order: `out[k] = v[obs_perm[k]]`; borrows when unpermuted.
@@ -409,14 +426,30 @@ mod tests {
     }
 
     #[test]
-    fn from_frame_rejects_unclaimed_loading_columns() {
-        let err = Design::from_frame(frame(vec![vec![0, 1]], vec![vec![1.0, 2.0]])).unwrap_err();
+    fn validate_weights_checks_count_and_finiteness() {
+        let design = Design::from_frame(frame(vec![vec![0, 0, 0, 0, 0]], vec![])).unwrap();
+        assert!(design.validate_weights(None).is_ok());
+        assert!(design
+            .validate_weights(Some(&[1.0, 2.0, 3.0, 4.0, 5.0]))
+            .is_ok());
+        // Zero weights are valid (an excluded observation).
+        assert!(design
+            .validate_weights(Some(&[0.0, 1.0, 2.0, 3.0, 4.0]))
+            .is_ok());
+        // Length mismatch.
+        assert!(design.validate_weights(Some(&[1.0, 2.0])).is_err());
+        // Negative / non-finite weights are rejected with the offending index.
         assert!(matches!(
-            err,
-            BuildError::UnclaimedLoadingColumns {
-                claimed: 0,
-                provided: 1
-            }
+            design.validate_weights(Some(&[1.0, -2.0, 3.0, 4.0, 5.0])),
+            Err(BuildError::InvalidWeight { index: 1, .. })
+        ));
+        assert!(matches!(
+            design.validate_weights(Some(&[1.0, 2.0, f64::NAN, 4.0, 5.0])),
+            Err(BuildError::InvalidWeight { index: 2, .. })
+        ));
+        assert!(matches!(
+            design.validate_weights(Some(&[1.0, 2.0, 3.0, f64::INFINITY, 5.0])),
+            Err(BuildError::InvalidWeight { index: 3, .. })
         ));
     }
 
@@ -454,6 +487,18 @@ mod tests {
         assert!(design.obs_perm.is_none());
         assert!(design.terms[0].sorted);
         assert!(!design.terms[1].sorted);
+    }
+
+    #[test]
+    fn from_frame_rejects_unclaimed_loading_columns() {
+        let err = Design::from_frame(frame(vec![vec![0, 1]], vec![vec![1.0, 2.0]])).unwrap_err();
+        assert!(matches!(
+            err,
+            BuildError::UnclaimedLoadingColumns {
+                claimed: 0,
+                provided: 1
+            }
+        ));
     }
 
     #[test]

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -4,7 +4,7 @@ pub(crate) mod collinearity;
 pub(crate) mod cross_tab;
 mod effect;
 pub(crate) mod factor_pairs;
-pub(crate) mod level_moments;
+mod level_moments;
 mod prepared;
 mod reparam;
 
@@ -95,6 +95,19 @@ pub(crate) struct TermMeta {
 }
 
 impl TermMeta {
+    /// Frame columns of the term's covariates, in coefficient-column order.
+    pub(crate) fn covariates(&self) -> impl Iterator<Item = u32> + '_ {
+        self.columns.iter().filter_map(|c| c.covariate().copied())
+    }
+
+    pub(crate) fn has_slopes(&self) -> bool {
+        self.covariates().next().is_some()
+    }
+
+    pub(crate) fn has_intercept(&self) -> bool {
+        self.columns.iter().any(|c| c.covariate().is_none())
+    }
+
     pub fn n_columns(&self) -> usize {
         self.columns.len()
     }

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -237,6 +237,14 @@ impl<'a> Design<'a> {
             terms.push(meta);
         }
 
+        let claimed: usize = terms.iter().map(|t| t.covariates().count()).sum();
+        if claimed != frame.n_loading_columns() {
+            return Err(BuildError::UnclaimedLoadingColumns {
+                claimed,
+                provided: frame.n_loading_columns(),
+            });
+        }
+
         // Rejected here rather than left to panic in `to_u32`.
         if u32::try_from(offset).is_err() {
             return Err(BuildError::DofSpaceExceedsU32 { n_dofs: offset });
@@ -429,6 +437,18 @@ mod tests {
     }
 
     #[test]
+    fn from_frame_rejects_unclaimed_loading_columns() {
+        let err = Design::from_frame(frame(vec![vec![0, 1]], vec![vec![1.0, 2.0]])).unwrap_err();
+        assert!(matches!(
+            err,
+            BuildError::UnclaimedLoadingColumns {
+                claimed: 0,
+                provided: 1
+            }
+        ));
+    }
+
+    #[test]
     fn permute_weights_checks_count_and_finiteness() {
         let design = Design::from_frame(frame(vec![vec![0, 0, 0, 0, 0]], vec![])).unwrap();
         let check = |w: &[f64]| design.permute_weights(Some(w.to_vec()));
@@ -491,11 +511,9 @@ mod tests {
 
     #[test]
     fn continuous_column_stays_row_aligned_after_locality_sort() {
-        let design = Design::from_frame(frame(
-            vec![vec![2, 0, 1, 0]],
-            vec![vec![10.0, 20.0, 30.0, 40.0]],
-        ))
-        .unwrap();
+        let levels = [2u32, 0, 1, 0];
+        let z = [10.0, 20.0, 30.0, 40.0];
+        let design = Design::new([Effect::new(&levels, true, [&z[..]]).unwrap()]).unwrap();
 
         let perm = design.obs_perm.as_deref().expect("permutation applied");
         assert_eq!(perm, [1, 3, 2, 0]);

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -285,34 +285,6 @@ impl<'a> Design<'a> {
         }
     }
 
-    /// Validated weights in internal observation order.
-    pub(crate) fn permute_weights(
-        &self,
-        weights: Option<Vec<f64>>,
-    ) -> Result<Option<Vec<f64>>, BuildError> {
-        if let Some(w) = &weights {
-            if w.len() != self.n_obs {
-                return Err(BuildError::WeightCountMismatch {
-                    expected: self.n_obs,
-                    got: w.len(),
-                });
-            }
-            // `wi >= 0.0` already rejects NaN; `is_finite` additionally rejects `+∞`.
-            if let Some((index, &value)) = w
-                .iter()
-                .enumerate()
-                .find(|&(_, &wi)| !(wi >= 0.0 && wi.is_finite()))
-            {
-                return Err(BuildError::InvalidWeight { index, value });
-            }
-        }
-        // The match keeps the unpermuted arm a plain move rather than a borrow-and-copy.
-        Ok(match &self.obs_perm {
-            Some(_) => weights.map(|w| self.permute_obs_in(&w).into_owned()),
-            None => weights,
-        })
-    }
-
     /// Caller order → internal order: `out[k] = v[obs_perm[k]]`; borrows when unpermuted.
     pub(crate) fn permute_obs_in<'v>(&self, v: &'v [f64]) -> Cow<'v, [f64]> {
         debug_assert_eq!(v.len(), self.n_obs);
@@ -449,31 +421,6 @@ mod tests {
     }
 
     #[test]
-    fn permute_weights_checks_count_and_finiteness() {
-        let design = Design::from_frame(frame(vec![vec![0, 0, 0, 0, 0]], vec![])).unwrap();
-        let check = |w: &[f64]| design.permute_weights(Some(w.to_vec()));
-        assert!(design.permute_weights(None).is_ok());
-        assert!(check(&[1.0, 2.0, 3.0, 4.0, 5.0]).is_ok());
-        // Zero weights are valid (an excluded observation).
-        assert!(check(&[0.0, 1.0, 2.0, 3.0, 4.0]).is_ok());
-        // Length mismatch.
-        assert!(check(&[1.0, 2.0]).is_err());
-        // Negative / non-finite weights are rejected with the offending index.
-        assert!(matches!(
-            check(&[1.0, -2.0, 3.0, 4.0, 5.0]),
-            Err(BuildError::InvalidWeight { index: 1, .. })
-        ));
-        assert!(matches!(
-            check(&[1.0, 2.0, f64::NAN, 4.0, 5.0]),
-            Err(BuildError::InvalidWeight { index: 2, .. })
-        ));
-        assert!(matches!(
-            check(&[1.0, 2.0, 3.0, f64::INFINITY, 5.0]),
-            Err(BuildError::InvalidWeight { index: 3, .. })
-        ));
-    }
-
-    #[test]
     fn from_frame_sorts_owned_unsorted_dominant() {
         // Factor 0 (3 levels) dominates and is unsorted; factor 1 starts sorted.
         let design =
@@ -507,18 +454,6 @@ mod tests {
         assert!(design.obs_perm.is_none());
         assert!(design.terms[0].sorted);
         assert!(!design.terms[1].sorted);
-    }
-
-    #[test]
-    fn continuous_column_stays_row_aligned_after_locality_sort() {
-        let levels = [2u32, 0, 1, 0];
-        let z = [10.0, 20.0, 30.0, 40.0];
-        let design = Design::new([Effect::new(&levels, true, [&z[..]]).unwrap()]).unwrap();
-
-        let perm = design.obs_perm.as_deref().expect("permutation applied");
-        assert_eq!(perm, [1, 3, 2, 0]);
-        assert_eq!(design.frame.level_column(0), [0, 0, 1, 2]);
-        assert_eq!(design.frame.loading_column(0), [20.0, 40.0, 30.0, 10.0]);
     }
 
     #[test]

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -4,13 +4,13 @@ pub(crate) mod collinearity;
 pub(crate) mod cross_tab;
 mod effect;
 pub(crate) mod factor_pairs;
-pub(crate) mod level_moments;
+mod level_moments;
 mod prepared;
 mod slope_basis;
 
 pub(crate) use cross_tab::{find_all_active_levels, BlockDiagonals, CrossTab};
 pub(crate) use prepared::PreparedDesign;
-pub(crate) use slope_basis::SlopeBasis;
+use slope_basis::SlopeBasis;
 
 pub use effect::Effect;
 

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -5,8 +5,12 @@ pub(crate) mod cross_tab;
 mod effect;
 pub(crate) mod factor_pairs;
 pub(crate) mod level_moments;
+mod prepared;
+mod slope_basis;
 
 pub(crate) use cross_tab::{find_all_active_levels, BlockDiagonals, CrossTab};
+pub(crate) use prepared::PreparedDesign;
+pub(crate) use slope_basis::SlopeBasis;
 
 pub use effect::Effect;
 
@@ -16,6 +20,7 @@ pub(crate) use factor_pairs::{
 };
 
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use crate::channel::Channel;
 use crate::observation::ObservationFrame;
@@ -90,6 +95,19 @@ pub(crate) struct TermMeta {
 }
 
 impl TermMeta {
+    /// Frame columns of the term's covariates, in coefficient-column order.
+    pub(crate) fn covariates(&self) -> impl Iterator<Item = u32> + '_ {
+        self.columns.iter().filter_map(|c| c.covariate().copied())
+    }
+
+    pub(crate) fn has_slopes(&self) -> bool {
+        self.covariates().next().is_some()
+    }
+
+    pub(crate) fn has_intercept(&self) -> bool {
+        self.columns.iter().any(|c| c.covariate().is_none())
+    }
+
     pub fn n_columns(&self) -> usize {
         self.columns.len()
     }
@@ -141,16 +159,16 @@ fn stable_argsort(key: &[u32], n_levels: usize) -> Vec<u32> {
     perm
 }
 
-/// Fixed-effects design: observation columns plus coefficient-space layout.
+/// Fixed-effects design: observation columns plus coefficient-space layout; clones share rows.
 #[derive(Clone, Debug)]
 pub struct Design<'a> {
     /// Columns in internal row order (caller's, or an owned locality-sorted copy).
-    pub(crate) frame: ObservationFrame<'a>,
+    pub(crate) frame: Arc<ObservationFrame<'a>>,
     pub(crate) terms: Vec<TermMeta>,
     pub(crate) n_obs: usize,
     pub(crate) n_dofs: usize,
     /// `obs_perm[k]` = caller's original index of the observation at internal position `k`.
-    pub(crate) obs_perm: Option<Vec<u32>>,
+    pub(crate) obs_perm: Option<Arc<[u32]>>,
 }
 
 impl<'a> Design<'a> {
@@ -234,13 +252,13 @@ impl<'a> Design<'a> {
                 for (q, meta) in terms.iter_mut().enumerate() {
                     meta.sorted = sorted_frame.level_column(q).is_sorted();
                 }
-                (sorted_frame, Some(perm))
+                (sorted_frame, Some(perm.into()))
             }
             _ => (frame, None),
         };
 
         Ok(Design {
-            frame,
+            frame: Arc::new(frame),
             terms,
             n_obs,
             n_dofs: offset,
@@ -251,7 +269,7 @@ impl<'a> Design<'a> {
     /// Convert the frame's columns to owned, dropping ties to caller buffers.
     pub fn into_owned(self) -> Design<'static> {
         Design {
-            frame: self.frame.into_owned(),
+            frame: Arc::new(Arc::unwrap_or_clone(self.frame).into_owned()),
             terms: self.terms,
             n_obs: self.n_obs,
             n_dofs: self.n_dofs,
@@ -259,9 +277,12 @@ impl<'a> Design<'a> {
         }
     }
 
-    /// Validate that an optional weight slice matches this design's observation count.
-    pub(crate) fn validate_weights(&self, weights: Option<&[f64]>) -> Result<(), BuildError> {
-        if let Some(w) = weights {
+    /// Validated weights in internal observation order.
+    pub(crate) fn permute_weights(
+        &self,
+        weights: Option<Vec<f64>>,
+    ) -> Result<Option<Vec<f64>>, BuildError> {
+        if let Some(w) = &weights {
             if w.len() != self.n_obs {
                 return Err(BuildError::WeightCountMismatch {
                     expected: self.n_obs,
@@ -277,7 +298,11 @@ impl<'a> Design<'a> {
                 return Err(BuildError::InvalidWeight { index, value });
             }
         }
-        Ok(())
+        // The match keeps the unpermuted arm a plain move rather than a borrow-and-copy.
+        Ok(match &self.obs_perm {
+            Some(_) => weights.map(|w| self.permute_obs_in(&w).into_owned()),
+            None => weights,
+        })
     }
 
     /// Caller order → internal order: `out[k] = v[obs_perm[k]]`; borrows when unpermuted.
@@ -404,29 +429,26 @@ mod tests {
     }
 
     #[test]
-    fn validate_weights_checks_count_and_finiteness() {
+    fn permute_weights_checks_count_and_finiteness() {
         let design = Design::from_frame(frame(vec![vec![0, 0, 0, 0, 0]], vec![])).unwrap();
-        assert!(design.validate_weights(None).is_ok());
-        assert!(design
-            .validate_weights(Some(&[1.0, 2.0, 3.0, 4.0, 5.0]))
-            .is_ok());
+        let check = |w: &[f64]| design.permute_weights(Some(w.to_vec()));
+        assert!(design.permute_weights(None).is_ok());
+        assert!(check(&[1.0, 2.0, 3.0, 4.0, 5.0]).is_ok());
         // Zero weights are valid (an excluded observation).
-        assert!(design
-            .validate_weights(Some(&[0.0, 1.0, 2.0, 3.0, 4.0]))
-            .is_ok());
+        assert!(check(&[0.0, 1.0, 2.0, 3.0, 4.0]).is_ok());
         // Length mismatch.
-        assert!(design.validate_weights(Some(&[1.0, 2.0])).is_err());
+        assert!(check(&[1.0, 2.0]).is_err());
         // Negative / non-finite weights are rejected with the offending index.
         assert!(matches!(
-            design.validate_weights(Some(&[1.0, -2.0, 3.0, 4.0, 5.0])),
+            check(&[1.0, -2.0, 3.0, 4.0, 5.0]),
             Err(BuildError::InvalidWeight { index: 1, .. })
         ));
         assert!(matches!(
-            design.validate_weights(Some(&[1.0, 2.0, f64::NAN, 4.0, 5.0])),
+            check(&[1.0, 2.0, f64::NAN, 4.0, 5.0]),
             Err(BuildError::InvalidWeight { index: 2, .. })
         ));
         assert!(matches!(
-            design.validate_weights(Some(&[1.0, 2.0, 3.0, f64::INFINITY, 5.0])),
+            check(&[1.0, 2.0, 3.0, f64::INFINITY, 5.0]),
             Err(BuildError::InvalidWeight { index: 3, .. })
         ));
     }
@@ -475,8 +497,8 @@ mod tests {
         ))
         .unwrap();
 
-        let perm = design.obs_perm.as_ref().expect("permutation applied");
-        assert_eq!(perm, &[1, 3, 2, 0]);
+        let perm = design.obs_perm.as_deref().expect("permutation applied");
+        assert_eq!(perm, [1, 3, 2, 0]);
         assert_eq!(design.frame.level_column(0), [0, 0, 1, 2]);
         assert_eq!(design.frame.loading_column(0), [20.0, 40.0, 30.0, 10.0]);
     }

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -9,7 +9,7 @@ mod prepared;
 mod slope_basis;
 
 pub(crate) use cross_tab::{find_all_active_levels, BlockDiagonals, CrossTab};
-pub(crate) use prepared::PreparedDesign;
+pub(crate) use prepared::{row_weight, PreparedDesign};
 use slope_basis::SlopeBasis;
 
 pub use effect::Effect;

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -294,27 +294,6 @@ impl<'a> Design<'a> {
         }
     }
 
-    /// Validate that an optional weight slice matches this design's observation count.
-    pub(crate) fn validate_weights(&self, weights: Option<&[f64]>) -> Result<(), BuildError> {
-        if let Some(w) = weights {
-            if w.len() != self.n_obs {
-                return Err(BuildError::WeightCountMismatch {
-                    expected: self.n_obs,
-                    got: w.len(),
-                });
-            }
-            // `wi >= 0.0` already rejects NaN; `is_finite` additionally rejects `+∞`.
-            if let Some((index, &value)) = w
-                .iter()
-                .enumerate()
-                .find(|&(_, &wi)| !(wi >= 0.0 && wi.is_finite()))
-            {
-                return Err(BuildError::InvalidWeight { index, value });
-            }
-        }
-        Ok(())
-    }
-
     /// Caller order → internal order: `out[k] = v[obs_perm[k]]`; borrows when unpermuted.
     pub(crate) fn permute_obs_in<'v>(&self, v: &'v [f64]) -> Cow<'v, [f64]> {
         debug_assert_eq!(v.len(), self.n_obs);
@@ -435,34 +414,6 @@ mod tests {
         assert!(matches!(
             err,
             BuildError::DofSpaceExceedsU32 { n_dofs } if n_dofs == u32::MAX as usize + 1
-        ));
-    }
-
-    #[test]
-    fn validate_weights_checks_count_and_finiteness() {
-        let design = Design::from_frame(frame(vec![vec![0, 0, 0, 0, 0]], vec![])).unwrap();
-        assert!(design.validate_weights(None).is_ok());
-        assert!(design
-            .validate_weights(Some(&[1.0, 2.0, 3.0, 4.0, 5.0]))
-            .is_ok());
-        // Zero weights are valid (an excluded observation).
-        assert!(design
-            .validate_weights(Some(&[0.0, 1.0, 2.0, 3.0, 4.0]))
-            .is_ok());
-        // Length mismatch.
-        assert!(design.validate_weights(Some(&[1.0, 2.0])).is_err());
-        // Negative / non-finite weights are rejected with the offending index.
-        assert!(matches!(
-            design.validate_weights(Some(&[1.0, -2.0, 3.0, 4.0, 5.0])),
-            Err(BuildError::InvalidWeight { index: 1, .. })
-        ));
-        assert!(matches!(
-            design.validate_weights(Some(&[1.0, 2.0, f64::NAN, 4.0, 5.0])),
-            Err(BuildError::InvalidWeight { index: 2, .. })
-        ));
-        assert!(matches!(
-            design.validate_weights(Some(&[1.0, 2.0, 3.0, f64::INFINITY, 5.0])),
-            Err(BuildError::InvalidWeight { index: 3, .. })
         ));
     }
 

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -5,7 +5,8 @@ use std::ops::Range;
 
 use rayon::prelude::*;
 
-use super::{row_weight, Design, PreparedDesign, TermMeta};
+use super::level_moments::{BasisScratch, LevelMoments, TermMoments};
+use super::{row_weight, Design};
 use crate::channel::Channel;
 use crate::BuildWarning;
 
@@ -18,9 +19,12 @@ const TABLE_BUDGET_BYTES: usize = 64 << 20;
 /// Rows one residual task claims; small enough that work stealing balances the tail.
 const ROWS_PER_TASK: usize = 1 << 16;
 
-pub(crate) fn detect_collinear_slopes(prepared: &PreparedDesign<'_>) -> Vec<BuildWarning> {
-    let design = &prepared.design;
-    if design.n_factors() < 2 || !design.terms.iter().any(TermMeta::has_slopes) {
+pub(crate) fn detect_collinear_slopes(
+    design: &Design<'_>,
+    sqrt_weights: Option<&[f64]>,
+    moments: &TermMoments,
+) -> Vec<BuildWarning> {
+    if design.n_factors() < 2 {
         return Vec::new();
     }
     let budget = TABLE_BUDGET_BYTES / std::mem::size_of::<f64>() / design.n_factors();
@@ -28,7 +32,7 @@ pub(crate) fn detect_collinear_slopes(prepared: &PreparedDesign<'_>) -> Vec<Buil
         .into_par_iter()
         .flat_map_iter(move |term| {
             let targets = screened_covariates(design, term);
-            residual_shares(prepared, term, &targets, budget)
+            residual_shares(design, sqrt_weights, moments, term, &targets, budget)
                 .into_iter()
                 .zip(targets)
                 .filter(|&(share, _)| share <= COLLINEARITY_TOL)
@@ -54,7 +58,9 @@ fn screened_covariates(design: &Design<'_>, term: usize) -> Vec<(Channel, u32)> 
 
 /// Two passes, so the share resolves below the `1e-16` a subtraction floors at.
 fn residual_shares(
-    prepared: &PreparedDesign<'_>,
+    design: &Design<'_>,
+    sqrt_weights: Option<&[f64]>,
+    moments: &TermMoments,
     term: usize,
     targets: &[(Channel, u32)],
     budget: usize,
@@ -63,37 +69,36 @@ fn residual_shares(
     if m == 0 {
         return Vec::new();
     }
-    let (design, sqrt_weights) = (&prepared.design, prepared.sqrt_weights.as_deref());
-    let meta = &design.terms[term];
+    let moments = &moments[term];
     let levels = design.frame.level_column(term);
-    let us: Vec<&[f64]> = meta
+    let zs: Vec<&[f64]> = moments
         .covariates()
-        .map(|c| prepared.basis.loading_column(c as usize))
+        .iter()
+        .map(|&c| design.frame.loading_column(c as usize))
         .collect();
-    let intercept = meta.has_intercept();
     let columns: Vec<&[f64]> = targets
         .iter()
         .map(|&(_, c)| design.frame.loading_column(c as usize))
         .collect();
-    let stride = columns.len() * (us.len() + 1);
-    let n_levels = meta.n_levels;
+    let stride = columns.len() * (zs.len() + 1);
+    let n_levels = moments.n_levels();
     let plan = ScreenPlan::new(budget, n_levels, stride);
     let screen = Screen {
         levels,
         sqrt_weights,
-        us,
+        zs,
         columns,
-        intercept,
+        zeros: vec![0.0; moments.n_slopes()],
+        moments,
         stride,
         // Grouping gathers every column, so it must buy back more than the one block.
-        order: match meta.sorted || plan.per_block == n_levels {
+        order: match design.terms[term].sorted || plan.per_block == n_levels {
             true => RowOrder::AsIs,
             false => RowOrder::Grouped(super::stable_argsort(levels, n_levels)),
         },
     };
 
     let mut table = vec![0.0f64; plan.per_block * stride];
-    let mut level_weight = vec![0.0f64; plan.per_block];
     let mut residual = vec![0.0f64; m];
     let mut variations = Variations {
         w_sum: 0.0,
@@ -105,14 +110,13 @@ fn residual_shares(
             levels: levels_block,
         };
         let table = &mut table[..block.levels.len() * stride];
-        let level_weight = &mut level_weight[..block.levels.len()];
         table.fill(0.0);
-        level_weight.fill(0.0);
-        screen.accumulate_cross(&block, table, level_weight, &mut variations);
-        screen.to_coefficients(table, level_weight);
+        screen.accumulate_cross(&block, table, &mut variations);
+        screen.to_coefficients(&block, table);
         screen.accumulate_residual(&block, table, &mut residual);
     }
 
+    let intercept = moments.intercept();
     residual
         .iter()
         .zip(&variations.stats)
@@ -129,12 +133,12 @@ fn residual_shares(
 struct Screen<'a> {
     levels: &'a [u32],
     sqrt_weights: Option<&'a [f64]>,
-    /// The term's slope columns in the solve basis.
-    us: Vec<&'a [f64]>,
+    zs: Vec<&'a [f64]>,
     columns: Vec<&'a [f64]>,
-    intercept: bool,
+    zeros: Vec<f64>,
+    moments: &'a LevelMoments,
     order: RowOrder,
-    /// One level's row of the table: `[Σw·c, Σw·u·c]` per target.
+    /// One level's row of the table: `[Σw·c, Σw·z·c]` per target.
     stride: usize,
 }
 
@@ -152,21 +156,22 @@ impl Screen<'_> {
         })
     }
 
+    /// Without an intercept the level's span holds no constant, so `z` enters uncentered.
+    fn center(&self, level: usize) -> &[f64] {
+        match self.moments.intercept() {
+            true => self.moments.mean(level),
+            false => &self.zeros,
+        }
+    }
+
     /// Each target's total variation rides this pass, since the rows are already loaded.
-    fn accumulate_cross(
-        &self,
-        block: &Block,
-        table: &mut [f64],
-        level_weight: &mut [f64],
-        variations: &mut Variations,
-    ) {
-        let v = self.us.len();
+    fn accumulate_cross(&self, block: &Block, table: &mut [f64], variations: &mut Variations) {
+        let v = self.zs.len();
         let stride = self.stride;
         let Variations { w_sum, stats } = variations;
         let mut running = *w_sum;
         for (obs, w, row) in self.active_rows(block.levels.start, block.rows.clone()) {
             running += w;
-            level_weight[row] += w;
             // Every target shares the running weight, so the Welford ratio is taken once.
             let ratio = w / running;
             for ((slot, column), stat) in table[row * stride..][..stride]
@@ -178,25 +183,58 @@ impl Screen<'_> {
                 stat.observe(c, w, ratio);
                 let wc = w * c;
                 slot[0] += wc;
-                for (s, u) in slot[1..].iter_mut().zip(&self.us) {
-                    *s += wc * u[obs];
+                for (s, z) in slot[1..].iter_mut().zip(&self.zs) {
+                    *s += wc * z[obs];
                 }
             }
         }
         *w_sum = running;
     }
 
-    /// `Σw·c` becomes the constant `c̄`; `Σw·u·c` is already the slope since `u` is orthonormal.
-    fn to_coefficients(&self, table: &mut [f64], level_weight: &[f64]) {
-        let v = self.us.len();
-        for (row, &w_sum) in table.chunks_exact_mut(self.stride).zip(level_weight) {
-            for slot in row.chunks_exact_mut(v + 1) {
-                slot[0] = match self.intercept && w_sum > 0.0 {
-                    true => slot[0] / w_sum,
-                    false => 0.0,
-                };
-            }
-        }
+    /// Rewrites a level's cross moments as the coefficients `[c̄, β]` of `c`'s fit on its span.
+    fn to_coefficients(&self, block: &Block, table: &mut [f64]) {
+        let v = self.zs.len();
+        let intercept = self.moments.intercept();
+        table
+            .par_chunks_exact_mut(self.stride)
+            .enumerate()
+            .for_each_init(
+                || (BasisScratch::new(v), vec![0.0f64; v]),
+                |(scratch, d), (offset, row)| {
+                    let level = block.levels.start + offset;
+                    let w_sum = self.moments.w_sum(level);
+                    if w_sum <= 0.0 {
+                        debug_assert!(
+                            row.iter().all(|&x| x == 0.0),
+                            "level {level} carries cross moments the term's weights deny"
+                        );
+                        return;
+                    }
+                    if v > 0 {
+                        self.moments.basis(level, scratch);
+                    }
+                    let center = self.center(level);
+                    for slot in row.chunks_exact_mut(v + 1) {
+                        let sum_wc = slot[0];
+                        for ((dj, &xj), &cj) in d.iter_mut().zip(&slot[1..]).zip(center) {
+                            *dj = xj - sum_wc * cj;
+                        }
+                        slot[0] = match intercept {
+                            true => sum_wc / w_sum,
+                            false => 0.0,
+                        };
+                        slot[1..].fill(0.0);
+                        if v > 0 {
+                            for q in scratch.basis.chunks_exact(v) {
+                                let projection = crate::linalg::dot(q, d);
+                                for (b, &qj) in slot[1..].iter_mut().zip(q) {
+                                    *b += projection * qj;
+                                }
+                            }
+                        }
+                    }
+                },
+            );
     }
 
     /// Adds each target's `Σw·(c − ĉ)²` from the coefficients left in `table`.
@@ -206,7 +244,7 @@ impl Screen<'_> {
         if block.rows.is_empty() {
             return;
         }
-        let v = self.us.len();
+        let v = self.zs.len();
         let stride = self.stride;
         let first = block.levels.start;
         let tasks = block.rows.len().div_ceil(ROWS_PER_TASK);
@@ -214,20 +252,23 @@ impl Screen<'_> {
             .into_par_iter()
             .map_init(
                 || vec![0.0f64; v],
-                |u_row, task| {
+                |dz, task| {
                     let mut totals = vec![0.0f64; self.columns.len()];
                     let start = block.rows.start + task * ROWS_PER_TASK;
                     let rows = start..(start + ROWS_PER_TASK).min(block.rows.end);
                     for (obs, w, row) in self.active_rows(first, rows) {
-                        for (uj, u) in u_row.iter_mut().zip(&self.us) {
-                            *uj = u[obs];
+                        for (dzj, (z, &cj)) in dz
+                            .iter_mut()
+                            .zip(self.zs.iter().zip(self.center(first + row)))
+                        {
+                            *dzj = z[obs] - cj;
                         }
                         for ((slot, column), total) in table[row * stride..][..stride]
                             .chunks_exact(v + 1)
                             .zip(&self.columns)
                             .zip(&mut totals)
                         {
-                            let r = column[obs] - slot[0] - crate::linalg::dot(&slot[1..], u_row);
+                            let r = column[obs] - slot[0] - crate::linalg::dot(&slot[1..], dz);
                             *total += w * r * r;
                         }
                     }

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -5,8 +5,7 @@ use std::ops::Range;
 
 use rayon::prelude::*;
 
-use super::level_moments::{BasisScratch, LevelMoments, TermMoments};
-use super::Design;
+use super::{Design, PreparedDesign};
 use crate::channel::Channel;
 use crate::BuildWarning;
 
@@ -19,12 +18,9 @@ const TABLE_BUDGET_BYTES: usize = 64 << 20;
 /// Rows one residual task claims; small enough that work stealing balances the tail.
 const ROWS_PER_TASK: usize = 1 << 16;
 
-pub(crate) fn detect_collinear_slopes(
-    design: &Design<'_>,
-    weights: Option<&[f64]>,
-    moments: &TermMoments,
-) -> Vec<BuildWarning> {
-    if design.n_factors() < 2 {
+pub(crate) fn detect_collinear_slopes(prepared: &PreparedDesign<'_>) -> Vec<BuildWarning> {
+    let design = &prepared.design;
+    if design.n_factors() < 2 || design.frame.n_loading_columns() == 0 {
         return Vec::new();
     }
     let budget = TABLE_BUDGET_BYTES / std::mem::size_of::<f64>() / design.n_factors();
@@ -32,7 +28,7 @@ pub(crate) fn detect_collinear_slopes(
         .into_par_iter()
         .flat_map_iter(move |term| {
             let targets = screened_covariates(design, term);
-            residual_shares(design, weights, moments, term, &targets, budget)
+            residual_shares(prepared, term, &targets, budget)
                 .into_iter()
                 .zip(targets)
                 .filter(|&(share, _)| share <= COLLINEARITY_TOL)
@@ -58,9 +54,7 @@ fn screened_covariates(design: &Design<'_>, term: usize) -> Vec<(Channel, u32)> 
 
 /// Two passes, so the share resolves below the `1e-16` a subtraction floors at.
 fn residual_shares(
-    design: &Design<'_>,
-    weights: Option<&[f64]>,
-    moments: &TermMoments,
+    prepared: &PreparedDesign<'_>,
     term: usize,
     targets: &[(Channel, u32)],
     budget: usize,
@@ -69,36 +63,37 @@ fn residual_shares(
     if m == 0 {
         return Vec::new();
     }
-    let moments = &moments[term];
+    let (design, weights) = (&prepared.design, prepared.weights.as_deref());
+    let meta = &design.terms[term];
     let levels = design.frame.level_column(term);
-    let zs: Vec<&[f64]> = moments
+    let us: Vec<&[f64]> = meta
         .covariates()
-        .iter()
-        .map(|&c| design.frame.loading_column(c as usize))
+        .map(|c| prepared.basis.loading_column(c as usize))
         .collect();
+    let intercept = meta.has_intercept();
     let columns: Vec<&[f64]> = targets
         .iter()
         .map(|&(_, c)| design.frame.loading_column(c as usize))
         .collect();
-    let stride = columns.len() * (zs.len() + 1);
-    let n_levels = moments.n_levels();
+    let stride = columns.len() * (us.len() + 1);
+    let n_levels = meta.n_levels;
     let plan = ScreenPlan::new(budget, n_levels, stride);
     let screen = Screen {
         levels,
         weights,
-        zs,
+        us,
         columns,
-        zeros: vec![0.0; moments.n_slopes()],
-        moments,
+        intercept,
         stride,
         // Grouping gathers every column, so it must buy back more than the one block.
-        order: match design.terms[term].sorted || plan.per_block == n_levels {
+        order: match meta.sorted || plan.per_block == n_levels {
             true => RowOrder::AsIs,
             false => RowOrder::Grouped(super::stable_argsort(levels, n_levels)),
         },
     };
 
     let mut table = vec![0.0f64; plan.per_block * stride];
+    let mut level_weight = vec![0.0f64; plan.per_block];
     let mut residual = vec![0.0f64; m];
     let mut variations = Variations {
         w_sum: 0.0,
@@ -110,13 +105,14 @@ fn residual_shares(
             levels: levels_block,
         };
         let table = &mut table[..block.levels.len() * stride];
+        let level_weight = &mut level_weight[..block.levels.len()];
         table.fill(0.0);
-        screen.accumulate_cross(&block, table, &mut variations);
-        screen.to_coefficients(&block, table);
+        level_weight.fill(0.0);
+        screen.accumulate_cross(&block, table, level_weight, &mut variations);
+        screen.to_coefficients(table, level_weight);
         screen.accumulate_residual(&block, table, &mut residual);
     }
 
-    let intercept = moments.intercept();
     residual
         .iter()
         .zip(&variations.stats)
@@ -133,12 +129,12 @@ fn residual_shares(
 struct Screen<'a> {
     levels: &'a [u32],
     weights: Option<&'a [f64]>,
-    zs: Vec<&'a [f64]>,
+    /// The term's slope columns in the solve basis.
+    us: Vec<&'a [f64]>,
     columns: Vec<&'a [f64]>,
-    zeros: Vec<f64>,
-    moments: &'a LevelMoments,
+    intercept: bool,
     order: RowOrder,
-    /// One level's row of the table: `[Σw·c, Σw·z·c]` per target.
+    /// One level's row of the table: `[Σw·c, Σw·u·c]` per target.
     stride: usize,
 }
 
@@ -156,22 +152,21 @@ impl Screen<'_> {
         })
     }
 
-    /// Without an intercept the level's span holds no constant, so `z` enters uncentered.
-    fn center(&self, level: usize) -> &[f64] {
-        match self.moments.intercept() {
-            true => self.moments.mean(level),
-            false => &self.zeros,
-        }
-    }
-
     /// Each target's total variation rides this pass, since the rows are already loaded.
-    fn accumulate_cross(&self, block: &Block, table: &mut [f64], variations: &mut Variations) {
-        let v = self.zs.len();
+    fn accumulate_cross(
+        &self,
+        block: &Block,
+        table: &mut [f64],
+        level_weight: &mut [f64],
+        variations: &mut Variations,
+    ) {
+        let v = self.us.len();
         let stride = self.stride;
         let Variations { w_sum, stats } = variations;
         let mut running = *w_sum;
         for (obs, w, row) in self.active_rows(block.levels.start, block.rows.clone()) {
             running += w;
+            level_weight[row] += w;
             // Every target shares the running weight, so the Welford ratio is taken once.
             let ratio = w / running;
             for ((slot, column), stat) in table[row * stride..][..stride]
@@ -183,58 +178,25 @@ impl Screen<'_> {
                 stat.observe(c, w, ratio);
                 let wc = w * c;
                 slot[0] += wc;
-                for (s, z) in slot[1..].iter_mut().zip(&self.zs) {
-                    *s += wc * z[obs];
+                for (s, u) in slot[1..].iter_mut().zip(&self.us) {
+                    *s += wc * u[obs];
                 }
             }
         }
         *w_sum = running;
     }
 
-    /// Rewrites a level's cross moments as the coefficients `[c̄, β]` of `c`'s fit on its span.
-    fn to_coefficients(&self, block: &Block, table: &mut [f64]) {
-        let v = self.zs.len();
-        let intercept = self.moments.intercept();
-        table
-            .par_chunks_exact_mut(self.stride)
-            .enumerate()
-            .for_each_init(
-                || (BasisScratch::new(v), vec![0.0f64; v]),
-                |(scratch, d), (offset, row)| {
-                    let level = block.levels.start + offset;
-                    let w_sum = self.moments.w_sum(level);
-                    if w_sum <= 0.0 {
-                        debug_assert!(
-                            row.iter().all(|&x| x == 0.0),
-                            "level {level} carries cross moments the term's weights deny"
-                        );
-                        return;
-                    }
-                    if v > 0 {
-                        self.moments.basis(level, scratch);
-                    }
-                    let center = self.center(level);
-                    for slot in row.chunks_exact_mut(v + 1) {
-                        let sum_wc = slot[0];
-                        for ((dj, &xj), &cj) in d.iter_mut().zip(&slot[1..]).zip(center) {
-                            *dj = xj - sum_wc * cj;
-                        }
-                        slot[0] = match intercept {
-                            true => sum_wc / w_sum,
-                            false => 0.0,
-                        };
-                        slot[1..].fill(0.0);
-                        if v > 0 {
-                            for q in scratch.basis.chunks_exact(v) {
-                                let projection = crate::linalg::dot(q, d);
-                                for (b, &qj) in slot[1..].iter_mut().zip(q) {
-                                    *b += projection * qj;
-                                }
-                            }
-                        }
-                    }
-                },
-            );
+    /// `Σw·c` becomes the fit's constant `c̄`; `Σw·u·c` already is its slope, `u` being orthonormal.
+    fn to_coefficients(&self, table: &mut [f64], level_weight: &[f64]) {
+        let v = self.us.len();
+        for (row, &w_sum) in table.chunks_exact_mut(self.stride).zip(level_weight) {
+            for slot in row.chunks_exact_mut(v + 1) {
+                slot[0] = match self.intercept && w_sum > 0.0 {
+                    true => slot[0] / w_sum,
+                    false => 0.0,
+                };
+            }
+        }
     }
 
     /// Adds each target's `Σw·(c − ĉ)²` from the coefficients left in `table`.
@@ -244,7 +206,7 @@ impl Screen<'_> {
         if block.rows.is_empty() {
             return;
         }
-        let v = self.zs.len();
+        let v = self.us.len();
         let stride = self.stride;
         let first = block.levels.start;
         let tasks = block.rows.len().div_ceil(ROWS_PER_TASK);
@@ -252,23 +214,20 @@ impl Screen<'_> {
             .into_par_iter()
             .map_init(
                 || vec![0.0f64; v],
-                |dz, task| {
+                |u_row, task| {
                     let mut totals = vec![0.0f64; self.columns.len()];
                     let start = block.rows.start + task * ROWS_PER_TASK;
                     let rows = start..(start + ROWS_PER_TASK).min(block.rows.end);
                     for (obs, w, row) in self.active_rows(first, rows) {
-                        for (dzj, (z, &cj)) in dz
-                            .iter_mut()
-                            .zip(self.zs.iter().zip(self.center(first + row)))
-                        {
-                            *dzj = z[obs] - cj;
+                        for (uj, u) in u_row.iter_mut().zip(&self.us) {
+                            *uj = u[obs];
                         }
                         for ((slot, column), total) in table[row * stride..][..stride]
                             .chunks_exact(v + 1)
                             .zip(&self.columns)
                             .zip(&mut totals)
                         {
-                            let r = column[obs] - slot[0] - crate::linalg::dot(&slot[1..], dz);
+                            let r = column[obs] - slot[0] - crate::linalg::dot(&slot[1..], u_row);
                             *total += w * r * r;
                         }
                     }

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -5,8 +5,7 @@ use std::ops::Range;
 
 use rayon::prelude::*;
 
-use super::level_moments::{BasisScratch, LevelMoments, TermMoments};
-use super::{row_weight, Design};
+use super::{row_weight, Design, PreparedDesign, TermMeta};
 use crate::channel::Channel;
 use crate::BuildWarning;
 
@@ -20,11 +19,11 @@ const TABLE_BUDGET_BYTES: usize = 64 << 20;
 const ROWS_PER_TASK: usize = 1 << 16;
 
 pub(crate) fn detect_collinear_slopes(
-    design: &Design<'_>,
+    prepared: &PreparedDesign<'_>,
     sqrt_weights: Option<&[f64]>,
-    moments: &TermMoments,
 ) -> Vec<BuildWarning> {
-    if design.n_factors() < 2 {
+    let design = &prepared.design;
+    if design.n_factors() < 2 || !design.terms.iter().any(TermMeta::has_slopes) {
         return Vec::new();
     }
     let budget = TABLE_BUDGET_BYTES / std::mem::size_of::<f64>() / design.n_factors();
@@ -32,7 +31,7 @@ pub(crate) fn detect_collinear_slopes(
         .into_par_iter()
         .flat_map_iter(move |term| {
             let targets = screened_covariates(design, term);
-            residual_shares(design, sqrt_weights, moments, term, &targets, budget)
+            residual_shares(prepared, sqrt_weights, term, &targets, budget)
                 .into_iter()
                 .zip(targets)
                 .filter(|&(share, _)| share <= COLLINEARITY_TOL)
@@ -58,9 +57,8 @@ fn screened_covariates(design: &Design<'_>, term: usize) -> Vec<(Channel, u32)> 
 
 /// Two passes, so the share resolves below the `1e-16` a subtraction floors at.
 fn residual_shares(
-    design: &Design<'_>,
+    prepared: &PreparedDesign<'_>,
     sqrt_weights: Option<&[f64]>,
-    moments: &TermMoments,
     term: usize,
     targets: &[(Channel, u32)],
     budget: usize,
@@ -69,36 +67,37 @@ fn residual_shares(
     if m == 0 {
         return Vec::new();
     }
-    let moments = &moments[term];
+    let design = &prepared.design;
+    let meta = &design.terms[term];
     let levels = design.frame.level_column(term);
-    let zs: Vec<&[f64]> = moments
+    let us: Vec<&[f64]> = meta
         .covariates()
-        .iter()
-        .map(|&c| design.frame.loading_column(c as usize))
+        .map(|c| prepared.loading_column(c as usize))
         .collect();
+    let intercept = meta.has_intercept();
     let columns: Vec<&[f64]> = targets
         .iter()
         .map(|&(_, c)| design.frame.loading_column(c as usize))
         .collect();
-    let stride = columns.len() * (zs.len() + 1);
-    let n_levels = moments.n_levels();
+    let stride = columns.len() * (us.len() + 1);
+    let n_levels = meta.n_levels;
     let plan = ScreenPlan::new(budget, n_levels, stride);
     let screen = Screen {
         levels,
         sqrt_weights,
-        zs,
+        us,
         columns,
-        zeros: vec![0.0; moments.n_slopes()],
-        moments,
+        intercept,
         stride,
         // Grouping gathers every column, so it must buy back more than the one block.
-        order: match design.terms[term].sorted || plan.per_block == n_levels {
+        order: match meta.sorted || plan.per_block == n_levels {
             true => RowOrder::AsIs,
             false => RowOrder::Grouped(super::stable_argsort(levels, n_levels)),
         },
     };
 
     let mut table = vec![0.0f64; plan.per_block * stride];
+    let mut level_weight = vec![0.0f64; plan.per_block];
     let mut residual = vec![0.0f64; m];
     let mut variations = Variations {
         w_sum: 0.0,
@@ -110,13 +109,14 @@ fn residual_shares(
             levels: levels_block,
         };
         let table = &mut table[..block.levels.len() * stride];
+        let level_weight = &mut level_weight[..block.levels.len()];
         table.fill(0.0);
-        screen.accumulate_cross(&block, table, &mut variations);
-        screen.to_coefficients(&block, table);
+        level_weight.fill(0.0);
+        screen.accumulate_cross(&block, table, level_weight, &mut variations);
+        screen.to_coefficients(table, level_weight);
         screen.accumulate_residual(&block, table, &mut residual);
     }
 
-    let intercept = moments.intercept();
     residual
         .iter()
         .zip(&variations.stats)
@@ -133,12 +133,12 @@ fn residual_shares(
 struct Screen<'a> {
     levels: &'a [u32],
     sqrt_weights: Option<&'a [f64]>,
-    zs: Vec<&'a [f64]>,
+    /// The term's slope columns in the solve basis.
+    us: Vec<&'a [f64]>,
     columns: Vec<&'a [f64]>,
-    zeros: Vec<f64>,
-    moments: &'a LevelMoments,
+    intercept: bool,
     order: RowOrder,
-    /// One level's row of the table: `[Σw·c, Σw·z·c]` per target.
+    /// One level's row of the table: `[Σw·c, Σw·u·c]` per target.
     stride: usize,
 }
 
@@ -156,22 +156,21 @@ impl Screen<'_> {
         })
     }
 
-    /// Without an intercept the level's span holds no constant, so `z` enters uncentered.
-    fn center(&self, level: usize) -> &[f64] {
-        match self.moments.intercept() {
-            true => self.moments.mean(level),
-            false => &self.zeros,
-        }
-    }
-
     /// Each target's total variation rides this pass, since the rows are already loaded.
-    fn accumulate_cross(&self, block: &Block, table: &mut [f64], variations: &mut Variations) {
-        let v = self.zs.len();
+    fn accumulate_cross(
+        &self,
+        block: &Block,
+        table: &mut [f64],
+        level_weight: &mut [f64],
+        variations: &mut Variations,
+    ) {
+        let v = self.us.len();
         let stride = self.stride;
         let Variations { w_sum, stats } = variations;
         let mut running = *w_sum;
         for (obs, w, row) in self.active_rows(block.levels.start, block.rows.clone()) {
             running += w;
+            level_weight[row] += w;
             // Every target shares the running weight, so the Welford ratio is taken once.
             let ratio = w / running;
             for ((slot, column), stat) in table[row * stride..][..stride]
@@ -183,58 +182,25 @@ impl Screen<'_> {
                 stat.observe(c, w, ratio);
                 let wc = w * c;
                 slot[0] += wc;
-                for (s, z) in slot[1..].iter_mut().zip(&self.zs) {
-                    *s += wc * z[obs];
+                for (s, u) in slot[1..].iter_mut().zip(&self.us) {
+                    *s += wc * u[obs];
                 }
             }
         }
         *w_sum = running;
     }
 
-    /// Rewrites a level's cross moments as the coefficients `[c̄, β]` of `c`'s fit on its span.
-    fn to_coefficients(&self, block: &Block, table: &mut [f64]) {
-        let v = self.zs.len();
-        let intercept = self.moments.intercept();
-        table
-            .par_chunks_exact_mut(self.stride)
-            .enumerate()
-            .for_each_init(
-                || (BasisScratch::new(v), vec![0.0f64; v]),
-                |(scratch, d), (offset, row)| {
-                    let level = block.levels.start + offset;
-                    let w_sum = self.moments.w_sum(level);
-                    if w_sum <= 0.0 {
-                        debug_assert!(
-                            row.iter().all(|&x| x == 0.0),
-                            "level {level} carries cross moments the term's weights deny"
-                        );
-                        return;
-                    }
-                    if v > 0 {
-                        self.moments.basis(level, scratch);
-                    }
-                    let center = self.center(level);
-                    for slot in row.chunks_exact_mut(v + 1) {
-                        let sum_wc = slot[0];
-                        for ((dj, &xj), &cj) in d.iter_mut().zip(&slot[1..]).zip(center) {
-                            *dj = xj - sum_wc * cj;
-                        }
-                        slot[0] = match intercept {
-                            true => sum_wc / w_sum,
-                            false => 0.0,
-                        };
-                        slot[1..].fill(0.0);
-                        if v > 0 {
-                            for q in scratch.basis.chunks_exact(v) {
-                                let projection = crate::linalg::dot(q, d);
-                                for (b, &qj) in slot[1..].iter_mut().zip(q) {
-                                    *b += projection * qj;
-                                }
-                            }
-                        }
-                    }
-                },
-            );
+    /// `Σw·c` becomes the constant `c̄`; `Σw·u·c` is already the slope since `u` is orthonormal.
+    fn to_coefficients(&self, table: &mut [f64], level_weight: &[f64]) {
+        let v = self.us.len();
+        for (row, &w_sum) in table.chunks_exact_mut(self.stride).zip(level_weight) {
+            for slot in row.chunks_exact_mut(v + 1) {
+                slot[0] = match self.intercept && w_sum > 0.0 {
+                    true => slot[0] / w_sum,
+                    false => 0.0,
+                };
+            }
+        }
     }
 
     /// Adds each target's `Σw·(c − ĉ)²` from the coefficients left in `table`.
@@ -244,7 +210,7 @@ impl Screen<'_> {
         if block.rows.is_empty() {
             return;
         }
-        let v = self.zs.len();
+        let v = self.us.len();
         let stride = self.stride;
         let first = block.levels.start;
         let tasks = block.rows.len().div_ceil(ROWS_PER_TASK);
@@ -252,23 +218,20 @@ impl Screen<'_> {
             .into_par_iter()
             .map_init(
                 || vec![0.0f64; v],
-                |dz, task| {
+                |u_row, task| {
                     let mut totals = vec![0.0f64; self.columns.len()];
                     let start = block.rows.start + task * ROWS_PER_TASK;
                     let rows = start..(start + ROWS_PER_TASK).min(block.rows.end);
                     for (obs, w, row) in self.active_rows(first, rows) {
-                        for (dzj, (z, &cj)) in dz
-                            .iter_mut()
-                            .zip(self.zs.iter().zip(self.center(first + row)))
-                        {
-                            *dzj = z[obs] - cj;
+                        for (uj, u) in u_row.iter_mut().zip(&self.us) {
+                            *uj = u[obs];
                         }
                         for ((slot, column), total) in table[row * stride..][..stride]
                             .chunks_exact(v + 1)
                             .zip(&self.columns)
                             .zip(&mut totals)
                         {
-                            let r = column[obs] - slot[0] - crate::linalg::dot(&slot[1..], dz);
+                            let r = column[obs] - slot[0] - crate::linalg::dot(&slot[1..], u_row);
                             *total += w * r * r;
                         }
                     }

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 
 use rayon::prelude::*;
 
-use super::{Design, PreparedDesign};
+use super::{Design, PreparedDesign, TermMeta};
 use crate::channel::Channel;
 use crate::BuildWarning;
 
@@ -20,7 +20,7 @@ const ROWS_PER_TASK: usize = 1 << 16;
 
 pub(crate) fn detect_collinear_slopes(prepared: &PreparedDesign<'_>) -> Vec<BuildWarning> {
     let design = &prepared.design;
-    if design.n_factors() < 2 || design.frame.n_loading_columns() == 0 {
+    if design.n_factors() < 2 || !design.terms.iter().any(TermMeta::has_slopes) {
         return Vec::new();
     }
     let budget = TABLE_BUDGET_BYTES / std::mem::size_of::<f64>() / design.n_factors();
@@ -186,7 +186,7 @@ impl Screen<'_> {
         *w_sum = running;
     }
 
-    /// `Σw·c` becomes the fit's constant `c̄`; `Σw·u·c` already is its slope, `u` being orthonormal.
+    /// `Σw·c` becomes the constant `c̄`; `Σw·u·c` is already the slope since `u` is orthonormal.
     fn to_coefficients(&self, table: &mut [f64], level_weight: &[f64]) {
         let v = self.us.len();
         for (row, &w_sum) in table.chunks_exact_mut(self.stride).zip(level_weight) {

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 
 use rayon::prelude::*;
 
-use super::{Design, PreparedDesign, TermMeta};
+use super::{row_weight, Design, PreparedDesign, TermMeta};
 use crate::channel::Channel;
 use crate::BuildWarning;
 
@@ -63,7 +63,7 @@ fn residual_shares(
     if m == 0 {
         return Vec::new();
     }
-    let (design, weights) = (&prepared.design, prepared.weights.as_deref());
+    let (design, sqrt_weights) = (&prepared.design, prepared.sqrt_weights.as_deref());
     let meta = &design.terms[term];
     let levels = design.frame.level_column(term);
     let us: Vec<&[f64]> = meta
@@ -80,7 +80,7 @@ fn residual_shares(
     let plan = ScreenPlan::new(budget, n_levels, stride);
     let screen = Screen {
         levels,
-        weights,
+        sqrt_weights,
         us,
         columns,
         intercept,
@@ -128,7 +128,7 @@ fn residual_shares(
 
 struct Screen<'a> {
     levels: &'a [u32],
-    weights: Option<&'a [f64]>,
+    sqrt_weights: Option<&'a [f64]>,
     /// The term's slope columns in the solve basis.
     us: Vec<&'a [f64]>,
     columns: Vec<&'a [f64]>,
@@ -147,7 +147,7 @@ impl Screen<'_> {
     ) -> impl Iterator<Item = (usize, f64, usize)> + '_ {
         rows.filter_map(move |i| {
             let obs = self.order.obs(i);
-            let w = self.weights.map_or(1.0, |w| w[obs]);
+            let w = row_weight(self.sqrt_weights, obs);
             (w > 0.0).then(|| (obs, w, self.levels[obs] as usize - first))
         })
     }

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 
 use rayon::prelude::*;
 
-use super::{row_weight, Design, PreparedDesign, TermMeta};
+use super::{Design, PreparedDesign, TermMeta};
 use crate::channel::Channel;
 use crate::BuildWarning;
 
@@ -18,10 +18,7 @@ const TABLE_BUDGET_BYTES: usize = 64 << 20;
 /// Rows one residual task claims; small enough that work stealing balances the tail.
 const ROWS_PER_TASK: usize = 1 << 16;
 
-pub(crate) fn detect_collinear_slopes(
-    prepared: &PreparedDesign<'_>,
-    sqrt_weights: Option<&[f64]>,
-) -> Vec<BuildWarning> {
+pub(crate) fn detect_collinear_slopes(prepared: &PreparedDesign<'_>) -> Vec<BuildWarning> {
     let design = &prepared.design;
     if design.n_factors() < 2 || !design.terms.iter().any(TermMeta::has_slopes) {
         return Vec::new();
@@ -31,7 +28,7 @@ pub(crate) fn detect_collinear_slopes(
         .into_par_iter()
         .flat_map_iter(move |term| {
             let targets = screened_covariates(design, term);
-            residual_shares(prepared, sqrt_weights, term, &targets, budget)
+            residual_shares(prepared, term, &targets, budget)
                 .into_iter()
                 .zip(targets)
                 .filter(|&(share, _)| share <= COLLINEARITY_TOL)
@@ -58,7 +55,6 @@ fn screened_covariates(design: &Design<'_>, term: usize) -> Vec<(Channel, u32)> 
 /// Two passes, so the share resolves below the `1e-16` a subtraction floors at.
 fn residual_shares(
     prepared: &PreparedDesign<'_>,
-    sqrt_weights: Option<&[f64]>,
     term: usize,
     targets: &[(Channel, u32)],
     budget: usize,
@@ -83,8 +79,8 @@ fn residual_shares(
     let n_levels = meta.n_levels;
     let plan = ScreenPlan::new(budget, n_levels, stride);
     let screen = Screen {
+        prepared,
         levels,
-        sqrt_weights,
         us,
         columns,
         intercept,
@@ -131,8 +127,8 @@ fn residual_shares(
 }
 
 struct Screen<'a> {
+    prepared: &'a PreparedDesign<'a>,
     levels: &'a [u32],
-    sqrt_weights: Option<&'a [f64]>,
     /// The term's slope columns in the solve basis.
     us: Vec<&'a [f64]>,
     columns: Vec<&'a [f64]>,
@@ -151,7 +147,7 @@ impl Screen<'_> {
     ) -> impl Iterator<Item = (usize, f64, usize)> + '_ {
         rows.filter_map(move |i| {
             let obs = self.order.obs(i);
-            let w = row_weight(self.sqrt_weights, obs);
+            let w = self.prepared.row_weight(obs);
             (w > 0.0).then(|| (obs, w, self.levels[obs] as usize - first))
         })
     }

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -7,8 +7,8 @@ use crate::Effect;
 const FULL_TABLE: usize = 1 << 24;
 
 fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usize)> {
-    let moments = TermMoments::build(design, weights).expect("design carries slopes");
-    detect_collinear_slopes(design, weights, &moments)
+    let prepared = PreparedDesign::new(design.clone(), weights);
+    detect_collinear_slopes(&prepared, weights)
         .into_iter()
         .map(|w| match w {
             BuildWarning::CollinearSlopeCovariate { slope, term, .. } => (slope, term),
@@ -19,9 +19,9 @@ fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usi
 
 /// The shares `term`'s screen reports, in target-channel order.
 fn shares(design: &Design<'_>, term: usize, budget: usize) -> Vec<f64> {
-    let moments = TermMoments::build(design, None).expect("design carries slopes");
+    let prepared = PreparedDesign::unweighted_for_test(design.clone());
     let targets = screened_covariates(design, term);
-    residual_shares(design, None, &moments, term, &targets, budget)
+    residual_shares(&prepared, None, term, &targets, budget)
 }
 
 fn two_factor_levels(n: usize) -> (Vec<u32>, Vec<u32>) {

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -7,8 +7,8 @@ use crate::Effect;
 const FULL_TABLE: usize = 1 << 24;
 
 fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usize)> {
-    let prepared = PreparedDesign::new(design.clone(), weights).expect("valid weights");
-    detect_collinear_slopes(&prepared)
+    let moments = TermMoments::build(design, weights).expect("design carries slopes");
+    detect_collinear_slopes(design, weights, &moments)
         .into_iter()
         .map(|w| match w {
             BuildWarning::CollinearSlopeCovariate { slope, term, .. } => (slope, term),
@@ -19,13 +19,9 @@ fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usi
 
 /// The shares `term`'s screen reports, in target-channel order.
 fn shares(design: &Design<'_>, term: usize, budget: usize) -> Vec<f64> {
+    let moments = TermMoments::build(design, None).expect("design carries slopes");
     let targets = screened_covariates(design, term);
-    residual_shares(
-        &PreparedDesign::unweighted_for_test(design.clone()),
-        term,
-        &targets,
-        budget,
-    )
+    residual_shares(design, None, &moments, term, &targets, budget)
 }
 
 fn two_factor_levels(n: usize) -> (Vec<u32>, Vec<u32>) {
@@ -166,6 +162,8 @@ fn zero_weight_rows_are_excluded_from_the_screen() {
         Effect::new(&b, true, [&spoiled[..]]).unwrap(),
     ])
     .unwrap();
+    // The screen reads frame order, so caller weights go through the locality permutation.
+    let weights = design.permute_obs_in(&weights).into_owned();
     assert!(!warn_pairs(&design, Some(&weights)).is_empty());
     assert_eq!(warn_pairs(&design, None), Vec::new());
 }

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -7,8 +7,7 @@ use crate::Effect;
 const FULL_TABLE: usize = 1 << 24;
 
 fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usize)> {
-    let prepared =
-        PreparedDesign::new(design.clone(), weights.map(<[f64]>::to_vec)).expect("valid weights");
+    let prepared = PreparedDesign::new(design.clone(), weights).expect("valid weights");
     detect_collinear_slopes(&prepared)
         .into_iter()
         .map(|w| match w {

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -7,8 +7,8 @@ use crate::Effect;
 const FULL_TABLE: usize = 1 << 24;
 
 fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usize)> {
-    let prepared = PreparedDesign::new(design.clone(), weights);
-    detect_collinear_slopes(&prepared, weights)
+    let prepared = PreparedDesign::new(design.clone(), weights).expect("valid weights");
+    detect_collinear_slopes(&prepared)
         .into_iter()
         .map(|w| match w {
             BuildWarning::CollinearSlopeCovariate { slope, term, .. } => (slope, term),
@@ -21,7 +21,7 @@ fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usi
 fn shares(design: &Design<'_>, term: usize, budget: usize) -> Vec<f64> {
     let prepared = PreparedDesign::unweighted_for_test(design.clone());
     let targets = screened_covariates(design, term);
-    residual_shares(&prepared, None, term, &targets, budget)
+    residual_shares(&prepared, term, &targets, budget)
 }
 
 fn two_factor_levels(n: usize) -> (Vec<u32>, Vec<u32>) {
@@ -162,8 +162,7 @@ fn zero_weight_rows_are_excluded_from_the_screen() {
         Effect::new(&b, true, [&spoiled[..]]).unwrap(),
     ])
     .unwrap();
-    // The screen reads frame order, so caller weights go through the locality permutation.
-    let weights = design.permute_obs_in(&weights).into_owned();
+    // PreparedDesign applies the locality permutation to caller-order weights.
     assert!(!warn_pairs(&design, Some(&weights)).is_empty());
     assert_eq!(warn_pairs(&design, None), Vec::new());
 }

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -7,8 +7,9 @@ use crate::Effect;
 const FULL_TABLE: usize = 1 << 24;
 
 fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usize)> {
-    let moments = TermMoments::build(design, weights).expect("design carries slopes");
-    detect_collinear_slopes(design, weights, &moments)
+    let prepared =
+        PreparedDesign::new(design.clone(), weights.map(<[f64]>::to_vec)).expect("valid weights");
+    detect_collinear_slopes(&prepared)
         .into_iter()
         .map(|w| match w {
             BuildWarning::CollinearSlopeCovariate { slope, term, .. } => (slope, term),
@@ -19,9 +20,13 @@ fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usi
 
 /// The shares `term`'s screen reports, in target-channel order.
 fn shares(design: &Design<'_>, term: usize, budget: usize) -> Vec<f64> {
-    let moments = TermMoments::build(design, None).expect("design carries slopes");
     let targets = screened_covariates(design, term);
-    residual_shares(design, None, &moments, term, &targets, budget)
+    residual_shares(
+        &PreparedDesign::unweighted_for_test(design.clone()),
+        term,
+        &targets,
+        budget,
+    )
 }
 
 fn two_factor_levels(n: usize) -> (Vec<u32>, Vec<u32>) {
@@ -162,8 +167,6 @@ fn zero_weight_rows_are_excluded_from_the_screen() {
         Effect::new(&b, true, [&spoiled[..]]).unwrap(),
     ])
     .unwrap();
-    // The screen reads frame order, so caller weights go through the locality permutation.
-    let weights = design.permute_obs_in(&weights).into_owned();
     assert!(!warn_pairs(&design, Some(&weights)).is_empty());
     assert_eq!(warn_pairs(&design, None), Vec::new());
 }

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -203,6 +203,7 @@ impl CrossTab {
     /// Reuses pre-computed active flags instead of rescanning; diagonals come back separately.
     pub(crate) fn build_for_pair_with_active(
         prepared: &PreparedDesign<'_>,
+        sqrt_weights: Option<&[f64]>,
         pair: ChannelPair,
         all_active: &[Vec<bool>],
     ) -> Option<(Self, BlockDiagonals, Vec<u32>)> {
@@ -214,7 +215,7 @@ impl CrossTab {
             design.terms[pair.cols.term].column_base(pair.cols.column),
         )?;
 
-        let (c, row_diag, col_diag) = accumulate_cross_block(prepared, pair, &active);
+        let (c, row_diag, col_diag) = accumulate_cross_block(prepared, sqrt_weights, pair, &active);
         let cross_tab = CrossTab::eager(c);
         let diagonals = BlockDiagonals {
             rows: row_diag,

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -11,7 +11,7 @@ use serde::ser::SerializeStruct;
 
 use crate::channel::ChannelPair;
 use crate::csr_block::{to_u32, CsrBlock};
-use crate::domain::Design;
+use crate::domain::{Design, PreparedDesign};
 
 mod accumulate;
 use accumulate::accumulate_cross_block;
@@ -202,11 +202,11 @@ impl CrossTab {
 
     /// Reuses pre-computed active flags instead of rescanning; diagonals come back separately.
     pub(crate) fn build_for_pair_with_active(
-        design: &Design<'_>,
-        weights: Option<&[f64]>,
+        prepared: &PreparedDesign<'_>,
         pair: ChannelPair,
         all_active: &[Vec<bool>],
     ) -> Option<(Self, BlockDiagonals, Vec<u32>)> {
+        let design = &prepared.design;
         let active = build_compact_mapping(
             &all_active[pair.rows.term],
             &all_active[pair.cols.term],
@@ -214,7 +214,7 @@ impl CrossTab {
             design.terms[pair.cols.term].column_base(pair.cols.column),
         )?;
 
-        let (c, row_diag, col_diag) = accumulate_cross_block(design, weights, pair, &active);
+        let (c, row_diag, col_diag) = accumulate_cross_block(prepared, pair, &active);
         let cross_tab = CrossTab::eager(c);
         let diagonals = BlockDiagonals {
             rows: row_diag,

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -203,7 +203,6 @@ impl CrossTab {
     /// Reuses pre-computed active flags instead of rescanning; diagonals come back separately.
     pub(crate) fn build_for_pair_with_active(
         prepared: &PreparedDesign<'_>,
-        sqrt_weights: Option<&[f64]>,
         pair: ChannelPair,
         all_active: &[Vec<bool>],
     ) -> Option<(Self, BlockDiagonals, Vec<u32>)> {
@@ -215,7 +214,7 @@ impl CrossTab {
             design.terms[pair.cols.term].column_base(pair.cols.column),
         )?;
 
-        let (c, row_diag, col_diag) = accumulate_cross_block(prepared, sqrt_weights, pair, &active);
+        let (c, row_diag, col_diag) = accumulate_cross_block(prepared, pair, &active);
         let cross_tab = CrossTab::eager(c);
         let diagonals = BlockDiagonals {
             rows: row_diag,

--- a/crates/within/src/domain/cross_tab/accumulate.rs
+++ b/crates/within/src/domain/cross_tab/accumulate.rs
@@ -10,7 +10,7 @@
 
 use crate::channel::ChannelPair;
 use crate::csr_block::CsrBlock;
-use crate::domain::Design;
+use crate::domain::PreparedDesign;
 
 use super::{to_u32, ActiveLevels};
 use crate::domain::Loading as ColumnLoading;
@@ -84,11 +84,12 @@ impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
 
 /// Accumulate into `C` plus diagonals, dispatching dense or sparse by peak transient memory.
 pub(super) fn accumulate_cross_block(
-    design: &Design<'_>,
-    weights: Option<&[f64]>,
+    prepared: &PreparedDesign<'_>,
     pair: ChannelPair,
     active: &ActiveLevels,
 ) -> (CsrBlock, Vec<f64>, Vec<f64>) {
+    let design = &prepared.design;
+    let weights = prepared.weights.as_deref();
     // Dispatching on cell count alone would pick sparse where it uses MORE memory.
     let table_size = active.n_rows.saturating_mul(active.n_cols);
     let dense_cost = table_size.saturating_mul(8);
@@ -99,7 +100,7 @@ pub(super) fn accumulate_cross_block(
     let col_levels = design.frame.level_column(pair.cols.term);
     let load = |col: ColumnLoading<u32>| {
         col.covariate()
-            .map(|&c| design.frame.loading_column(c as usize))
+            .map(|&c| prepared.basis.loading_column(c as usize))
     };
     // One arm per loading combination; closures aren't generic, so the literals repeat.
     match (

--- a/crates/within/src/domain/cross_tab/accumulate.rs
+++ b/crates/within/src/domain/cross_tab/accumulate.rs
@@ -85,11 +85,11 @@ impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
 /// Accumulate into `C` plus diagonals, dispatching dense or sparse by peak transient memory.
 pub(super) fn accumulate_cross_block(
     prepared: &PreparedDesign<'_>,
+    sqrt_weights: Option<&[f64]>,
     pair: ChannelPair,
     active: &ActiveLevels,
 ) -> (CsrBlock, Vec<f64>, Vec<f64>) {
     let design = &prepared.design;
-    let sqrt_weights = prepared.sqrt_weights.as_deref();
     // Dispatching on cell count alone would pick sparse where it uses MORE memory.
     let table_size = active.n_rows.saturating_mul(active.n_cols);
     let dense_cost = table_size.saturating_mul(8);
@@ -100,7 +100,7 @@ pub(super) fn accumulate_cross_block(
     let col_levels = design.frame.level_column(pair.cols.term);
     let load = |col: ColumnLoading<u32>| {
         col.covariate()
-            .map(|&c| prepared.basis.loading_column(c as usize))
+            .map(|&c| prepared.loading_column(c as usize))
     };
     // One arm per loading combination; closures aren't generic, so the literals repeat.
     match (

--- a/crates/within/src/domain/cross_tab/accumulate.rs
+++ b/crates/within/src/domain/cross_tab/accumulate.rs
@@ -10,7 +10,7 @@
 
 use crate::channel::ChannelPair;
 use crate::csr_block::CsrBlock;
-use crate::domain::PreparedDesign;
+use crate::domain::{row_weight, PreparedDesign};
 
 use super::{to_u32, ActiveLevels};
 use crate::domain::Loading as ColumnLoading;
@@ -57,7 +57,7 @@ pub(super) struct PairColumns<'a, Lq: Loading, Lr: Loading> {
     pub(super) col_levels: &'a [u32],
     pub(super) row_load: Lq,
     pub(super) col_load: Lr,
-    pub(super) weights: Option<&'a [f64]>,
+    pub(super) sqrt_weights: Option<&'a [f64]>,
 }
 
 impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
@@ -69,7 +69,7 @@ impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
         if cj == u32::MAX || ck == u32::MAX {
             return None;
         }
-        let w = self.weights.map_or(1.0, |w| w[uid]);
+        let w = row_weight(self.sqrt_weights, uid);
         let l_row = self.row_load.at(uid);
         let l_col = self.col_load.at(uid);
         Some(Contribution {
@@ -89,7 +89,7 @@ pub(super) fn accumulate_cross_block(
     active: &ActiveLevels,
 ) -> (CsrBlock, Vec<f64>, Vec<f64>) {
     let design = &prepared.design;
-    let weights = prepared.weights.as_deref();
+    let sqrt_weights = prepared.sqrt_weights.as_deref();
     // Dispatching on cell count alone would pick sparse where it uses MORE memory.
     let table_size = active.n_rows.saturating_mul(active.n_cols);
     let dense_cost = table_size.saturating_mul(8);
@@ -113,7 +113,7 @@ pub(super) fn accumulate_cross_block(
                 col_levels,
                 row_load: Unit,
                 col_load: Unit,
-                weights,
+                sqrt_weights,
             },
             active,
             go_sparse,
@@ -124,7 +124,7 @@ pub(super) fn accumulate_cross_block(
                 col_levels,
                 row_load: zq,
                 col_load: Unit,
-                weights,
+                sqrt_weights,
             },
             active,
             go_sparse,
@@ -135,7 +135,7 @@ pub(super) fn accumulate_cross_block(
                 col_levels,
                 row_load: Unit,
                 col_load: zr,
-                weights,
+                sqrt_weights,
             },
             active,
             go_sparse,
@@ -146,7 +146,7 @@ pub(super) fn accumulate_cross_block(
                 col_levels,
                 row_load: zq,
                 col_load: zr,
-                weights,
+                sqrt_weights,
             },
             active,
             go_sparse,

--- a/crates/within/src/domain/cross_tab/accumulate.rs
+++ b/crates/within/src/domain/cross_tab/accumulate.rs
@@ -85,11 +85,11 @@ impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
 /// Accumulate into `C` plus diagonals, dispatching dense or sparse by peak transient memory.
 pub(super) fn accumulate_cross_block(
     prepared: &PreparedDesign<'_>,
-    sqrt_weights: Option<&[f64]>,
     pair: ChannelPair,
     active: &ActiveLevels,
 ) -> (CsrBlock, Vec<f64>, Vec<f64>) {
     let design = &prepared.design;
+    let sqrt_weights = prepared.sqrt_weights();
     // Dispatching on cell count alone would pick sparse where it uses MORE memory.
     let table_size = active.n_rows.saturating_mul(active.n_cols);
     let dense_cost = table_size.saturating_mul(8);

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -43,7 +43,7 @@ fn test_cross_tab_sparse_accumulation_path() {
     let design_sparse = design_of(vec![fa.clone(), fb.clone()]);
     let active_sparse = find_all_active_levels(&design_sparse.design);
     let (ct_sparse, diag_sparse, _) =
-        CrossTab::build_for_pair_with_active(&design_sparse, None, INTERCEPT_PAIR, &active_sparse)
+        CrossTab::build_for_pair_with_active(&design_sparse, INTERCEPT_PAIR, &active_sparse)
             .expect("sparse cross tab should build");
 
     // Dense reference: collapse levels so n_rows * n_cols <= 5M.
@@ -52,7 +52,7 @@ fn test_cross_tab_sparse_accumulation_path() {
     let design_dense = design_of(vec![fa_small.clone(), fb_small.clone()]);
     let active_dense = find_all_active_levels(&design_dense.design);
     let (_ct_dense, diag_dense, _) =
-        CrossTab::build_for_pair_with_active(&design_dense, None, INTERCEPT_PAIR, &active_dense)
+        CrossTab::build_for_pair_with_active(&design_dense, INTERCEPT_PAIR, &active_dense)
             .expect("dense cross tab should build");
 
     // Each observation appears exactly once in its row/col bucket.
@@ -121,7 +121,7 @@ fn test_extract_component_two_components() {
     let design = design_of(vec![fa, fb]);
     let all_active = find_all_active_levels(&design.design);
     let (ct, parent_diag, _) =
-        CrossTab::build_for_pair_with_active(&design, None, INTERCEPT_PAIR, &all_active)
+        CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
     let components = ct.bipartite_connected_components();
@@ -234,7 +234,7 @@ proptest! {
 
         let design = design_of(vec![fa, fb]);
         let all_active = find_all_active_levels(&design.design);
-        let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, None, INTERCEPT_PAIR, &all_active)
+        let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
         let components = ct.bipartite_connected_components();

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -3,11 +3,10 @@ use proptest::prelude::*;
 use super::accumulate::{
     accumulate_dense_cross_block, accumulate_sparse_cross_block, PairColumns, Unit,
 };
-use super::{build_compact_mapping, CrossTab};
+use super::{build_compact_mapping, find_all_active_levels, CrossTab};
 use crate::channel::{Channel, ChannelPair};
 use crate::csr_block::CsrBlock;
-use crate::domain::find_all_active_levels;
-use crate::domain::{Design, Effect};
+use crate::domain::{Design, Effect, PreparedDesign};
 use crate::observation::ObservationFrame;
 
 impl CrossTab {
@@ -23,10 +22,10 @@ const INTERCEPT_PAIR: ChannelPair = ChannelPair {
     cols: Channel { term: 1, column: 0 },
 };
 
-fn design_of(columns: Vec<Vec<u32>>) -> Design<'static> {
+fn design_of(columns: Vec<Vec<u32>>) -> PreparedDesign<'static> {
     let frame = ObservationFrame::new(columns.into_iter().map(Into::into).collect(), Vec::new())
         .expect("valid frame");
-    Design::from_frame(frame).expect("valid design")
+    PreparedDesign::unweighted_for_test(Design::from_frame(frame).expect("valid design"))
 }
 
 #[test]
@@ -44,18 +43,18 @@ fn test_cross_tab_sparse_accumulation_path() {
 
     // Sparse path (large level counts)
     let design_sparse = design_of(vec![fa.clone(), fb.clone()]);
-    let active_sparse = find_all_active_levels(&design_sparse);
+    let active_sparse = find_all_active_levels(&design_sparse.design);
     let (ct_sparse, diag_sparse, _) =
-        CrossTab::build_for_pair_with_active(&design_sparse, None, INTERCEPT_PAIR, &active_sparse)
+        CrossTab::build_for_pair_with_active(&design_sparse, INTERCEPT_PAIR, &active_sparse)
             .expect("sparse cross tab should build");
 
     // Dense reference: collapse levels so n_rows * n_cols <= 5M.
     let fa_small: Vec<u32> = fa.iter().map(|&x| x % 100).collect();
     let fb_small: Vec<u32> = fb.iter().map(|&x| x % 100).collect();
     let design_dense = design_of(vec![fa_small.clone(), fb_small.clone()]);
-    let active_dense = find_all_active_levels(&design_dense);
+    let active_dense = find_all_active_levels(&design_dense.design);
     let (_ct_dense, diag_dense, _) =
-        CrossTab::build_for_pair_with_active(&design_dense, None, INTERCEPT_PAIR, &active_dense)
+        CrossTab::build_for_pair_with_active(&design_dense, INTERCEPT_PAIR, &active_dense)
             .expect("dense cross tab should build");
 
     // Each observation appears exactly once in its row/col bucket.
@@ -122,9 +121,9 @@ fn test_extract_component_two_components() {
     let fa = vec![0u32, 0, 1, 1, 2, 2, 3, 3];
     let fb = vec![0u32, 1, 0, 1, 2, 3, 2, 3];
     let design = design_of(vec![fa, fb]);
-    let all_active = find_all_active_levels(&design);
+    let all_active = find_all_active_levels(&design.design);
     let (ct, parent_diag, _) =
-        CrossTab::build_for_pair_with_active(&design, None, INTERCEPT_PAIR, &all_active)
+        CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
     let components = ct.bipartite_connected_components();
@@ -236,8 +235,8 @@ proptest! {
         }
 
         let design = design_of(vec![fa, fb]);
-        let all_active = find_all_active_levels(&design);
-        let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, None, INTERCEPT_PAIR, &all_active)
+        let all_active = find_all_active_levels(&design.design);
+        let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
         let components = ct.bipartite_connected_components();
@@ -287,7 +286,7 @@ fn test_find_all_active_levels_with_gaps() {
     let fb = vec![0u32, 1, 2, 0, 1, 2];
     let design = design_of(vec![fa, fb]);
 
-    let active = find_all_active_levels(&design);
+    let active = find_all_active_levels(&design.design);
 
     // Factor 0: 5 levels, only 0, 2, 4 active.
     assert_eq!(active[0].len(), 5, "factor 0 should have 5 levels");

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -7,7 +7,6 @@ use super::{build_compact_mapping, find_all_active_levels, CrossTab};
 use crate::channel::{Channel, ChannelPair};
 use crate::csr_block::CsrBlock;
 use crate::domain::{Design, Effect, PreparedDesign};
-use crate::observation::ObservationFrame;
 
 impl CrossTab {
     pub(crate) fn from_dense_for_test(table: &[f64], n_rows: usize, n_cols: usize) -> Self {
@@ -21,12 +20,6 @@ const INTERCEPT_PAIR: ChannelPair = ChannelPair {
     rows: Channel { term: 0, column: 0 },
     cols: Channel { term: 1, column: 0 },
 };
-
-fn design_of(columns: Vec<Vec<u32>>) -> PreparedDesign<'static> {
-    let frame = ObservationFrame::new(columns.into_iter().map(Into::into).collect(), Vec::new())
-        .expect("valid frame");
-    PreparedDesign::unweighted_for_test(Design::from_frame(frame).expect("valid design"))
-}
 
 #[test]
 fn test_cross_tab_sparse_accumulation_path() {
@@ -42,7 +35,7 @@ fn test_cross_tab_sparse_accumulation_path() {
     }
 
     // Sparse path (large level counts)
-    let design_sparse = design_of(vec![fa.clone(), fb.clone()]);
+    let design_sparse = PreparedDesign::from_levels_for_test(vec![fa.clone(), fb.clone()]);
     let active_sparse = find_all_active_levels(&design_sparse.design);
     let (ct_sparse, diag_sparse, _) =
         CrossTab::build_for_pair_with_active(&design_sparse, INTERCEPT_PAIR, &active_sparse)
@@ -51,7 +44,8 @@ fn test_cross_tab_sparse_accumulation_path() {
     // Dense reference: collapse levels so n_rows * n_cols <= 5M.
     let fa_small: Vec<u32> = fa.iter().map(|&x| x % 100).collect();
     let fb_small: Vec<u32> = fb.iter().map(|&x| x % 100).collect();
-    let design_dense = design_of(vec![fa_small.clone(), fb_small.clone()]);
+    let design_dense =
+        PreparedDesign::from_levels_for_test(vec![fa_small.clone(), fb_small.clone()]);
     let active_dense = find_all_active_levels(&design_dense.design);
     let (_ct_dense, diag_dense, _) =
         CrossTab::build_for_pair_with_active(&design_dense, INTERCEPT_PAIR, &active_dense)
@@ -120,7 +114,7 @@ fn test_extract_component_two_components() {
     // Two disconnected bipartite components: q/r levels {0,1} and {2,3}.
     let fa = vec![0u32, 0, 1, 1, 2, 2, 3, 3];
     let fb = vec![0u32, 1, 0, 1, 2, 3, 2, 3];
-    let design = design_of(vec![fa, fb]);
+    let design = PreparedDesign::from_levels_for_test(vec![fa, fb]);
     let all_active = find_all_active_levels(&design.design);
     let (ct, parent_diag, _) =
         CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
@@ -234,7 +228,7 @@ proptest! {
             fb.push((s % n_cols as u64) as u32);
         }
 
-        let design = design_of(vec![fa, fb]);
+        let design = PreparedDesign::from_levels_for_test(vec![fa, fb]);
         let all_active = find_all_active_levels(&design.design);
         let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
@@ -284,7 +278,7 @@ fn test_find_all_active_levels_with_gaps() {
     // Factor 0 has 5 levels but only 0, 2, 4 appear; factor 1 uses all 3.
     let fa = vec![0u32, 2, 4, 0, 2, 4];
     let fb = vec![0u32, 1, 2, 0, 1, 2];
-    let design = design_of(vec![fa, fb]);
+    let design = PreparedDesign::from_levels_for_test(vec![fa, fb]);
 
     let active = find_all_active_levels(&design.design);
 

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -328,7 +328,7 @@ fn dense_and_sparse_paths_agree_on_signed_data() {
         col_levels: design.frame.level_column(1),
         row_load: design.frame.loading_column(0),
         col_load: Unit,
-        weights: None,
+        sqrt_weights: None,
     };
     let (c_dense, dq_dense, dr_dense) = accumulate_dense_cross_block(cols, &active);
     let (c_sparse, dq_sparse, dr_sparse) = accumulate_sparse_cross_block(cols, &active);

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -3,9 +3,10 @@ use proptest::prelude::*;
 use super::accumulate::{
     accumulate_dense_cross_block, accumulate_sparse_cross_block, PairColumns, Unit,
 };
-use super::{build_compact_mapping, find_all_active_levels, CrossTab};
+use super::{build_compact_mapping, CrossTab};
 use crate::channel::{Channel, ChannelPair};
 use crate::csr_block::CsrBlock;
+use crate::domain::find_all_active_levels;
 use crate::domain::{Design, Effect, PreparedDesign};
 
 impl CrossTab {
@@ -21,6 +22,10 @@ const INTERCEPT_PAIR: ChannelPair = ChannelPair {
     cols: Channel { term: 1, column: 0 },
 };
 
+fn design_of(columns: Vec<Vec<u32>>) -> PreparedDesign<'static> {
+    PreparedDesign::from_levels_for_test(columns)
+}
+
 #[test]
 fn test_cross_tab_sparse_accumulation_path() {
     // n_rows * n_cols > 5M triggers the sparse path; few observations keep both paths equal.
@@ -35,20 +40,19 @@ fn test_cross_tab_sparse_accumulation_path() {
     }
 
     // Sparse path (large level counts)
-    let design_sparse = PreparedDesign::from_levels_for_test(vec![fa.clone(), fb.clone()]);
+    let design_sparse = design_of(vec![fa.clone(), fb.clone()]);
     let active_sparse = find_all_active_levels(&design_sparse.design);
     let (ct_sparse, diag_sparse, _) =
-        CrossTab::build_for_pair_with_active(&design_sparse, INTERCEPT_PAIR, &active_sparse)
+        CrossTab::build_for_pair_with_active(&design_sparse, None, INTERCEPT_PAIR, &active_sparse)
             .expect("sparse cross tab should build");
 
     // Dense reference: collapse levels so n_rows * n_cols <= 5M.
     let fa_small: Vec<u32> = fa.iter().map(|&x| x % 100).collect();
     let fb_small: Vec<u32> = fb.iter().map(|&x| x % 100).collect();
-    let design_dense =
-        PreparedDesign::from_levels_for_test(vec![fa_small.clone(), fb_small.clone()]);
+    let design_dense = design_of(vec![fa_small.clone(), fb_small.clone()]);
     let active_dense = find_all_active_levels(&design_dense.design);
     let (_ct_dense, diag_dense, _) =
-        CrossTab::build_for_pair_with_active(&design_dense, INTERCEPT_PAIR, &active_dense)
+        CrossTab::build_for_pair_with_active(&design_dense, None, INTERCEPT_PAIR, &active_dense)
             .expect("dense cross tab should build");
 
     // Each observation appears exactly once in its row/col bucket.
@@ -114,10 +118,10 @@ fn test_extract_component_two_components() {
     // Two disconnected bipartite components: q/r levels {0,1} and {2,3}.
     let fa = vec![0u32, 0, 1, 1, 2, 2, 3, 3];
     let fb = vec![0u32, 1, 0, 1, 2, 3, 2, 3];
-    let design = PreparedDesign::from_levels_for_test(vec![fa, fb]);
+    let design = design_of(vec![fa, fb]);
     let all_active = find_all_active_levels(&design.design);
     let (ct, parent_diag, _) =
-        CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
+        CrossTab::build_for_pair_with_active(&design, None, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
     let components = ct.bipartite_connected_components();
@@ -228,9 +232,9 @@ proptest! {
             fb.push((s % n_cols as u64) as u32);
         }
 
-        let design = PreparedDesign::from_levels_for_test(vec![fa, fb]);
+        let design = design_of(vec![fa, fb]);
         let all_active = find_all_active_levels(&design.design);
-        let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
+        let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, None, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
         let components = ct.bipartite_connected_components();
@@ -278,7 +282,7 @@ fn test_find_all_active_levels_with_gaps() {
     // Factor 0 has 5 levels but only 0, 2, 4 appear; factor 1 uses all 3.
     let fa = vec![0u32, 2, 4, 0, 2, 4];
     let fb = vec![0u32, 1, 2, 0, 1, 2];
-    let design = PreparedDesign::from_levels_for_test(vec![fa, fb]);
+    let design = design_of(vec![fa, fb]);
 
     let active = find_all_active_levels(&design.design);
 

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -12,7 +12,7 @@ use crate::channel::{Channel, ChannelPair};
 use crate::config::LocalSolverConfig;
 use crate::{BuildError, BuildWarning};
 
-use super::{find_all_active_levels, BlockDiagonals, CrossTab, Design};
+use super::{find_all_active_levels, BlockDiagonals, CrossTab, PreparedDesign};
 
 mod sddm;
 use crate::domain::Loading;
@@ -34,11 +34,12 @@ pub(crate) struct LocalDomain {
 
 /// Same-factor channel pairs are exactly orthogonal after whitening, so never enumerated.
 pub(crate) fn build_local_domains(
-    design: &Design<'_>,
-    weights: Option<&[f64]>,
+    prepared: &PreparedDesign<'_>,
     config: &LocalSolverConfig,
 ) -> Result<(Vec<LocalDomain>, Vec<BuildWarning>), BuildError> {
     use rayon::prelude::*;
+
+    let design = &prepared.design;
 
     if !config.ridge.is_finite() || config.ridge < 0.0 {
         return Err(BuildError::InvalidRidge {
@@ -59,13 +60,13 @@ pub(crate) fn build_local_domains(
                 .map(move |&cols| ChannelPair { rows, cols })
         })
         .collect();
-    let all_active = find_all_active_levels(design);
 
+    let all_active = find_all_active_levels(design);
     let per_pair: Vec<(Vec<LocalDomain>, Vec<BuildWarning>)> = pairs
         .par_iter()
         .map(|&pair| {
             let Some((full_ct, full_diag, l2g)) =
-                CrossTab::build_for_pair_with_active(design, weights, pair, &all_active)
+                CrossTab::build_for_pair_with_active(prepared, pair, &all_active)
             else {
                 return Ok((Vec::new(), Vec::new()));
             };
@@ -205,11 +206,11 @@ fn compute_partition_weights(domain_pairs: &mut [LocalDomain], n_dofs: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::Design;
+    use crate::domain::{Design, PreparedDesign};
     use crate::observation::ObservationFrame;
     use crate::Effect;
 
-    fn make_test_design() -> Design<'static> {
+    fn make_test_design() -> PreparedDesign<'static> {
         let frame = ObservationFrame::new(
             vec![
                 vec![0u32, 1, 2, 0, 1, 2].into(),
@@ -219,14 +220,14 @@ mod tests {
             Vec::new(),
         )
         .expect("valid frame");
-        Design::from_frame(frame).expect("valid test design")
+        PreparedDesign::unweighted_for_test(Design::from_frame(frame).expect("valid test design"))
     }
 
     #[test]
     fn test_full_cover_domain_count() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
+        let (domain_pairs, _) =
+            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
         // 3 factor pairs; each pair may produce multiple components
         assert!(domain_pairs.len() >= 3);
     }
@@ -234,9 +235,9 @@ mod tests {
     #[test]
     fn test_partition_of_unity() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
-        let n_dofs = dm.n_dofs;
+        let (domain_pairs, _) =
+            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
+        let n_dofs = dm.design.n_dofs;
         // Two-sided PoU: squared weights must sum to 1 at every DOF.
         let mut weight_sq_sum = vec![0.0; n_dofs];
         for ld in &domain_pairs {
@@ -265,8 +266,10 @@ mod tests {
             Effect::new(&levels_c, true, []).expect("effect c"),
         ])
         .expect("valid slope design");
+        let n_dofs = design.n_dofs;
+        let design = PreparedDesign::unweighted_for_test(design);
 
-        let (domain_pairs, _) = build_local_domains(&design, None, &LocalSolverConfig::default())
+        let (domain_pairs, _) = build_local_domains(&design, &LocalSolverConfig::default())
             .expect("slope domains build");
 
         for ld in &domain_pairs {
@@ -280,7 +283,7 @@ mod tests {
         }
 
         // Non-vacuity: without a shared DOF, uniform vs 1/√c weights are indistinguishable.
-        let mut counts = vec![0u32; design.n_dofs];
+        let mut counts = vec![0u32; n_dofs];
         for ld in &domain_pairs {
             for &idx in ld.core.global_indices() {
                 counts[idx as usize] += 1;
@@ -295,9 +298,9 @@ mod tests {
     #[test]
     fn test_domains_cover_all_dofs() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
-        let mut covered = vec![false; dm.n_dofs];
+        let (domain_pairs, _) =
+            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
+        let mut covered = vec![false; dm.design.n_dofs];
         for ld in &domain_pairs {
             for &idx in ld.core.global_indices() {
                 covered[idx as usize] = true;

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -204,20 +204,14 @@ fn compute_partition_weights(domain_pairs: &mut [LocalDomain], n_dofs: usize) {
 mod tests {
     use super::*;
     use crate::domain::{Design, PreparedDesign};
-    use crate::observation::ObservationFrame;
     use crate::Effect;
 
     fn make_test_design() -> PreparedDesign<'static> {
-        let frame = ObservationFrame::new(
-            vec![
-                vec![0u32, 1, 2, 0, 1, 2].into(),
-                vec![0u32, 1, 0, 1, 0, 1].into(),
-                vec![0u32, 0, 1, 1, 0, 1].into(),
-            ],
-            Vec::new(),
-        )
-        .expect("valid frame");
-        PreparedDesign::unweighted_for_test(Design::from_frame(frame).expect("valid test design"))
+        PreparedDesign::from_levels_for_test(vec![
+            vec![0, 1, 2, 0, 1, 2],
+            vec![0, 1, 0, 1, 0, 1],
+            vec![0, 0, 1, 1, 0, 1],
+        ])
     }
 
     #[test]

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -12,7 +12,7 @@ use crate::channel::{Channel, ChannelPair};
 use crate::config::LocalSolverConfig;
 use crate::{BuildError, BuildWarning};
 
-use super::{find_all_active_levels, BlockDiagonals, CrossTab, PreparedDesign, TermMeta};
+use super::{find_all_active_levels, BlockDiagonals, CrossTab, PreparedDesign};
 
 mod sddm;
 use crate::domain::Loading;
@@ -35,6 +35,7 @@ pub(crate) struct LocalDomain {
 /// Same-factor channel pairs are exactly orthogonal after whitening, so never enumerated.
 pub(crate) fn build_local_domains(
     prepared: &PreparedDesign<'_>,
+    sqrt_weights: Option<&[f64]>,
     config: &LocalSolverConfig,
 ) -> Result<(Vec<LocalDomain>, Vec<BuildWarning>), BuildError> {
     use rayon::prelude::*;
@@ -60,13 +61,13 @@ pub(crate) fn build_local_domains(
                 .map(move |&cols| ChannelPair { rows, cols })
         })
         .collect();
-
     let all_active = find_all_active_levels(design);
+
     let per_pair: Vec<(Vec<LocalDomain>, Vec<BuildWarning>)> = pairs
         .par_iter()
         .map(|&pair| {
             let Some((full_ct, full_diag, l2g)) =
-                CrossTab::build_for_pair_with_active(prepared, pair, &all_active)
+                CrossTab::build_for_pair_with_active(prepared, sqrt_weights, pair, &all_active)
             else {
                 return Ok((Vec::new(), Vec::new()));
             };
@@ -88,7 +89,10 @@ pub(crate) fn build_local_domains(
     }
 
     // A slope channel breaks `1/√c`'s equal-informativeness assumption (#94), so stay uniform.
-    if !design.terms.iter().any(TermMeta::has_slopes) {
+    if !channels
+        .iter()
+        .any(|&c| design.loading(c).covariate().is_some())
+    {
         compute_partition_weights(&mut domain_pairs, design.n_dofs);
     }
 
@@ -217,8 +221,8 @@ mod tests {
     #[test]
     fn test_full_cover_domain_count() {
         let dm = make_test_design();
-        let (domain_pairs, _) =
-            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
+        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
+            .expect("plain domains build");
         // 3 factor pairs; each pair may produce multiple components
         assert!(domain_pairs.len() >= 3);
     }
@@ -226,8 +230,8 @@ mod tests {
     #[test]
     fn test_partition_of_unity() {
         let dm = make_test_design();
-        let (domain_pairs, _) =
-            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
+        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
+            .expect("plain domains build");
         let n_dofs = dm.design.n_dofs;
         // Two-sided PoU: squared weights must sum to 1 at every DOF.
         let mut weight_sq_sum = vec![0.0; n_dofs];
@@ -257,10 +261,9 @@ mod tests {
             Effect::new(&levels_c, true, []).expect("effect c"),
         ])
         .expect("valid slope design");
-        let n_dofs = design.n_dofs;
         let design = PreparedDesign::unweighted_for_test(design);
 
-        let (domain_pairs, _) = build_local_domains(&design, &LocalSolverConfig::default())
+        let (domain_pairs, _) = build_local_domains(&design, None, &LocalSolverConfig::default())
             .expect("slope domains build");
 
         for ld in &domain_pairs {
@@ -274,7 +277,7 @@ mod tests {
         }
 
         // Non-vacuity: without a shared DOF, uniform vs 1/√c weights are indistinguishable.
-        let mut counts = vec![0u32; n_dofs];
+        let mut counts = vec![0u32; design.design.n_dofs];
         for ld in &domain_pairs {
             for &idx in ld.core.global_indices() {
                 counts[idx as usize] += 1;
@@ -289,8 +292,8 @@ mod tests {
     #[test]
     fn test_domains_cover_all_dofs() {
         let dm = make_test_design();
-        let (domain_pairs, _) =
-            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
+        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
+            .expect("plain domains build");
         let mut covered = vec![false; dm.design.n_dofs];
         for ld in &domain_pairs {
             for &idx in ld.core.global_indices() {

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -12,7 +12,7 @@ use crate::channel::{Channel, ChannelPair};
 use crate::config::LocalSolverConfig;
 use crate::{BuildError, BuildWarning};
 
-use super::{find_all_active_levels, BlockDiagonals, CrossTab, PreparedDesign};
+use super::{find_all_active_levels, BlockDiagonals, CrossTab, PreparedDesign, TermMeta};
 
 mod sddm;
 use crate::domain::Loading;
@@ -88,10 +88,7 @@ pub(crate) fn build_local_domains(
     }
 
     // A slope channel breaks `1/√c`'s equal-informativeness assumption (#94), so stay uniform.
-    if !channels
-        .iter()
-        .any(|&c| design.loading(c).covariate().is_some())
-    {
+    if !design.terms.iter().any(TermMeta::has_slopes) {
         compute_partition_weights(&mut domain_pairs, design.n_dofs);
     }
 

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -35,7 +35,6 @@ pub(crate) struct LocalDomain {
 /// Same-factor channel pairs are exactly orthogonal after whitening, so never enumerated.
 pub(crate) fn build_local_domains(
     prepared: &PreparedDesign<'_>,
-    sqrt_weights: Option<&[f64]>,
     config: &LocalSolverConfig,
 ) -> Result<(Vec<LocalDomain>, Vec<BuildWarning>), BuildError> {
     use rayon::prelude::*;
@@ -67,7 +66,7 @@ pub(crate) fn build_local_domains(
         .par_iter()
         .map(|&pair| {
             let Some((full_ct, full_diag, l2g)) =
-                CrossTab::build_for_pair_with_active(prepared, sqrt_weights, pair, &all_active)
+                CrossTab::build_for_pair_with_active(prepared, pair, &all_active)
             else {
                 return Ok((Vec::new(), Vec::new()));
             };
@@ -221,8 +220,8 @@ mod tests {
     #[test]
     fn test_full_cover_domain_count() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
+        let (domain_pairs, _) =
+            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
         // 3 factor pairs; each pair may produce multiple components
         assert!(domain_pairs.len() >= 3);
     }
@@ -230,8 +229,8 @@ mod tests {
     #[test]
     fn test_partition_of_unity() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
+        let (domain_pairs, _) =
+            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
         let n_dofs = dm.design.n_dofs;
         // Two-sided PoU: squared weights must sum to 1 at every DOF.
         let mut weight_sq_sum = vec![0.0; n_dofs];
@@ -263,7 +262,7 @@ mod tests {
         .expect("valid slope design");
         let design = PreparedDesign::unweighted_for_test(design);
 
-        let (domain_pairs, _) = build_local_domains(&design, None, &LocalSolverConfig::default())
+        let (domain_pairs, _) = build_local_domains(&design, &LocalSolverConfig::default())
             .expect("slope domains build");
 
         for ld in &domain_pairs {
@@ -292,8 +291,8 @@ mod tests {
     #[test]
     fn test_domains_cover_all_dofs() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
+        let (domain_pairs, _) =
+            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
         let mut covered = vec![false; dm.design.n_dofs];
         for ld in &domain_pairs {
             for &idx in ld.core.global_indices() {

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -1,7 +1,4 @@
-//! Per-level weighted moments of a term's loading columns, built once and read
-//! by both the collinearity screen and the slope whitening.
-
-use rayon::prelude::*;
+//! Per-level weighted moments of a term's loading columns, the input to slope whitening.
 
 use super::{row_weight, Design};
 
@@ -9,40 +6,10 @@ use super::{row_weight, Design};
 /// within-level variance falls to `RANK_TOL` × its own initial variance.
 pub(crate) const RANK_TOL: f64 = 1e-10;
 
-/// Every term's [`LevelMoments`], indexed by term.
-pub(crate) struct TermMoments(Vec<LevelMoments>);
-
-impl TermMoments {
-    /// `None` when no term carries a covariate, so nothing downstream has work.
-    pub(crate) fn build(design: &Design<'_>, sqrt_weights: Option<&[f64]>) -> Option<Self> {
-        let has_slopes = design
-            .terms
-            .iter()
-            .any(|t| t.columns.iter().any(|c| c.covariate().is_some()));
-        has_slopes.then(|| {
-            Self(
-                (0..design.terms.len())
-                    .into_par_iter()
-                    .map(|term| LevelMoments::build(design, term, sqrt_weights))
-                    .collect(),
-            )
-        })
-    }
-}
-
-impl std::ops::Index<usize> for TermMoments {
-    type Output = LevelMoments;
-
-    fn index(&self, term: usize) -> &LevelMoments {
-        &self.0[term]
-    }
-}
-
 /// One-pass weighted within-level moments (multivariate Welford); structural
 /// zeros stay exact, so rank drops survive a zero tolerance.
 pub(crate) struct LevelMoments {
-    /// Frame columns of the term's covariates, in coefficient-column order.
-    covariates: Box<[u32]>,
+    v: usize,
     intercept: bool,
     w_sum: Vec<f64>,
     mean: Vec<f64>,
@@ -60,26 +27,20 @@ fn tri_len(v: usize) -> usize {
 }
 
 impl LevelMoments {
-    fn build(design: &Design<'_>, term: usize, sqrt_weights: Option<&[f64]>) -> Self {
+    pub(crate) fn build(design: &Design<'_>, term: usize, sqrt_weights: Option<&[f64]>) -> Self {
         let meta = &design.terms[term];
-        let covariates: Box<[u32]> = meta
-            .columns
-            .iter()
-            .filter_map(|c| c.covariate().copied())
+        let zs: Vec<&[f64]> = meta
+            .covariates()
+            .map(|c| design.frame.loading_column(c as usize))
             .collect();
-        let v = covariates.len();
+        let v = zs.len();
         let mut moments = Self {
-            intercept: v < meta.columns.len(),
+            v,
+            intercept: meta.has_intercept(),
             w_sum: vec![0.0; meta.n_levels],
             mean: vec![0.0; meta.n_levels * v],
             comoment: vec![0.0; meta.n_levels * tri_len(v)],
-            covariates,
         };
-        let zs: Vec<&[f64]> = moments
-            .covariates
-            .iter()
-            .map(|&c| design.frame.loading_column(c as usize))
-            .collect();
         let mut z_row = vec![0.0; v];
         let mut delta = vec![0.0; v];
         for (obs, &level) in design.frame.level_column(term).iter().enumerate() {
@@ -96,7 +57,7 @@ impl LevelMoments {
         if w <= 0.0 {
             return;
         }
-        let v = self.n_slopes();
+        let v = self.v;
         self.w_sum[level] += w;
         let ratio = w / self.w_sum[level];
         let mean = &mut self.mean[level * v..][..v];
@@ -113,29 +74,12 @@ impl LevelMoments {
         }
     }
 
-    pub(crate) fn n_slopes(&self) -> usize {
-        self.covariates.len()
-    }
-
-    /// Frame columns of the term's covariates, in coefficient-column order.
-    pub(crate) fn covariates(&self) -> &[u32] {
-        &self.covariates
-    }
-
-    pub(crate) fn intercept(&self) -> bool {
-        self.intercept
-    }
-
-    pub(crate) fn n_levels(&self) -> usize {
-        self.w_sum.len()
-    }
-
     pub(crate) fn w_sum(&self, level: usize) -> f64 {
         self.w_sum[level]
     }
 
     pub(crate) fn mean(&self, level: usize) -> &[f64] {
-        let v = self.n_slopes();
+        let v = self.v;
         &self.mean[level * v..][..v]
     }
 
@@ -143,7 +87,7 @@ impl LevelMoments {
     /// left in `scratch` so a sweep over levels allocates nothing. `G` is
     /// centered against a pinned intercept, raw (`M2 + w·μμᵀ`) without one.
     pub(crate) fn basis(&self, level: usize, scratch: &mut BasisScratch) {
-        let v = self.n_slopes();
+        let v = self.v;
         let com = &self.comoment[level * tri_len(v)..][..tri_len(v)];
         let mean = self.mean(level);
         let w = self.w_sum[level];

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -1,6 +1,6 @@
 //! Per-level weighted moments of a term's loading columns, the input to slope whitening.
 
-use super::Design;
+use super::{row_weight, Design};
 
 /// Relative rank tolerance: a slope direction drops once its remaining
 /// within-level variance falls to `RANK_TOL` × its own initial variance.
@@ -27,7 +27,7 @@ fn tri_len(v: usize) -> usize {
 }
 
 impl LevelMoments {
-    pub(crate) fn build(design: &Design<'_>, term: usize, weights: Option<&[f64]>) -> Self {
+    pub(crate) fn build(design: &Design<'_>, term: usize, sqrt_weights: Option<&[f64]>) -> Self {
         let meta = &design.terms[term];
         let zs: Vec<&[f64]> = meta
             .covariates()
@@ -47,7 +47,7 @@ impl LevelMoments {
             for (zr, col) in z_row.iter_mut().zip(&zs) {
                 *zr = col[obs];
             }
-            let w = weights.map_or(1.0, |w| w[obs]);
+            let w = row_weight(sqrt_weights, obs);
             moments.observe(level as usize, &z_row, w, &mut delta);
         }
         moments

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -1,9 +1,8 @@
-//! Per-level weighted moments of a term's loading columns, built once and read
-//! by both the collinearity screen and the slope whitening.
+//! Per-level weighted moments of a term's loading columns, the input to slope whitening.
 
 use rayon::prelude::*;
 
-use super::Design;
+use super::{Design, TermMeta};
 
 /// Relative rank tolerance: a slope direction drops once its remaining
 /// within-level variance falls to `RANK_TOL` × its own initial variance.
@@ -15,11 +14,7 @@ pub(crate) struct TermMoments(Vec<LevelMoments>);
 impl TermMoments {
     /// `None` when no term carries a covariate, so nothing downstream has work.
     pub(crate) fn build(design: &Design<'_>, weights: Option<&[f64]>) -> Option<Self> {
-        let has_slopes = design
-            .terms
-            .iter()
-            .any(|t| t.columns.iter().any(|c| c.covariate().is_some()));
-        has_slopes.then(|| {
+        design.terms.iter().any(TermMeta::has_slopes).then(|| {
             Self(
                 (0..design.terms.len())
                     .into_par_iter()
@@ -62,14 +57,10 @@ fn tri_len(v: usize) -> usize {
 impl LevelMoments {
     fn build(design: &Design<'_>, term: usize, weights: Option<&[f64]>) -> Self {
         let meta = &design.terms[term];
-        let covariates: Box<[u32]> = meta
-            .columns
-            .iter()
-            .filter_map(|c| c.covariate().copied())
-            .collect();
+        let covariates: Box<[u32]> = meta.covariates().collect();
         let v = covariates.len();
         let mut moments = Self {
-            intercept: v < meta.columns.len(),
+            intercept: meta.has_intercept(),
             w_sum: vec![0.0; meta.n_levels],
             mean: vec![0.0; meta.n_levels * v],
             comoment: vec![0.0; meta.n_levels * tri_len(v)],
@@ -120,14 +111,6 @@ impl LevelMoments {
     /// Frame columns of the term's covariates, in coefficient-column order.
     pub(crate) fn covariates(&self) -> &[u32] {
         &self.covariates
-    }
-
-    pub(crate) fn intercept(&self) -> bool {
-        self.intercept
-    }
-
-    pub(crate) fn n_levels(&self) -> usize {
-        self.w_sum.len()
     }
 
     pub(crate) fn w_sum(&self, level: usize) -> f64 {

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -1,43 +1,15 @@
 //! Per-level weighted moments of a term's loading columns, the input to slope whitening.
 
-use rayon::prelude::*;
-
-use super::{Design, TermMeta};
+use super::Design;
 
 /// Relative rank tolerance: a slope direction drops once its remaining
 /// within-level variance falls to `RANK_TOL` × its own initial variance.
 pub(crate) const RANK_TOL: f64 = 1e-10;
 
-/// Every term's [`LevelMoments`], indexed by term.
-pub(crate) struct TermMoments(Vec<LevelMoments>);
-
-impl TermMoments {
-    /// `None` when no term carries a covariate, so nothing downstream has work.
-    pub(crate) fn build(design: &Design<'_>, weights: Option<&[f64]>) -> Option<Self> {
-        design.terms.iter().any(TermMeta::has_slopes).then(|| {
-            Self(
-                (0..design.terms.len())
-                    .into_par_iter()
-                    .map(|term| LevelMoments::build(design, term, weights))
-                    .collect(),
-            )
-        })
-    }
-}
-
-impl std::ops::Index<usize> for TermMoments {
-    type Output = LevelMoments;
-
-    fn index(&self, term: usize) -> &LevelMoments {
-        &self.0[term]
-    }
-}
-
 /// One-pass weighted within-level moments (multivariate Welford); structural
 /// zeros stay exact, so rank drops survive a zero tolerance.
 pub(crate) struct LevelMoments {
-    /// Frame columns of the term's covariates, in coefficient-column order.
-    covariates: Box<[u32]>,
+    v: usize,
     intercept: bool,
     w_sum: Vec<f64>,
     mean: Vec<f64>,
@@ -55,22 +27,20 @@ fn tri_len(v: usize) -> usize {
 }
 
 impl LevelMoments {
-    fn build(design: &Design<'_>, term: usize, weights: Option<&[f64]>) -> Self {
+    pub(crate) fn build(design: &Design<'_>, term: usize, weights: Option<&[f64]>) -> Self {
         let meta = &design.terms[term];
-        let covariates: Box<[u32]> = meta.covariates().collect();
-        let v = covariates.len();
+        let zs: Vec<&[f64]> = meta
+            .covariates()
+            .map(|c| design.frame.loading_column(c as usize))
+            .collect();
+        let v = zs.len();
         let mut moments = Self {
+            v,
             intercept: meta.has_intercept(),
             w_sum: vec![0.0; meta.n_levels],
             mean: vec![0.0; meta.n_levels * v],
             comoment: vec![0.0; meta.n_levels * tri_len(v)],
-            covariates,
         };
-        let zs: Vec<&[f64]> = moments
-            .covariates
-            .iter()
-            .map(|&c| design.frame.loading_column(c as usize))
-            .collect();
         let mut z_row = vec![0.0; v];
         let mut delta = vec![0.0; v];
         for (obs, &level) in design.frame.level_column(term).iter().enumerate() {
@@ -105,12 +75,7 @@ impl LevelMoments {
     }
 
     pub(crate) fn n_slopes(&self) -> usize {
-        self.covariates.len()
-    }
-
-    /// Frame columns of the term's covariates, in coefficient-column order.
-    pub(crate) fn covariates(&self) -> &[u32] {
-        &self.covariates
+        self.v
     }
 
     pub(crate) fn w_sum(&self, level: usize) -> f64 {

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -1,4 +1,7 @@
-//! Per-level weighted moments of a term's loading columns, the input to slope whitening.
+//! Per-level weighted moments of a term's loading columns, built once and read
+//! by both the collinearity screen and the slope whitening.
+
+use rayon::prelude::*;
 
 use super::{row_weight, Design};
 
@@ -6,10 +9,40 @@ use super::{row_weight, Design};
 /// within-level variance falls to `RANK_TOL` × its own initial variance.
 pub(crate) const RANK_TOL: f64 = 1e-10;
 
+/// Every term's [`LevelMoments`], indexed by term.
+pub(crate) struct TermMoments(Vec<LevelMoments>);
+
+impl TermMoments {
+    /// `None` when no term carries a covariate, so nothing downstream has work.
+    pub(crate) fn build(design: &Design<'_>, sqrt_weights: Option<&[f64]>) -> Option<Self> {
+        let has_slopes = design
+            .terms
+            .iter()
+            .any(|t| t.columns.iter().any(|c| c.covariate().is_some()));
+        has_slopes.then(|| {
+            Self(
+                (0..design.terms.len())
+                    .into_par_iter()
+                    .map(|term| LevelMoments::build(design, term, sqrt_weights))
+                    .collect(),
+            )
+        })
+    }
+}
+
+impl std::ops::Index<usize> for TermMoments {
+    type Output = LevelMoments;
+
+    fn index(&self, term: usize) -> &LevelMoments {
+        &self.0[term]
+    }
+}
+
 /// One-pass weighted within-level moments (multivariate Welford); structural
 /// zeros stay exact, so rank drops survive a zero tolerance.
 pub(crate) struct LevelMoments {
-    v: usize,
+    /// Frame columns of the term's covariates, in coefficient-column order.
+    covariates: Box<[u32]>,
     intercept: bool,
     w_sum: Vec<f64>,
     mean: Vec<f64>,
@@ -27,20 +60,26 @@ fn tri_len(v: usize) -> usize {
 }
 
 impl LevelMoments {
-    pub(crate) fn build(design: &Design<'_>, term: usize, sqrt_weights: Option<&[f64]>) -> Self {
+    fn build(design: &Design<'_>, term: usize, sqrt_weights: Option<&[f64]>) -> Self {
         let meta = &design.terms[term];
-        let zs: Vec<&[f64]> = meta
-            .covariates()
-            .map(|c| design.frame.loading_column(c as usize))
+        let covariates: Box<[u32]> = meta
+            .columns
+            .iter()
+            .filter_map(|c| c.covariate().copied())
             .collect();
-        let v = zs.len();
+        let v = covariates.len();
         let mut moments = Self {
-            v,
-            intercept: meta.has_intercept(),
+            intercept: v < meta.columns.len(),
             w_sum: vec![0.0; meta.n_levels],
             mean: vec![0.0; meta.n_levels * v],
             comoment: vec![0.0; meta.n_levels * tri_len(v)],
+            covariates,
         };
+        let zs: Vec<&[f64]> = moments
+            .covariates
+            .iter()
+            .map(|&c| design.frame.loading_column(c as usize))
+            .collect();
         let mut z_row = vec![0.0; v];
         let mut delta = vec![0.0; v];
         for (obs, &level) in design.frame.level_column(term).iter().enumerate() {
@@ -57,7 +96,7 @@ impl LevelMoments {
         if w <= 0.0 {
             return;
         }
-        let v = self.v;
+        let v = self.n_slopes();
         self.w_sum[level] += w;
         let ratio = w / self.w_sum[level];
         let mean = &mut self.mean[level * v..][..v];
@@ -74,12 +113,29 @@ impl LevelMoments {
         }
     }
 
+    pub(crate) fn n_slopes(&self) -> usize {
+        self.covariates.len()
+    }
+
+    /// Frame columns of the term's covariates, in coefficient-column order.
+    pub(crate) fn covariates(&self) -> &[u32] {
+        &self.covariates
+    }
+
+    pub(crate) fn intercept(&self) -> bool {
+        self.intercept
+    }
+
+    pub(crate) fn n_levels(&self) -> usize {
+        self.w_sum.len()
+    }
+
     pub(crate) fn w_sum(&self, level: usize) -> f64 {
         self.w_sum[level]
     }
 
     pub(crate) fn mean(&self, level: usize) -> &[f64] {
-        let v = self.v;
+        let v = self.n_slopes();
         &self.mean[level * v..][..v]
     }
 
@@ -87,7 +143,7 @@ impl LevelMoments {
     /// left in `scratch` so a sweep over levels allocates nothing. `G` is
     /// centered against a pinned intercept, raw (`M2 + w·μμᵀ`) without one.
     pub(crate) fn basis(&self, level: usize, scratch: &mut BasisScratch) {
-        let v = self.v;
+        let v = self.n_slopes();
         let com = &self.comoment[level * tri_len(v)..][..tri_len(v)];
         let mean = self.mean(level);
         let w = self.w_sum[level];

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -57,7 +57,7 @@ impl LevelMoments {
         if w <= 0.0 {
             return;
         }
-        let v = self.n_slopes();
+        let v = self.v;
         self.w_sum[level] += w;
         let ratio = w / self.w_sum[level];
         let mean = &mut self.mean[level * v..][..v];
@@ -74,16 +74,12 @@ impl LevelMoments {
         }
     }
 
-    pub(crate) fn n_slopes(&self) -> usize {
-        self.v
-    }
-
     pub(crate) fn w_sum(&self, level: usize) -> f64 {
         self.w_sum[level]
     }
 
     pub(crate) fn mean(&self, level: usize) -> &[f64] {
-        let v = self.n_slopes();
+        let v = self.v;
         &self.mean[level * v..][..v]
     }
 
@@ -91,7 +87,7 @@ impl LevelMoments {
     /// left in `scratch` so a sweep over levels allocates nothing. `G` is
     /// centered against a pinned intercept, raw (`M2 + w·μμᵀ`) without one.
     pub(crate) fn basis(&self, level: usize, scratch: &mut BasisScratch) {
-        let v = self.n_slopes();
+        let v = self.v;
         let com = &self.comoment[level * tri_len(v)..][..tri_len(v)];
         let mean = self.mean(level);
         let w = self.w_sum[level];

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -10,11 +10,8 @@ pub(crate) struct PreparedDesign<'a> {
 }
 
 impl<'a> PreparedDesign<'a> {
-    pub(crate) fn new(design: Design<'a>, weights: Option<Vec<f64>>) -> Result<Self, BuildError> {
-        let sqrt_weights = design.permute_weights(weights)?.map(|mut w| {
-            w.iter_mut().for_each(|wi| *wi = wi.sqrt());
-            w
-        });
+    pub(crate) fn new(design: Design<'a>, weights: Option<&[f64]>) -> Result<Self, BuildError> {
+        let sqrt_weights = weights.map(|w| sqrt_weights(&design, w)).transpose()?;
         let basis = SlopeBasis::build(&design, sqrt_weights.as_deref());
         Ok(Self {
             design,
@@ -22,6 +19,28 @@ impl<'a> PreparedDesign<'a> {
             basis,
         })
     }
+}
+
+/// Validated `√w` in internal observation order.
+fn sqrt_weights(design: &Design<'_>, w: &[f64]) -> Result<Vec<f64>, BuildError> {
+    if w.len() != design.n_obs {
+        return Err(BuildError::WeightCountMismatch {
+            expected: design.n_obs,
+            got: w.len(),
+        });
+    }
+    // `wi >= 0.0` already rejects NaN; `is_finite` additionally rejects `+∞`.
+    if let Some((index, &value)) = w
+        .iter()
+        .enumerate()
+        .find(|&(_, &wi)| !(wi >= 0.0 && wi.is_finite()))
+    {
+        return Err(BuildError::InvalidWeight { index, value });
+    }
+    Ok(match &design.obs_perm {
+        None => w.iter().map(|wi| wi.sqrt()).collect(),
+        Some(perm) => perm.iter().map(|&i| w[i as usize].sqrt()).collect(),
+    })
 }
 
 /// The Gram weight of row `obs`: the operator applies `s`, so its normal matrix carries `s²`.
@@ -44,5 +63,42 @@ mod tests {
         pub(crate) fn from_levels_for_test(columns: Vec<Vec<u32>>) -> Self {
             Self::unweighted_for_test(Design::from_levels_for_test(columns))
         }
+    }
+
+    #[test]
+    fn weights_are_checked_for_count_and_finiteness() {
+        let design = Design::from_levels_for_test(vec![vec![0, 0, 0, 0, 0]]);
+        let check = |w: &[f64]| sqrt_weights(&design, w);
+        assert!(check(&[1.0, 2.0, 3.0, 4.0, 5.0]).is_ok());
+        // Zero weights are valid (an excluded observation).
+        assert!(check(&[0.0, 1.0, 2.0, 3.0, 4.0]).is_ok());
+        assert!(matches!(
+            check(&[1.0, 2.0]),
+            Err(BuildError::WeightCountMismatch {
+                expected: 5,
+                got: 2
+            })
+        ));
+        // Negative / non-finite weights are rejected with the offending index.
+        assert!(matches!(
+            check(&[1.0, -2.0, 3.0, 4.0, 5.0]),
+            Err(BuildError::InvalidWeight { index: 1, .. })
+        ));
+        assert!(matches!(
+            check(&[1.0, 2.0, f64::NAN, 4.0, 5.0]),
+            Err(BuildError::InvalidWeight { index: 2, .. })
+        ));
+        assert!(matches!(
+            check(&[1.0, 2.0, 3.0, f64::INFINITY, 5.0]),
+            Err(BuildError::InvalidWeight { index: 3, .. })
+        ));
+    }
+
+    #[test]
+    fn sqrt_weights_follow_the_locality_permutation() {
+        // Dominant factor [2,0,1,0] argsorts to [1,3,2,0].
+        let design = Design::from_levels_for_test(vec![vec![2, 0, 1, 0]]);
+        let s = sqrt_weights(&design, &[1.0, 4.0, 9.0, 16.0]).unwrap();
+        assert_eq!(s, [2.0, 4.0, 3.0, 1.0]);
     }
 }

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -1,30 +1,32 @@
 use super::{Design, SlopeBasis};
 use crate::BuildError;
 
-/// A [`Design`] plus what one weight vector determines: the weights and the slope basis.
+/// A [`Design`] plus what one weight vector determines: the row scaling and the slope basis.
 pub(crate) struct PreparedDesign<'a> {
     pub(crate) design: Design<'a>,
-    /// Raw weights in internal observation order; `None` is unweighted.
-    pub(crate) weights: Option<Vec<f64>>,
-    /// `W^{1/2}`, the operator's row scaling; kept since `s·s` is not bitwise `w`.
+    /// `W^{1/2}` in internal observation order; `None` is unweighted.
     pub(crate) sqrt_weights: Option<Vec<f64>>,
     pub(crate) basis: SlopeBasis,
 }
 
 impl<'a> PreparedDesign<'a> {
     pub(crate) fn new(design: Design<'a>, weights: Option<Vec<f64>>) -> Result<Self, BuildError> {
-        let weights = design.permute_weights(weights)?;
-        let basis = SlopeBasis::build(&design, weights.as_deref());
-        let sqrt_weights = weights
-            .as_ref()
-            .map(|w| w.iter().map(|wi| wi.sqrt()).collect());
+        let sqrt_weights = design.permute_weights(weights)?.map(|mut w| {
+            w.iter_mut().for_each(|wi| *wi = wi.sqrt());
+            w
+        });
+        let basis = SlopeBasis::build(&design, sqrt_weights.as_deref());
         Ok(Self {
             design,
-            weights,
             sqrt_weights,
             basis,
         })
     }
+}
+
+/// The Gram weight of row `obs`: the operator applies `s`, so its normal matrix carries `s²`.
+pub(crate) fn row_weight(sqrt_weights: Option<&[f64]>, obs: usize) -> f64 {
+    sqrt_weights.map_or(1.0, |s| s[obs] * s[obs])
 }
 
 #[cfg(test)]

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -1,51 +1,27 @@
-use super::{Design, SlopeBasis};
-use crate::BuildError;
+use super::level_moments::TermMoments;
+use super::{Design, SlopeReparam};
 
-/// A [`Design`] plus what one weight vector determines: the row scaling and the slope basis.
+/// A [`Design`] plus the whitened slope basis one weight vector determines.
 pub(crate) struct PreparedDesign<'a> {
     pub(crate) design: Design<'a>,
-    /// `W^{1/2}` in internal observation order; `None` is unweighted.
-    pub(crate) sqrt_weights: Option<Vec<f64>>,
-    pub(crate) basis: SlopeBasis,
+    /// `None` for slope-free designs.
+    pub(crate) reparam: Option<SlopeReparam>,
 }
 
 impl<'a> PreparedDesign<'a> {
-    pub(crate) fn new(design: Design<'a>, weights: Option<&[f64]>) -> Result<Self, BuildError> {
-        let sqrt_weights = weights.map(|w| sqrt_weights(&design, w)).transpose()?;
-        let basis = SlopeBasis::build(&design, sqrt_weights.as_deref());
-        Ok(Self {
-            design,
-            sqrt_weights,
-            basis,
-        })
+    pub(crate) fn new(design: Design<'a>, moments: Option<&TermMoments>) -> Self {
+        let reparam = moments.and_then(|m| SlopeReparam::build(&design, m));
+        Self { design, reparam }
     }
-}
 
-/// Validated `√w` in internal observation order.
-fn sqrt_weights(design: &Design<'_>, w: &[f64]) -> Result<Vec<f64>, BuildError> {
-    if w.len() != design.n_obs {
-        return Err(BuildError::WeightCountMismatch {
-            expected: design.n_obs,
-            got: w.len(),
-        });
+    /// Loading column `column` in the solve basis.
+    pub(crate) fn loading_column(&self, column: usize) -> &[f64] {
+        // Only slope terms reference loading columns, and any slope term makes `reparam` `Some`.
+        self.reparam
+            .as_ref()
+            .expect("loading column on a slope-free design")
+            .loading_column(column)
     }
-    // `wi >= 0.0` already rejects NaN; `is_finite` additionally rejects `+∞`.
-    if let Some((index, &value)) = w
-        .iter()
-        .enumerate()
-        .find(|&(_, &wi)| !(wi >= 0.0 && wi.is_finite()))
-    {
-        return Err(BuildError::InvalidWeight { index, value });
-    }
-    Ok(match &design.obs_perm {
-        None => w.iter().map(|wi| wi.sqrt()).collect(),
-        Some(perm) => perm.iter().map(|&i| w[i as usize].sqrt()).collect(),
-    })
-}
-
-/// The Gram weight of row `obs`: the operator applies `s`, so its normal matrix carries `s²`.
-pub(crate) fn row_weight(sqrt_weights: Option<&[f64]>, obs: usize) -> f64 {
-    sqrt_weights.map_or(1.0, |s| s[obs] * s[obs])
 }
 
 #[cfg(test)]
@@ -55,7 +31,8 @@ mod tests {
     impl<'a> PreparedDesign<'a> {
         /// Unweighted, whitened like a solver would.
         pub(crate) fn unweighted_for_test(design: Design<'a>) -> Self {
-            Self::new(design, None).expect("unweighted preparation cannot fail")
+            let moments = TermMoments::build(&design, None);
+            Self::new(design, moments.as_ref())
         }
     }
 
@@ -63,42 +40,5 @@ mod tests {
         pub(crate) fn from_levels_for_test(columns: Vec<Vec<u32>>) -> Self {
             Self::unweighted_for_test(Design::from_levels_for_test(columns))
         }
-    }
-
-    #[test]
-    fn weights_are_checked_for_count_and_finiteness() {
-        let design = Design::from_levels_for_test(vec![vec![0, 0, 0, 0, 0]]);
-        let check = |w: &[f64]| sqrt_weights(&design, w);
-        assert!(check(&[1.0, 2.0, 3.0, 4.0, 5.0]).is_ok());
-        // Zero weights are valid (an excluded observation).
-        assert!(check(&[0.0, 1.0, 2.0, 3.0, 4.0]).is_ok());
-        assert!(matches!(
-            check(&[1.0, 2.0]),
-            Err(BuildError::WeightCountMismatch {
-                expected: 5,
-                got: 2
-            })
-        ));
-        // Negative / non-finite weights are rejected with the offending index.
-        assert!(matches!(
-            check(&[1.0, -2.0, 3.0, 4.0, 5.0]),
-            Err(BuildError::InvalidWeight { index: 1, .. })
-        ));
-        assert!(matches!(
-            check(&[1.0, 2.0, f64::NAN, 4.0, 5.0]),
-            Err(BuildError::InvalidWeight { index: 2, .. })
-        ));
-        assert!(matches!(
-            check(&[1.0, 2.0, 3.0, f64::INFINITY, 5.0]),
-            Err(BuildError::InvalidWeight { index: 3, .. })
-        ));
-    }
-
-    #[test]
-    fn sqrt_weights_follow_the_locality_permutation() {
-        // Dominant factor [2,0,1,0] argsorts to [1,3,2,0].
-        let design = Design::from_levels_for_test(vec![vec![2, 0, 1, 0]]);
-        let s = sqrt_weights(&design, &[1.0, 4.0, 9.0, 16.0]).unwrap();
-        assert_eq!(s, [2.0, 4.0, 3.0, 1.0]);
     }
 }

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -1,0 +1,48 @@
+//! A design fixed to one weight vector: the state every solve on it shares.
+
+use super::{Design, SlopeBasis};
+use crate::BuildError;
+
+/// A [`Design`] plus what one weight vector determines: the weights and the slope basis.
+pub(crate) struct PreparedDesign<'a> {
+    pub(crate) design: Design<'a>,
+    /// Raw weights in internal observation order; `None` is unweighted.
+    pub(crate) weights: Option<Vec<f64>>,
+    /// `W^{1/2}`, the operator's row scaling; kept beside `weights` since `s·s` is not bitwise `w`.
+    pub(crate) sqrt_weights: Option<Vec<f64>>,
+    pub(crate) basis: SlopeBasis,
+}
+
+impl<'a> PreparedDesign<'a> {
+    pub(crate) fn new(design: Design<'a>, weights: Option<Vec<f64>>) -> Result<Self, BuildError> {
+        let weights = design.permute_weights(weights)?;
+        let basis = SlopeBasis::build(&design, weights.as_deref());
+        let sqrt_weights = weights
+            .as_ref()
+            .map(|w| w.iter().map(|wi| wi.sqrt()).collect());
+        Ok(Self {
+            design,
+            weights,
+            sqrt_weights,
+            basis,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl<'a> PreparedDesign<'a> {
+        /// Unweighted, whitened like a solver would.
+        pub(crate) fn unweighted_for_test(design: Design<'a>) -> Self {
+            Self::new(design, None).expect("unweighted preparation cannot fail")
+        }
+    }
+
+    impl PreparedDesign<'static> {
+        pub(crate) fn from_levels_for_test(columns: Vec<Vec<u32>>) -> Self {
+            Self::unweighted_for_test(Design::from_levels_for_test(columns))
+        }
+    }
+}

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -1,5 +1,3 @@
-//! A design fixed to one weight vector: the state every solve on it shares.
-
 use super::{Design, SlopeBasis};
 use crate::BuildError;
 
@@ -8,7 +6,7 @@ pub(crate) struct PreparedDesign<'a> {
     pub(crate) design: Design<'a>,
     /// Raw weights in internal observation order; `None` is unweighted.
     pub(crate) weights: Option<Vec<f64>>,
-    /// `W^{1/2}`, the operator's row scaling; kept beside `weights` since `s·s` is not bitwise `w`.
+    /// `W^{1/2}`, the operator's row scaling; kept since `s·s` is not bitwise `w`.
     pub(crate) sqrt_weights: Option<Vec<f64>>,
     pub(crate) basis: SlopeBasis,
 }

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -1,4 +1,3 @@
-use super::level_moments::TermMoments;
 use super::{Design, SlopeReparam};
 
 /// A [`Design`] plus the whitened slope basis one weight vector determines.
@@ -9,8 +8,8 @@ pub(crate) struct PreparedDesign<'a> {
 }
 
 impl<'a> PreparedDesign<'a> {
-    pub(crate) fn new(design: Design<'a>, moments: Option<&TermMoments>) -> Self {
-        let reparam = moments.and_then(|m| SlopeReparam::build(&design, m));
+    pub(crate) fn new(design: Design<'a>, sqrt_weights: Option<&[f64]>) -> Self {
+        let reparam = SlopeReparam::build(&design, sqrt_weights);
         Self { design, reparam }
     }
 
@@ -31,8 +30,7 @@ mod tests {
     impl<'a> PreparedDesign<'a> {
         /// Unweighted, whitened like a solver would.
         pub(crate) fn unweighted_for_test(design: Design<'a>) -> Self {
-            let moments = TermMoments::build(&design, None);
-            Self::new(design, moments.as_ref())
+            Self::new(design, None)
         }
     }
 

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -1,16 +1,38 @@
-use super::{Design, SlopeReparam};
+use super::{row_weight, Design, SlopeReparam};
+use crate::BuildError;
 
-/// A [`Design`] plus the whitened slope basis one weight vector determines.
+/// A [`Design`] plus all state one weight vector determines.
 pub(crate) struct PreparedDesign<'a> {
     pub(crate) design: Design<'a>,
+    /// `W^{1/2}` in the design's internal observation order; `None` is unweighted.
+    sqrt_weights: Option<Vec<f64>>,
     /// `None` for slope-free designs.
     pub(crate) reparam: Option<SlopeReparam>,
 }
 
 impl<'a> PreparedDesign<'a> {
-    pub(crate) fn new(design: Design<'a>, sqrt_weights: Option<&[f64]>) -> Self {
-        let reparam = SlopeReparam::build(&design, sqrt_weights);
-        Self { design, reparam }
+    pub(crate) fn new(design: Design<'a>, weights: Option<&[f64]>) -> Result<Self, BuildError> {
+        let sqrt_weights = weights
+            .map(|weights| prepare_sqrt_weights(&design, weights))
+            .transpose()?;
+        let reparam = SlopeReparam::build(&design, sqrt_weights.as_deref());
+        Ok(Self {
+            design,
+            sqrt_weights,
+            reparam,
+        })
+    }
+
+    /// `W^{1/2}` in internal observation order; `None` is unweighted.
+    #[inline]
+    pub(crate) fn sqrt_weights(&self) -> Option<&[f64]> {
+        self.sqrt_weights.as_deref()
+    }
+
+    /// The Gram weight of row `obs`: the operator applies `s`, so its normal matrix carries `s²`.
+    #[inline]
+    pub(crate) fn row_weight(&self, obs: usize) -> f64 {
+        row_weight(self.sqrt_weights(), obs)
     }
 
     /// Loading column `column` in the solve basis.
@@ -23,6 +45,29 @@ impl<'a> PreparedDesign<'a> {
     }
 }
 
+/// Validate caller-order weights, then return `√w` in the design's internal order.
+fn prepare_sqrt_weights(design: &Design<'_>, weights: &[f64]) -> Result<Vec<f64>, BuildError> {
+    if weights.len() != design.n_obs {
+        return Err(BuildError::WeightCountMismatch {
+            expected: design.n_obs,
+            got: weights.len(),
+        });
+    }
+    // `wi >= 0.0` already rejects NaN; `is_finite` additionally rejects `+∞`.
+    if let Some((index, &value)) = weights
+        .iter()
+        .enumerate()
+        .find(|&(_, &wi)| !(wi >= 0.0 && wi.is_finite()))
+    {
+        return Err(BuildError::InvalidWeight { index, value });
+    }
+    Ok(design
+        .permute_obs_in(weights)
+        .iter()
+        .map(|weight| weight.sqrt())
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -30,7 +75,7 @@ mod tests {
     impl<'a> PreparedDesign<'a> {
         /// Unweighted, whitened like a solver would.
         pub(crate) fn unweighted_for_test(design: Design<'a>) -> Self {
-            Self::new(design, None)
+            Self::new(design, None).expect("unweighted preparation cannot fail")
         }
     }
 
@@ -38,5 +83,49 @@ mod tests {
         pub(crate) fn from_levels_for_test(columns: Vec<Vec<u32>>) -> Self {
             Self::unweighted_for_test(Design::from_levels_for_test(columns))
         }
+    }
+
+    #[test]
+    fn owns_sqrt_weights_in_internal_observation_order() {
+        // Dominant factor [2,0,1,0] argsorts to caller positions [1,3,2,0].
+        let design = Design::from_levels_for_test(vec![vec![2, 0, 1, 0]]);
+        let prepared = PreparedDesign::new(design, Some(&[1.0, 4.0, 9.0, 16.0])).unwrap();
+
+        assert_eq!(prepared.sqrt_weights(), Some(&[2.0, 4.0, 3.0, 1.0][..]));
+        assert_eq!(
+            (0..4)
+                .map(|obs| prepared.row_weight(obs))
+                .collect::<Vec<_>>(),
+            [4.0, 16.0, 9.0, 1.0]
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_weights_before_permuting_them() {
+        let design = Design::from_levels_for_test(vec![vec![2, 0, 1, 0]]);
+
+        assert!(PreparedDesign::new(design.clone(), None).is_ok());
+        assert!(PreparedDesign::new(design.clone(), Some(&[1.0, 2.0, 3.0, 4.0])).is_ok());
+        // Zero weights are valid (an excluded observation).
+        assert!(PreparedDesign::new(design.clone(), Some(&[0.0, 1.0, 2.0, 3.0])).is_ok());
+        assert!(matches!(
+            PreparedDesign::new(design.clone(), Some(&[1.0, 2.0])),
+            Err(BuildError::WeightCountMismatch {
+                expected: 4,
+                got: 2
+            })
+        ));
+        assert!(matches!(
+            PreparedDesign::new(design.clone(), Some(&[1.0, -2.0, 3.0, 4.0])),
+            Err(BuildError::InvalidWeight { index: 1, .. })
+        ));
+        assert!(matches!(
+            PreparedDesign::new(design.clone(), Some(&[1.0, 2.0, f64::NAN, 4.0])),
+            Err(BuildError::InvalidWeight { index: 2, .. })
+        ));
+        assert!(matches!(
+            PreparedDesign::new(design, Some(&[1.0, 2.0, 3.0, f64::INFINITY])),
+            Err(BuildError::InvalidWeight { index: 3, .. })
+        ));
     }
 }

--- a/crates/within/src/domain/reparam.rs
+++ b/crates/within/src/domain/reparam.rs
@@ -1,6 +1,8 @@
 //! Within-level reparametrization of a design's varying-slope terms.
 
-use super::level_moments::{BasisScratch, TermMoments};
+use rayon::prelude::*;
+
+use super::level_moments::{BasisScratch, LevelMoments};
 use super::Design;
 use crate::channel::{Channel, CoefficientAddress};
 use crate::linalg::dot;
@@ -41,26 +43,23 @@ impl SlopeReparam {
     /// `None` for slope-free designs. Unidentified directions become
     /// exact-zero columns, so the minimal-norm solve leaves exact-`0`
     /// coefficients.
-    pub(crate) fn build(design: &Design<'_>, moments: &TermMoments) -> Option<Self> {
+    pub(crate) fn build(design: &Design<'_>, sqrt_weights: Option<&[f64]>) -> Option<Self> {
         let mut loadings = vec![Vec::new(); design.frame.n_loading_columns()];
-        let mut terms = Vec::new();
+        let slope_terms: Vec<usize> = (0..design.terms.len())
+            .filter(|&t| design.terms[t].has_slopes())
+            .collect();
+        let moments: Vec<LevelMoments> = slope_terms
+            .par_iter()
+            .map(|&term| LevelMoments::build(design, term, sqrt_weights))
+            .collect();
         let mut unidentified = Vec::new();
-        for term in 0..design.terms.len() {
-            if !design.terms[term]
-                .columns
-                .iter()
-                .any(|c| c.covariate().is_some())
-            {
-                continue;
-            }
-            terms.push(TermReparam::build(
-                design,
-                term,
-                moments,
-                &mut loadings,
-                &mut unidentified,
-            ));
-        }
+        let terms: Vec<TermReparam> = slope_terms
+            .iter()
+            .zip(&moments)
+            .map(|(&term, moments)| {
+                TermReparam::build(design, term, moments, &mut loadings, &mut unidentified)
+            })
+            .collect();
         (!terms.is_empty()).then_some(Self {
             terms,
             loadings,
@@ -82,21 +81,19 @@ impl SlopeReparam {
 }
 
 impl TermReparam {
-    /// Whiten one term's loading columns into `loadings`, appending its
-    /// unidentified directions ascending in `(level, column)`.
+    /// Whitens one term into `loadings`; unidentified directions append in `(level, column)` order.
     fn build(
         design: &Design<'_>,
         term: usize,
-        moments: &TermMoments,
+        moments: &LevelMoments,
         loadings: &mut [Vec<f64>],
         unidentified: &mut Vec<CoefficientAddress>,
     ) -> Self {
         let meta = &design.terms[term];
         let (offset, n_levels) = (meta.offset, meta.n_levels);
-        let intercept = meta.columns.iter().any(|l| l.covariate().is_none());
-        let moments = &moments[term];
-        let v = moments.n_slopes();
-        let z_cols: Vec<usize> = moments.covariates().iter().map(|&c| c as usize).collect();
+        let intercept = meta.has_intercept();
+        let z_cols: Vec<usize> = meta.covariates().map(|c| c as usize).collect();
+        let v = z_cols.len();
         let levels = design.frame.level_column(term);
         let zs: Vec<&[f64]> = z_cols
             .iter()

--- a/crates/within/src/domain/reparam.rs
+++ b/crates/within/src/domain/reparam.rs
@@ -1,8 +1,6 @@
-//! Within-level orthonormal basis of a design's varying-slope terms.
+//! Within-level reparametrization of a design's varying-slope terms.
 
-use rayon::prelude::*;
-
-use super::level_moments::{BasisScratch, LevelMoments};
+use super::level_moments::{BasisScratch, TermMoments};
 use super::Design;
 use crate::channel::{Channel, CoefficientAddress};
 use crate::linalg::dot;
@@ -10,9 +8,11 @@ use crate::linalg::dot;
 #[cfg(test)]
 mod tests;
 
-/// Per-level basis making each slope term's within-level Gram the identity; empty without slopes.
-pub(crate) struct SlopeBasis {
-    terms: Vec<TermBasis>,
+/// Per-level change of basis making each slope-bearing term's within-level
+/// Gram the identity; [`Self::back_transform`] restores the user's
+/// parametrization.
+pub(crate) struct SlopeReparam {
+    terms: Vec<TermReparam>,
     /// The frame's loading columns in the solve basis, indexed like the frame's.
     loadings: Vec<Vec<f64>>,
     /// Directions the data cannot identify, ascending in `(term, level, column)`.
@@ -20,7 +20,7 @@ pub(crate) struct SlopeBasis {
 }
 
 /// One slope-bearing term's whitening state.
-struct TermBasis {
+struct TermReparam {
     offset: usize,
     n_levels: usize,
     /// Slopes start at column 1 behind an intercept, at 0 without one.
@@ -36,31 +36,39 @@ struct LevelTransform {
     center: Box<[f64]>,
 }
 
-impl SlopeBasis {
-    pub(crate) fn build(design: &Design<'_>, sqrt_weights: Option<&[f64]>) -> Self {
+impl SlopeReparam {
+    /// Orthonormalize every slope-bearing term's loading columns into `loadings`;
+    /// `None` for slope-free designs. Unidentified directions become
+    /// exact-zero columns, so the minimal-norm solve leaves exact-`0`
+    /// coefficients.
+    pub(crate) fn build(design: &Design<'_>, moments: &TermMoments) -> Option<Self> {
         let mut loadings = vec![Vec::new(); design.frame.n_loading_columns()];
-        let slope_terms: Vec<usize> = (0..design.terms.len())
-            .filter(|&t| design.terms[t].has_slopes())
-            .collect();
-        let moments: Vec<LevelMoments> = slope_terms
-            .par_iter()
-            .map(|&term| LevelMoments::build(design, term, sqrt_weights))
-            .collect();
+        let mut terms = Vec::new();
         let mut unidentified = Vec::new();
-        let terms = slope_terms
-            .iter()
-            .zip(&moments)
-            .map(|(&term, moments)| {
-                TermBasis::build(design, term, moments, &mut loadings, &mut unidentified)
-            })
-            .collect();
-        Self {
+        for term in 0..design.terms.len() {
+            if !design.terms[term]
+                .columns
+                .iter()
+                .any(|c| c.covariate().is_some())
+            {
+                continue;
+            }
+            terms.push(TermReparam::build(
+                design,
+                term,
+                moments,
+                &mut loadings,
+                &mut unidentified,
+            ));
+        }
+        (!terms.is_empty()).then_some(Self {
             terms,
             loadings,
             unidentified,
-        }
+        })
     }
 
+    /// Loading column `column` in the solve basis.
     pub(crate) fn loading_column(&self, column: usize) -> &[f64] {
         &self.loadings[column]
     }
@@ -73,20 +81,22 @@ impl SlopeBasis {
     }
 }
 
-impl TermBasis {
-    /// Whitens one term into `loadings`; unidentified directions append in `(level, column)` order.
+impl TermReparam {
+    /// Whiten one term's loading columns into `loadings`, appending its
+    /// unidentified directions ascending in `(level, column)`.
     fn build(
         design: &Design<'_>,
         term: usize,
-        moments: &LevelMoments,
+        moments: &TermMoments,
         loadings: &mut [Vec<f64>],
         unidentified: &mut Vec<CoefficientAddress>,
     ) -> Self {
         let meta = &design.terms[term];
         let (offset, n_levels) = (meta.offset, meta.n_levels);
-        let intercept = meta.has_intercept();
-        let z_cols: Vec<usize> = meta.covariates().map(|c| c as usize).collect();
-        let v = z_cols.len();
+        let intercept = meta.columns.iter().any(|l| l.covariate().is_none());
+        let moments = &moments[term];
+        let v = moments.n_slopes();
+        let z_cols: Vec<usize> = moments.covariates().iter().map(|&c| c as usize).collect();
         let levels = design.frame.level_column(term);
         let zs: Vec<&[f64]> = z_cols
             .iter()

--- a/crates/within/src/domain/reparam/tests.rs
+++ b/crates/within/src/domain/reparam/tests.rs
@@ -2,7 +2,6 @@
 //! not reachable through the public API.
 
 use crate::channel::Channel;
-use crate::domain::level_moments::TermMoments;
 use crate::domain::Effect;
 
 use super::*;
@@ -27,18 +26,15 @@ fn three_term_effects() -> Vec<Effect<'static>> {
 #[test]
 fn build_whitens_each_slope_bearing_term() {
     let design = Design::new(three_term_effects()).unwrap();
-    let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&design, &moments).unwrap();
-    assert!(rp.unidentified.is_empty());
+    let basis = SlopeReparam::build(&design, None).unwrap();
+    assert!(basis.unidentified.is_empty());
 
     for term in [0, 2] {
         let meta = &design.terms[term];
         let levels = design.frame.level_column(term);
         let us: Vec<&[f64]> = meta
-            .columns
-            .iter()
-            .filter_map(|c| c.covariate())
-            .map(|&k| rp.loading_column(k as usize))
+            .covariates()
+            .map(|k| basis.loading_column(k as usize))
             .collect();
         for level in 0..meta.n_levels {
             let obs: Vec<usize> = (0..levels.len())
@@ -61,6 +57,12 @@ fn build_whitens_each_slope_bearing_term() {
 }
 
 #[test]
+fn slope_free_design_has_no_reparam() {
+    let design = Design::from_levels_for_test(vec![vec![0, 1, 0], vec![0, 0, 1]]);
+    assert!(SlopeReparam::build(&design, None).is_none());
+}
+
+#[test]
 fn unidentified_directions_ascend_across_terms() {
     // Index-order term iteration keeps the list ascending without any sort.
     let f0 = [0u32, 0, 1, 1, 2, 2];
@@ -72,10 +74,9 @@ fn unidentified_directions_ascend_across_terms() {
         Effect::new(&f1, true, [&z1[..]]).unwrap(),
     ];
     let design = Design::new(effects).unwrap();
-    let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&design, &moments).unwrap();
+    let basis = SlopeReparam::build(&design, None).unwrap();
     assert_eq!(
-        rp.unidentified,
+        basis.unidentified,
         vec![
             CoefficientAddress {
                 channel: Channel { term: 0, column: 1 },
@@ -92,12 +93,11 @@ fn unidentified_directions_ascend_across_terms() {
 #[test]
 fn back_transform_leaves_other_terms_untouched() {
     let design = Design::new(three_term_effects()).unwrap();
-    let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&design, &moments).unwrap();
+    let basis = SlopeReparam::build(&design, None).unwrap();
 
     let mut x: Vec<f64> = (0..design.n_dofs).map(|i| 1.0 + i as f64).collect();
     let before = x.clone();
-    rp.back_transform(&mut x);
+    basis.back_transform(&mut x);
 
     // Plain term 1 sits between the two slope-bearing blocks.
     let (t1, t2) = (design.terms[1].offset, design.terms[2].offset);

--- a/crates/within/src/domain/reparam/tests.rs
+++ b/crates/within/src/domain/reparam/tests.rs
@@ -2,6 +2,7 @@
 //! not reachable through the public API.
 
 use crate::channel::Channel;
+use crate::domain::level_moments::TermMoments;
 use crate::domain::Effect;
 
 use super::*;
@@ -26,15 +27,18 @@ fn three_term_effects() -> Vec<Effect<'static>> {
 #[test]
 fn build_whitens_each_slope_bearing_term() {
     let design = Design::new(three_term_effects()).unwrap();
-    let basis = SlopeBasis::build(&design, None);
-    assert!(basis.unidentified.is_empty());
+    let moments = TermMoments::build(&design, None).unwrap();
+    let rp = SlopeReparam::build(&design, &moments).unwrap();
+    assert!(rp.unidentified.is_empty());
 
     for term in [0, 2] {
         let meta = &design.terms[term];
         let levels = design.frame.level_column(term);
         let us: Vec<&[f64]> = meta
-            .covariates()
-            .map(|k| basis.loading_column(k as usize))
+            .columns
+            .iter()
+            .filter_map(|c| c.covariate())
+            .map(|&k| rp.loading_column(k as usize))
             .collect();
         for level in 0..meta.n_levels {
             let obs: Vec<usize> = (0..levels.len())
@@ -57,15 +61,6 @@ fn build_whitens_each_slope_bearing_term() {
 }
 
 #[test]
-fn slope_free_design_gets_an_empty_basis() {
-    let design = Design::from_levels_for_test(vec![vec![0, 1, 0], vec![0, 0, 1]]);
-    let basis = SlopeBasis::build(&design, None);
-    assert!(basis.terms.is_empty());
-    assert!(basis.loadings.is_empty());
-    assert!(basis.unidentified.is_empty());
-}
-
-#[test]
 fn unidentified_directions_ascend_across_terms() {
     // Index-order term iteration keeps the list ascending without any sort.
     let f0 = [0u32, 0, 1, 1, 2, 2];
@@ -77,9 +72,10 @@ fn unidentified_directions_ascend_across_terms() {
         Effect::new(&f1, true, [&z1[..]]).unwrap(),
     ];
     let design = Design::new(effects).unwrap();
-    let basis = SlopeBasis::build(&design, None);
+    let moments = TermMoments::build(&design, None).unwrap();
+    let rp = SlopeReparam::build(&design, &moments).unwrap();
     assert_eq!(
-        basis.unidentified,
+        rp.unidentified,
         vec![
             CoefficientAddress {
                 channel: Channel { term: 0, column: 1 },
@@ -96,11 +92,12 @@ fn unidentified_directions_ascend_across_terms() {
 #[test]
 fn back_transform_leaves_other_terms_untouched() {
     let design = Design::new(three_term_effects()).unwrap();
-    let basis = SlopeBasis::build(&design, None);
+    let moments = TermMoments::build(&design, None).unwrap();
+    let rp = SlopeReparam::build(&design, &moments).unwrap();
 
     let mut x: Vec<f64> = (0..design.n_dofs).map(|i| 1.0 + i as f64).collect();
     let before = x.clone();
-    basis.back_transform(&mut x);
+    rp.back_transform(&mut x);
 
     // Plain term 1 sits between the two slope-bearing blocks.
     let (t1, t2) = (design.terms[1].offset, design.terms[2].offset);

--- a/crates/within/src/domain/slope_basis.rs
+++ b/crates/within/src/domain/slope_basis.rs
@@ -39,14 +39,14 @@ struct LevelTransform {
 }
 
 impl SlopeBasis {
-    pub(crate) fn build(design: &Design<'_>, weights: Option<&[f64]>) -> Self {
+    pub(crate) fn build(design: &Design<'_>, sqrt_weights: Option<&[f64]>) -> Self {
         let mut loadings = vec![Vec::new(); design.frame.n_loading_columns()];
         let slope_terms: Vec<usize> = (0..design.terms.len())
             .filter(|&t| design.terms[t].has_slopes())
             .collect();
         let moments: Vec<LevelMoments> = slope_terms
             .par_iter()
-            .map(|&term| LevelMoments::build(design, term, weights))
+            .map(|&term| LevelMoments::build(design, term, sqrt_weights))
             .collect();
         let mut unidentified = Vec::new();
         let terms = slope_terms

--- a/crates/within/src/domain/slope_basis.rs
+++ b/crates/within/src/domain/slope_basis.rs
@@ -23,10 +23,8 @@ pub(crate) struct SlopeBasis {
 struct TermBasis {
     offset: usize,
     n_levels: usize,
-    /// Coefficient column of the term's constant, if it has one.
-    intercept_column: Option<usize>,
-    /// Coefficient column of each covariate, in order.
-    slope_columns: Box<[usize]>,
+    /// Slopes start at column 1 behind an intercept, at 0 without one.
+    intercept: bool,
     transforms: Vec<LevelTransform>,
 }
 
@@ -56,8 +54,6 @@ impl SlopeBasis {
                 TermBasis::build(design, term, moments, &mut loadings, &mut unidentified)
             })
             .collect();
-        // `Design::build` rejects unclaimed loading columns, so whitening leaves none unwritten.
-        debug_assert!(loadings.iter().all(|l| l.len() == design.n_obs));
         Self {
             terms,
             loadings,
@@ -88,15 +84,9 @@ impl TermBasis {
     ) -> Self {
         let meta = &design.terms[term];
         let (offset, n_levels) = (meta.offset, meta.n_levels);
-        let intercept_column = meta.columns.iter().position(|l| l.covariate().is_none());
-        let (slope_columns, z_cols): (Vec<usize>, Vec<usize>) = meta
-            .columns
-            .iter()
-            .enumerate()
-            .filter_map(|(col, l)| l.covariate().map(|&z| (col, z as usize)))
-            .unzip();
-        let intercept = intercept_column.is_some();
-        let v = slope_columns.len();
+        let intercept = meta.has_intercept();
+        let z_cols: Vec<usize> = meta.covariates().map(|c| c as usize).collect();
+        let v = z_cols.len();
         let levels = design.frame.level_column(term);
         let zs: Vec<&[f64]> = z_cols
             .iter()
@@ -120,7 +110,7 @@ impl TermBasis {
                     unidentified.push(CoefficientAddress {
                         channel: Channel {
                             term,
-                            column: slope_columns[j],
+                            column: j + intercept as usize,
                         },
                         level,
                     });
@@ -154,8 +144,7 @@ impl TermBasis {
         Self {
             offset,
             n_levels,
-            intercept_column,
-            slope_columns: slope_columns.into(),
+            intercept,
             transforms,
         }
     }
@@ -163,7 +152,7 @@ impl TermBasis {
     /// Map this term's solve-basis coefficients back to the user's
     /// parametrization; slots outside the term's block are untouched.
     fn back_transform(&self, x: &mut [f64]) {
-        let v = self.slope_columns.len();
+        let v = self.transforms.first().map_or(0, |t| t.center.len());
         let mut b = vec![0.0; v];
         for (l, t) in self.transforms.iter().enumerate() {
             if t.w.is_empty() {
@@ -179,13 +168,13 @@ impl TermBasis {
             for (j, &bj) in b.iter().enumerate() {
                 x[self.slope_slot(j, l)] = bj;
             }
-            if let Some(c) = self.intercept_column {
-                x[self.offset + c * self.n_levels + l] -= dot(&b, &t.center);
+            if self.intercept {
+                x[self.offset + l] -= dot(&b, &t.center);
             }
         }
     }
 
     fn slope_slot(&self, j: usize, level: usize) -> usize {
-        self.offset + self.slope_columns[j] * self.n_levels + level
+        self.offset + (j + self.intercept as usize) * self.n_levels + level
     }
 }

--- a/crates/within/src/domain/slope_basis.rs
+++ b/crates/within/src/domain/slope_basis.rs
@@ -1,26 +1,24 @@
-//! Within-level reparametrization of a design's varying-slope terms.
+//! Within-level orthonormal basis of a design's varying-slope terms.
 
-use crate::domain::level_moments::{BasisScratch, TermMoments};
-use crate::domain::Design;
-
-use super::CoefficientAddress;
-use crate::channel::Channel;
+use super::level_moments::{BasisScratch, TermMoments};
+use super::Design;
+use crate::channel::{Channel, CoefficientAddress};
 use crate::linalg::dot;
 
 #[cfg(test)]
 mod tests;
 
-/// Per-level change of basis making each slope-bearing term's within-level
-/// Gram the identity; [`Self::back_transform`] restores the user's
-/// parametrization.
-pub(crate) struct SlopeReparam {
-    terms: Vec<TermReparam>,
+/// Per-level basis making each slope term's within-level Gram the identity; empty without slopes.
+pub(crate) struct SlopeBasis {
+    terms: Vec<TermBasis>,
+    /// The frame's loading columns in the solve basis, indexed like the frame's.
+    loadings: Vec<Vec<f64>>,
     /// Directions the data cannot identify, ascending in `(term, level, column)`.
     pub(crate) unidentified: Vec<CoefficientAddress>,
 }
 
 /// One slope-bearing term's whitening state.
-struct TermReparam {
+struct TermBasis {
     offset: usize,
     n_levels: usize,
     /// Coefficient column of the term's constant, if it has one.
@@ -38,28 +36,34 @@ struct LevelTransform {
     center: Box<[f64]>,
 }
 
-impl SlopeReparam {
-    /// Orthonormalize every slope-bearing term's loading columns in place;
-    /// `None` for slope-free designs. Unidentified directions become
-    /// exact-zero columns, so the minimal-norm solve leaves exact-`0`
-    /// coefficients.
-    pub(crate) fn build(design: &mut Design<'_>, moments: &TermMoments) -> Option<Self> {
+impl SlopeBasis {
+    pub(crate) fn build(design: &Design<'_>, weights: Option<&[f64]>) -> Self {
+        let mut loadings = vec![Vec::new(); design.frame.n_loading_columns()];
         let mut terms = Vec::new();
         let mut unidentified = Vec::new();
-        for term in 0..design.terms.len() {
-            if !design.terms[term]
-                .columns
-                .iter()
-                .any(|c| c.covariate().is_some())
-            {
-                continue;
+        if let Some(moments) = TermMoments::build(design, weights) {
+            for term in (0..design.terms.len()).filter(|&t| design.terms[t].has_slopes()) {
+                terms.push(TermBasis::build(
+                    design,
+                    term,
+                    &moments,
+                    &mut loadings,
+                    &mut unidentified,
+                ));
             }
-            terms.push(TermReparam::build(design, term, moments, &mut unidentified));
         }
-        (!terms.is_empty()).then_some(Self {
+        // `Design::new` claims every loading column, so whitening leaves none unwritten.
+        debug_assert!(loadings.iter().all(|l| l.len() == design.n_obs));
+        Self {
             terms,
+            loadings,
             unidentified,
-        })
+        }
+    }
+
+    /// Loading column `column` in the solve basis.
+    pub(crate) fn loading_column(&self, column: usize) -> &[f64] {
+        &self.loadings[column]
     }
 
     /// Map solve-basis coefficients back to the user's parametrization.
@@ -70,13 +74,13 @@ impl SlopeReparam {
     }
 }
 
-impl TermReparam {
-    /// Whiten one term's loading columns in place, appending its unidentified
-    /// directions ascending in `(level, column)`.
+impl TermBasis {
+    /// Whiten one term into `loadings`; unidentified directions append ascending in `(level, column)`.
     fn build(
-        design: &mut Design<'_>,
+        design: &Design<'_>,
         term: usize,
         moments: &TermMoments,
+        loadings: &mut [Vec<f64>],
         unidentified: &mut Vec<CoefficientAddress>,
     ) -> Self {
         let meta = &design.terms[term];
@@ -144,7 +148,7 @@ impl TermReparam {
             }
         }
         for (out, &c) in u_cols.into_iter().zip(&z_cols) {
-            design.frame.set_loading_column(c, out);
+            loadings[c] = out;
         }
 
         Self {

--- a/crates/within/src/domain/slope_basis.rs
+++ b/crates/within/src/domain/slope_basis.rs
@@ -56,7 +56,7 @@ impl SlopeBasis {
                 TermBasis::build(design, term, moments, &mut loadings, &mut unidentified)
             })
             .collect();
-        // `Design::new` claims every loading column, so whitening leaves none unwritten.
+        // `Design::build` rejects unclaimed loading columns, so whitening leaves none unwritten.
         debug_assert!(loadings.iter().all(|l| l.len() == design.n_obs));
         Self {
             terms,
@@ -65,7 +65,6 @@ impl SlopeBasis {
         }
     }
 
-    /// Loading column `column` in the solve basis.
     pub(crate) fn loading_column(&self, column: usize) -> &[f64] {
         &self.loadings[column]
     }
@@ -90,12 +89,14 @@ impl TermBasis {
         let meta = &design.terms[term];
         let (offset, n_levels) = (meta.offset, meta.n_levels);
         let intercept_column = meta.columns.iter().position(|l| l.covariate().is_none());
-        let slope_columns: Box<[usize]> = (0..meta.columns.len())
-            .filter(|&c| meta.columns[c].covariate().is_some())
-            .collect();
+        let (slope_columns, z_cols): (Vec<usize>, Vec<usize>) = meta
+            .columns
+            .iter()
+            .enumerate()
+            .filter_map(|(col, l)| l.covariate().map(|&z| (col, z as usize)))
+            .unzip();
         let intercept = intercept_column.is_some();
         let v = slope_columns.len();
-        let z_cols: Vec<usize> = meta.covariates().map(|c| c as usize).collect();
         let levels = design.frame.level_column(term);
         let zs: Vec<&[f64]> = z_cols
             .iter()
@@ -154,7 +155,7 @@ impl TermBasis {
             offset,
             n_levels,
             intercept_column,
-            slope_columns,
+            slope_columns: slope_columns.into(),
             transforms,
         }
     }

--- a/crates/within/src/domain/slope_basis.rs
+++ b/crates/within/src/domain/slope_basis.rs
@@ -1,6 +1,8 @@
 //! Within-level orthonormal basis of a design's varying-slope terms.
 
-use super::level_moments::{BasisScratch, TermMoments};
+use rayon::prelude::*;
+
+use super::level_moments::{BasisScratch, LevelMoments};
 use super::Design;
 use crate::channel::{Channel, CoefficientAddress};
 use crate::linalg::dot;
@@ -39,19 +41,21 @@ struct LevelTransform {
 impl SlopeBasis {
     pub(crate) fn build(design: &Design<'_>, weights: Option<&[f64]>) -> Self {
         let mut loadings = vec![Vec::new(); design.frame.n_loading_columns()];
-        let mut terms = Vec::new();
+        let slope_terms: Vec<usize> = (0..design.terms.len())
+            .filter(|&t| design.terms[t].has_slopes())
+            .collect();
+        let moments: Vec<LevelMoments> = slope_terms
+            .par_iter()
+            .map(|&term| LevelMoments::build(design, term, weights))
+            .collect();
         let mut unidentified = Vec::new();
-        if let Some(moments) = TermMoments::build(design, weights) {
-            for term in (0..design.terms.len()).filter(|&t| design.terms[t].has_slopes()) {
-                terms.push(TermBasis::build(
-                    design,
-                    term,
-                    &moments,
-                    &mut loadings,
-                    &mut unidentified,
-                ));
-            }
-        }
+        let terms = slope_terms
+            .iter()
+            .zip(&moments)
+            .map(|(&term, moments)| {
+                TermBasis::build(design, term, moments, &mut loadings, &mut unidentified)
+            })
+            .collect();
         // `Design::new` claims every loading column, so whitening leaves none unwritten.
         debug_assert!(loadings.iter().all(|l| l.len() == design.n_obs));
         Self {
@@ -75,28 +79,23 @@ impl SlopeBasis {
 }
 
 impl TermBasis {
-    /// Whiten one term into `loadings`; unidentified directions append ascending in `(level, column)`.
+    /// Whitens one term into `loadings`; unidentified directions append in `(level, column)` order.
     fn build(
         design: &Design<'_>,
         term: usize,
-        moments: &TermMoments,
+        moments: &LevelMoments,
         loadings: &mut [Vec<f64>],
         unidentified: &mut Vec<CoefficientAddress>,
     ) -> Self {
         let meta = &design.terms[term];
         let (offset, n_levels) = (meta.offset, meta.n_levels);
-        let mut intercept_column = None;
-        let mut slope_columns = Vec::new();
-        for (column, loading) in meta.columns.iter().enumerate() {
-            match loading.covariate() {
-                Some(_) => slope_columns.push(column),
-                None => intercept_column = Some(column),
-            }
-        }
+        let intercept_column = meta.columns.iter().position(|l| l.covariate().is_none());
+        let slope_columns: Box<[usize]> = (0..meta.columns.len())
+            .filter(|&c| meta.columns[c].covariate().is_some())
+            .collect();
         let intercept = intercept_column.is_some();
-        let moments = &moments[term];
-        let v = moments.n_slopes();
-        let z_cols: Vec<usize> = moments.covariates().iter().map(|&c| c as usize).collect();
+        let v = slope_columns.len();
+        let z_cols: Vec<usize> = meta.covariates().map(|c| c as usize).collect();
         let levels = design.frame.level_column(term);
         let zs: Vec<&[f64]> = z_cols
             .iter()
@@ -155,7 +154,7 @@ impl TermBasis {
             offset,
             n_levels,
             intercept_column,
-            slope_columns: slope_columns.into(),
+            slope_columns,
             transforms,
         }
     }

--- a/crates/within/src/domain/slope_basis/tests.rs
+++ b/crates/within/src/domain/slope_basis/tests.rs
@@ -2,7 +2,6 @@
 //! not reachable through the public API.
 
 use crate::channel::Channel;
-use crate::domain::level_moments::TermMoments;
 use crate::domain::Effect;
 
 use super::*;
@@ -26,10 +25,9 @@ fn three_term_effects() -> Vec<Effect<'static>> {
 
 #[test]
 fn build_whitens_each_slope_bearing_term() {
-    let mut design = Design::new(three_term_effects()).unwrap();
-    let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
-    assert!(rp.unidentified.is_empty());
+    let design = Design::new(three_term_effects()).unwrap();
+    let basis = SlopeBasis::build(&design, None);
+    assert!(basis.unidentified.is_empty());
 
     for term in [0, 2] {
         let meta = &design.terms[term];
@@ -38,7 +36,7 @@ fn build_whitens_each_slope_bearing_term() {
             .columns
             .iter()
             .filter_map(|c| c.covariate())
-            .map(|&k| design.frame.loading_column(k as usize))
+            .map(|&k| basis.loading_column(k as usize))
             .collect();
         for level in 0..meta.n_levels {
             let obs: Vec<usize> = (0..levels.len())
@@ -61,6 +59,15 @@ fn build_whitens_each_slope_bearing_term() {
 }
 
 #[test]
+fn slope_free_design_gets_an_empty_basis() {
+    let design = Design::from_levels_for_test(vec![vec![0, 1, 0], vec![0, 0, 1]]);
+    let basis = SlopeBasis::build(&design, None);
+    assert!(basis.terms.is_empty());
+    assert!(basis.loadings.is_empty());
+    assert!(basis.unidentified.is_empty());
+}
+
+#[test]
 fn unidentified_directions_ascend_across_terms() {
     // Index-order term iteration keeps the list ascending without any sort.
     let f0 = [0u32, 0, 1, 1, 2, 2];
@@ -71,11 +78,10 @@ fn unidentified_directions_ascend_across_terms() {
         Effect::new(&f0, true, [&z0[..]]).unwrap(),
         Effect::new(&f1, true, [&z1[..]]).unwrap(),
     ];
-    let mut design = Design::new(effects).unwrap();
-    let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
+    let design = Design::new(effects).unwrap();
+    let basis = SlopeBasis::build(&design, None);
     assert_eq!(
-        rp.unidentified,
+        basis.unidentified,
         vec![
             CoefficientAddress {
                 channel: Channel { term: 0, column: 1 },
@@ -91,13 +97,12 @@ fn unidentified_directions_ascend_across_terms() {
 
 #[test]
 fn back_transform_leaves_other_terms_untouched() {
-    let mut design = Design::new(three_term_effects()).unwrap();
-    let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&mut design, &moments).unwrap();
+    let design = Design::new(three_term_effects()).unwrap();
+    let basis = SlopeBasis::build(&design, None);
 
     let mut x: Vec<f64> = (0..design.n_dofs).map(|i| 1.0 + i as f64).collect();
     let before = x.clone();
-    rp.back_transform(&mut x);
+    basis.back_transform(&mut x);
 
     // Plain term 1 sits between the two slope-bearing blocks.
     let (t1, t2) = (design.terms[1].offset, design.terms[2].offset);

--- a/crates/within/src/domain/slope_basis/tests.rs
+++ b/crates/within/src/domain/slope_basis/tests.rs
@@ -33,10 +33,8 @@ fn build_whitens_each_slope_bearing_term() {
         let meta = &design.terms[term];
         let levels = design.frame.level_column(term);
         let us: Vec<&[f64]> = meta
-            .columns
-            .iter()
-            .filter_map(|c| c.covariate())
-            .map(|&k| basis.loading_column(k as usize))
+            .covariates()
+            .map(|k| basis.loading_column(k as usize))
             .collect();
         for level in 0..meta.n_levels {
             let obs: Vec<usize> = (0..levels.len())

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -99,6 +99,14 @@ pub enum BuildError {
         /// The offending value.
         value: f64,
     },
+    /// The frame carries continuous columns that no term uses as a slope.
+    #[error("frame has {provided} loading columns but the terms claim {claimed}")]
+    UnclaimedLoadingColumns {
+        /// Loading columns referenced by the terms.
+        claimed: usize,
+        /// Continuous columns in the frame.
+        provided: usize,
+    },
     /// Usually raw entity IDs passed as factor codes, inflating `n_levels = max code + 1`.
     #[error("design has {n_dofs} degrees of freedom, exceeding the u32 column-index limit")]
     DofSpaceExceedsU32 {

--- a/crates/within/src/lib.rs
+++ b/crates/within/src/lib.rs
@@ -37,7 +37,7 @@ pub(crate) mod linalg;
 pub(crate) mod operator;
 pub(crate) mod solver;
 
-pub use channel::{Channel, ChannelPair};
+pub use channel::{Channel, ChannelPair, CoefficientAddress};
 pub use config::{
     ApproxCholConfig, ApproxSchurConfig, LocalSolverConfig, LsmrOptions, PreconditionerConfig,
     ReductionStrategy, ScalingConfig, ScalingFailure, SchurMode,
@@ -46,6 +46,6 @@ pub use domain::{Design, Effect};
 pub use error::{BuildError, BuildWarning, SolveError, WithinError};
 pub use operator::schwarz::Preconditioner;
 pub use solver::{
-    solve, solve_batch, BatchSolveResult, CoefficientAddress, CoefficientLayout, IntoDesign,
-    PreconditionerInput, SolveResult, Solver,
+    solve, solve_batch, BatchSolveResult, CoefficientLayout, IntoDesign, PreconditionerInput,
+    SolveResult, Solver,
 };

--- a/crates/within/src/observation.rs
+++ b/crates/within/src/observation.rs
@@ -59,6 +59,10 @@ impl<'a> ObservationFrame<'a> {
         self.categorical.len()
     }
 
+    pub(crate) fn n_loading_columns(&self) -> usize {
+        self.continuous.len()
+    }
+
     /// Level codes of factor `factor`.
     pub fn level_column(&self, factor: usize) -> &[u32] {
         &self.categorical[factor]
@@ -67,12 +71,6 @@ impl<'a> ObservationFrame<'a> {
     /// Loadings of continuous column `k`.
     pub fn loading_column(&self, k: usize) -> &[f64] {
         &self.continuous[k]
-    }
-
-    /// Replace loading column `i` with an owned column of matching row count.
-    pub(crate) fn set_loading_column(&mut self, i: usize, column: Vec<f64>) {
-        debug_assert_eq!(column.len(), self.n_obs);
-        self.continuous[i] = Cow::Owned(column);
     }
 
     /// Convert every column to owned, dropping ties to caller buffers.

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -22,6 +22,7 @@ const PAR_THRESHOLD: usize = 10_000;
 /// Design operator `D` or `W^{1/2} D`, whose normal equations `AᵀA = DᵀWD` recover the Gramian.
 pub(crate) struct DesignOperator<'a> {
     prepared: &'a PreparedDesign<'a>,
+    sqrt_weights: Option<&'a [f64]>,
     /// Sized once to the largest term's block, so it allocates per operator, not per iteration.
     scatter_scratch: Vec<AtomicF64>,
     /// Debug-only reentry sentinel: a concurrent `apply_adjoint` would race the scratch writes.
@@ -30,11 +31,22 @@ pub(crate) struct DesignOperator<'a> {
 }
 
 impl<'a> DesignOperator<'a> {
-    pub(crate) fn new(prepared: &'a PreparedDesign<'a>) -> Self {
+    /// `sqrt_weights` must be pre-square-rooted and `design.n_obs` long.
+    pub(crate) fn new(prepared: &'a PreparedDesign<'a>, sqrt_weights: Option<&'a [f64]>) -> Self {
         let design = &prepared.design;
+        if let Some(sw) = sqrt_weights {
+            assert_eq!(
+                sw.len(),
+                design.n_obs,
+                "sqrt-weights length {} does not match design.n_obs {}",
+                sw.len(),
+                design.n_obs
+            );
+        }
         let max_block = design.terms.iter().map(|t| t.n_dofs()).max().unwrap_or(0);
         Self {
             prepared,
+            sqrt_weights,
             scatter_scratch: (0..max_block).map(|_| AtomicF64::new(0.0)).collect(),
             #[cfg(debug_assertions)]
             adjoint_active: AtomicBool::new(false),
@@ -43,7 +55,7 @@ impl<'a> DesignOperator<'a> {
 
     /// Observation-space RHS `b = W^{1/2} y`; borrows unweighted, owns weighted.
     pub(crate) fn weighted_rhs<'y>(&self, y: &'y [f64]) -> Cow<'y, [f64]> {
-        match self.prepared.sqrt_weights.as_deref() {
+        match self.sqrt_weights {
             None => Cow::Borrowed(y),
             Some(sw) => Cow::Owned(y.iter().zip(sw).map(|(&yi, &swi)| swi * yi).collect()),
         }
@@ -84,20 +96,20 @@ impl Operator for DesignOperator<'_> {
     }
 
     fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
-        debug_assert_eq!(x.len(), self.ncols());
-        debug_assert_eq!(y.len(), self.nrows());
-        gather_apply(self.prepared, x, y, self.prepared.sqrt_weights.as_deref());
+        debug_assert_eq!(x.len(), self.prepared.design.n_dofs);
+        debug_assert_eq!(y.len(), self.prepared.design.n_obs);
+        gather_apply(self.prepared, x, y, self.sqrt_weights);
         Ok(())
     }
 
     fn apply_adjoint(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
         #[cfg(debug_assertions)]
         let _guard = ReentryGuard::acquire(&self.adjoint_active);
-        debug_assert_eq!(x.len(), self.nrows());
-        debug_assert_eq!(y.len(), self.ncols());
+        debug_assert_eq!(x.len(), self.prepared.design.n_obs);
+        debug_assert_eq!(y.len(), self.prepared.design.n_dofs);
         y.fill(0.0);
         // No lock needed: `solve_batch` builds one operator per RHS, so calls are sequential.
-        match self.prepared.sqrt_weights.as_deref() {
+        match self.sqrt_weights {
             Some(sw) => scatter_apply(self.prepared, &self.scatter_scratch, y, &|i| sw[i] * x[i]),
             None => scatter_apply(self.prepared, &self.scatter_scratch, y, &|i| x[i]),
         }
@@ -118,11 +130,14 @@ mod reentry_guard_tests {
     #[test]
     #[should_panic(expected = "concurrently")]
     fn apply_adjoint_detects_in_flight_reentry() {
-        let prepared = PreparedDesign::from_levels_for_test(vec![vec![0, 1, 0]]);
-        let op = DesignOperator::new(&prepared);
+        let design = PreparedDesign::from_levels_for_test(vec![vec![0, 1, 0]]);
+        let op = DesignOperator::new(&design, None);
         // Simulate a sibling `apply_adjoint` already in flight on this operator.
         op.adjoint_active.store(true, Ordering::Release);
-        op.apply_adjoint(&vec![0.0; op.nrows()], &mut vec![0.0; op.ncols()])
-            .expect("unreachable: the guard panics before returning");
+        op.apply_adjoint(
+            &vec![0.0; op.prepared.design.n_obs],
+            &mut vec![0.0; op.prepared.design.n_dofs],
+        )
+        .expect("unreachable: the guard panics before returning");
     }
 }

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use portable_atomic::AtomicF64;
 use schwarz_precond::Operator;
 
-use crate::domain::Design;
+use crate::domain::PreparedDesign;
 
 mod gather;
 mod scatter;
@@ -21,8 +21,7 @@ const PAR_THRESHOLD: usize = 10_000;
 
 /// Design operator `D` or `W^{1/2} D`, whose normal equations `AᵀA = DᵀWD` recover the Gramian.
 pub(crate) struct DesignOperator<'a> {
-    design: &'a Design<'a>,
-    sqrt_weights: Option<&'a [f64]>,
+    prepared: &'a PreparedDesign<'a>,
     /// Sized once to the largest term's block, so it allocates per operator, not per iteration.
     scatter_scratch: Vec<AtomicF64>,
     /// Debug-only reentry sentinel: a concurrent `apply_adjoint` would race the scratch writes.
@@ -31,21 +30,11 @@ pub(crate) struct DesignOperator<'a> {
 }
 
 impl<'a> DesignOperator<'a> {
-    /// `sqrt_weights` must be pre-square-rooted and `design.n_obs` long.
-    pub(crate) fn new(design: &'a Design<'a>, sqrt_weights: Option<&'a [f64]>) -> Self {
-        if let Some(sw) = sqrt_weights {
-            assert_eq!(
-                sw.len(),
-                design.n_obs,
-                "sqrt-weights length {} does not match design.n_obs {}",
-                sw.len(),
-                design.n_obs
-            );
-        }
+    pub(crate) fn new(prepared: &'a PreparedDesign<'a>) -> Self {
+        let design = &prepared.design;
         let max_block = design.terms.iter().map(|t| t.n_dofs()).max().unwrap_or(0);
         Self {
-            design,
-            sqrt_weights,
+            prepared,
             scatter_scratch: (0..max_block).map(|_| AtomicF64::new(0.0)).collect(),
             #[cfg(debug_assertions)]
             adjoint_active: AtomicBool::new(false),
@@ -54,7 +43,7 @@ impl<'a> DesignOperator<'a> {
 
     /// Observation-space RHS `b = W^{1/2} y`; borrows unweighted, owns weighted.
     pub(crate) fn weighted_rhs<'y>(&self, y: &'y [f64]) -> Cow<'y, [f64]> {
-        match self.sqrt_weights {
+        match self.prepared.sqrt_weights.as_deref() {
             None => Cow::Borrowed(y),
             Some(sw) => Cow::Owned(y.iter().zip(sw).map(|(&yi, &swi)| swi * yi).collect()),
         }
@@ -87,30 +76,30 @@ impl Drop for ReentryGuard<'_> {
 
 impl Operator for DesignOperator<'_> {
     fn nrows(&self) -> usize {
-        self.design.n_obs
+        self.prepared.design.n_obs
     }
 
     fn ncols(&self) -> usize {
-        self.design.n_dofs
+        self.prepared.design.n_dofs
     }
 
     fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
-        debug_assert_eq!(x.len(), self.design.n_dofs);
-        debug_assert_eq!(y.len(), self.design.n_obs);
-        gather_apply(self.design, x, y, self.sqrt_weights);
+        debug_assert_eq!(x.len(), self.ncols());
+        debug_assert_eq!(y.len(), self.nrows());
+        gather_apply(self.prepared, x, y, self.prepared.sqrt_weights.as_deref());
         Ok(())
     }
 
     fn apply_adjoint(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
         #[cfg(debug_assertions)]
         let _guard = ReentryGuard::acquire(&self.adjoint_active);
-        debug_assert_eq!(x.len(), self.design.n_obs);
-        debug_assert_eq!(y.len(), self.design.n_dofs);
+        debug_assert_eq!(x.len(), self.nrows());
+        debug_assert_eq!(y.len(), self.ncols());
         y.fill(0.0);
         // No lock needed: `solve_batch` builds one operator per RHS, so calls are sequential.
-        match self.sqrt_weights {
-            Some(sw) => scatter_apply(self.design, &self.scatter_scratch, y, &|i| sw[i] * x[i]),
-            None => scatter_apply(self.design, &self.scatter_scratch, y, &|i| x[i]),
+        match self.prepared.sqrt_weights.as_deref() {
+            Some(sw) => scatter_apply(self.prepared, &self.scatter_scratch, y, &|i| sw[i] * x[i]),
+            None => scatter_apply(self.prepared, &self.scatter_scratch, y, &|i| x[i]),
         }
         Ok(())
     }
@@ -124,29 +113,16 @@ mod reentry_guard_tests {
     use schwarz_precond::Operator;
 
     use super::DesignOperator;
-    use crate::domain::Design;
-    use crate::observation::ObservationFrame;
-
-    fn one_factor_design() -> Design<'static> {
-        let frame = ObservationFrame::new(
-            vec![vec![0u32, 1, 0]].into_iter().map(Into::into).collect(),
-            Vec::new(),
-        )
-        .expect("valid frame");
-        Design::from_frame(frame).expect("valid design")
-    }
+    use crate::domain::PreparedDesign;
 
     #[test]
     #[should_panic(expected = "concurrently")]
     fn apply_adjoint_detects_in_flight_reentry() {
-        let design = one_factor_design();
-        let op = DesignOperator::new(&design, None);
+        let prepared = PreparedDesign::from_levels_for_test(vec![vec![0, 1, 0]]);
+        let op = DesignOperator::new(&prepared);
         // Simulate a sibling `apply_adjoint` already in flight on this operator.
         op.adjoint_active.store(true, Ordering::Release);
-        op.apply_adjoint(
-            &vec![0.0; op.design.n_obs],
-            &mut vec![0.0; op.design.n_dofs],
-        )
-        .expect("unreachable: the guard panics before returning");
+        op.apply_adjoint(&vec![0.0; op.nrows()], &mut vec![0.0; op.ncols()])
+            .expect("unreachable: the guard panics before returning");
     }
 }

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -22,7 +22,6 @@ const PAR_THRESHOLD: usize = 10_000;
 /// Design operator `D` or `W^{1/2} D`, whose normal equations `AᵀA = DᵀWD` recover the Gramian.
 pub(crate) struct DesignOperator<'a> {
     prepared: &'a PreparedDesign<'a>,
-    sqrt_weights: Option<&'a [f64]>,
     /// Sized once to the largest term's block, so it allocates per operator, not per iteration.
     scatter_scratch: Vec<AtomicF64>,
     /// Debug-only reentry sentinel: a concurrent `apply_adjoint` would race the scratch writes.
@@ -31,22 +30,11 @@ pub(crate) struct DesignOperator<'a> {
 }
 
 impl<'a> DesignOperator<'a> {
-    /// `sqrt_weights` must be pre-square-rooted and `design.n_obs` long.
-    pub(crate) fn new(prepared: &'a PreparedDesign<'a>, sqrt_weights: Option<&'a [f64]>) -> Self {
+    pub(crate) fn new(prepared: &'a PreparedDesign<'a>) -> Self {
         let design = &prepared.design;
-        if let Some(sw) = sqrt_weights {
-            assert_eq!(
-                sw.len(),
-                design.n_obs,
-                "sqrt-weights length {} does not match design.n_obs {}",
-                sw.len(),
-                design.n_obs
-            );
-        }
         let max_block = design.terms.iter().map(|t| t.n_dofs()).max().unwrap_or(0);
         Self {
             prepared,
-            sqrt_weights,
             scatter_scratch: (0..max_block).map(|_| AtomicF64::new(0.0)).collect(),
             #[cfg(debug_assertions)]
             adjoint_active: AtomicBool::new(false),
@@ -55,7 +43,7 @@ impl<'a> DesignOperator<'a> {
 
     /// Observation-space RHS `b = W^{1/2} y`; borrows unweighted, owns weighted.
     pub(crate) fn weighted_rhs<'y>(&self, y: &'y [f64]) -> Cow<'y, [f64]> {
-        match self.sqrt_weights {
+        match self.prepared.sqrt_weights() {
             None => Cow::Borrowed(y),
             Some(sw) => Cow::Owned(y.iter().zip(sw).map(|(&yi, &swi)| swi * yi).collect()),
         }
@@ -98,7 +86,7 @@ impl Operator for DesignOperator<'_> {
     fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
         debug_assert_eq!(x.len(), self.prepared.design.n_dofs);
         debug_assert_eq!(y.len(), self.prepared.design.n_obs);
-        gather_apply(self.prepared, x, y, self.sqrt_weights);
+        gather_apply(self.prepared, x, y, self.prepared.sqrt_weights());
         Ok(())
     }
 
@@ -109,7 +97,7 @@ impl Operator for DesignOperator<'_> {
         debug_assert_eq!(y.len(), self.prepared.design.n_dofs);
         y.fill(0.0);
         // No lock needed: `solve_batch` builds one operator per RHS, so calls are sequential.
-        match self.sqrt_weights {
+        match self.prepared.sqrt_weights() {
             Some(sw) => scatter_apply(self.prepared, &self.scatter_scratch, y, &|i| sw[i] * x[i]),
             None => scatter_apply(self.prepared, &self.scatter_scratch, y, &|i| x[i]),
         }
@@ -131,7 +119,7 @@ mod reentry_guard_tests {
     #[should_panic(expected = "concurrently")]
     fn apply_adjoint_detects_in_flight_reentry() {
         let design = PreparedDesign::from_levels_for_test(vec![vec![0, 1, 0]]);
-        let op = DesignOperator::new(&design, None);
+        let op = DesignOperator::new(&design);
         // Simulate a sibling `apply_adjoint` already in flight on this operator.
         op.adjoint_active.store(true, Ordering::Release);
         op.apply_adjoint(

--- a/crates/within/src/operator/design/gather.rs
+++ b/crates/within/src/operator/design/gather.rs
@@ -20,33 +20,34 @@ pub(crate) fn gather_apply(
 
     dst.fill(0.0);
 
+    let frame = &design.frame;
     for_each_chunk(dst, |chunk, row_start| {
         for (q, t) in design.terms.iter().enumerate() {
             let (offset, n_levels) = (t.offset, t.n_levels);
-            let levels = design.frame.level_column(q);
+            let levels = frame.level_column(q);
             let col = |c: usize| &src[offset + c * n_levels..offset + (c + 1) * n_levels];
             match &*t.columns {
                 [Loading::Constant] => gather_term(chunk, row_start, levels, [col(0)], |_| [1.0]),
                 [Loading::Constant, Loading::Covariate(c0)] => {
-                    let z0 = prepared.basis.loading_column(*c0 as usize);
+                    let z0 = prepared.loading_column(*c0 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1)], |i| [1.0, z0[i]])
                 }
                 [Loading::Constant, Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                    let z0 = prepared.basis.loading_column(*c0 as usize);
-                    let z1 = prepared.basis.loading_column(*c1 as usize);
+                    let z0 = prepared.loading_column(*c0 as usize);
+                    let z1 = prepared.loading_column(*c1 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1), col(2)], |i| {
                         [1.0, z0[i], z1[i]]
                     })
                 }
                 [Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                    let z0 = prepared.basis.loading_column(*c0 as usize);
-                    let z1 = prepared.basis.loading_column(*c1 as usize);
+                    let z0 = prepared.loading_column(*c0 as usize);
+                    let z1 = prepared.loading_column(*c1 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1)], |i| {
                         [z0[i], z1[i]]
                     })
                 }
                 [Loading::Covariate(c0)] => {
-                    let z0 = prepared.basis.loading_column(*c0 as usize);
+                    let z0 = prepared.loading_column(*c0 as usize);
                     gather_term(chunk, row_start, levels, [col(0)], |i| [z0[i]])
                 }
                 columns => {
@@ -60,7 +61,7 @@ pub(crate) fn gather_apply(
                             acc += match loading {
                                 Loading::Constant => coef,
                                 Loading::Covariate(k) => {
-                                    coef * prepared.basis.loading_column(*k as usize)[i]
+                                    coef * prepared.loading_column(*k as usize)[i]
                                 }
                             };
                         }

--- a/crates/within/src/operator/design/gather.rs
+++ b/crates/within/src/operator/design/gather.rs
@@ -3,50 +3,50 @@
 use rayon::prelude::*;
 
 use super::PAR_THRESHOLD;
-use crate::domain::Design;
 use crate::domain::Loading;
+use crate::domain::PreparedDesign;
 
 /// Gather-apply `dst[i] = Σ_t Σ_c src[…] · loading_c(i)`, times `scale[i]` when given.
 pub(crate) fn gather_apply(
-    design: &Design<'_>,
+    prepared: &PreparedDesign<'_>,
     src: &[f64],
     dst: &mut [f64],
     scale: Option<&[f64]>,
 ) {
+    let design = &prepared.design;
     debug_assert!(scale.is_none_or(|s| s.len() == design.n_obs));
     debug_assert_eq!(src.len(), design.n_dofs);
     debug_assert_eq!(dst.len(), design.n_obs);
 
     dst.fill(0.0);
 
-    let frame = &design.frame;
     for_each_chunk(dst, |chunk, row_start| {
         for (q, t) in design.terms.iter().enumerate() {
             let (offset, n_levels) = (t.offset, t.n_levels);
-            let levels = frame.level_column(q);
+            let levels = design.frame.level_column(q);
             let col = |c: usize| &src[offset + c * n_levels..offset + (c + 1) * n_levels];
             match &*t.columns {
                 [Loading::Constant] => gather_term(chunk, row_start, levels, [col(0)], |_| [1.0]),
                 [Loading::Constant, Loading::Covariate(c0)] => {
-                    let z0 = frame.loading_column(*c0 as usize);
+                    let z0 = prepared.basis.loading_column(*c0 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1)], |i| [1.0, z0[i]])
                 }
                 [Loading::Constant, Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                    let z0 = frame.loading_column(*c0 as usize);
-                    let z1 = frame.loading_column(*c1 as usize);
+                    let z0 = prepared.basis.loading_column(*c0 as usize);
+                    let z1 = prepared.basis.loading_column(*c1 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1), col(2)], |i| {
                         [1.0, z0[i], z1[i]]
                     })
                 }
                 [Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                    let z0 = frame.loading_column(*c0 as usize);
-                    let z1 = frame.loading_column(*c1 as usize);
+                    let z0 = prepared.basis.loading_column(*c0 as usize);
+                    let z1 = prepared.basis.loading_column(*c1 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1)], |i| {
                         [z0[i], z1[i]]
                     })
                 }
                 [Loading::Covariate(c0)] => {
-                    let z0 = frame.loading_column(*c0 as usize);
+                    let z0 = prepared.basis.loading_column(*c0 as usize);
                     gather_term(chunk, row_start, levels, [col(0)], |i| [z0[i]])
                 }
                 columns => {
@@ -60,7 +60,7 @@ pub(crate) fn gather_apply(
                             acc += match loading {
                                 Loading::Constant => coef,
                                 Loading::Covariate(k) => {
-                                    coef * frame.loading_column(*k as usize)[i]
+                                    coef * prepared.basis.loading_column(*k as usize)[i]
                                 }
                             };
                         }

--- a/crates/within/src/operator/design/scatter.rs
+++ b/crates/within/src/operator/design/scatter.rs
@@ -8,44 +8,44 @@ use rayon::prelude::*;
 
 use super::PAR_THRESHOLD;
 use crate::domain::Loading;
-use crate::domain::{Design, TermMeta};
+use crate::domain::{PreparedDesign, TermMeta};
 
 /// Adjoint scatter over all terms; `base(i)` is the row value each column scales by its loading.
 pub(super) fn scatter_apply(
-    design: &Design<'_>,
+    prepared: &PreparedDesign<'_>,
     scratch: &[AtomicF64],
     dst: &mut [f64],
     base: &(impl Fn(usize) -> f64 + Sync),
 ) {
+    let design = &prepared.design;
     debug_assert_eq!(dst.len(), design.n_dofs);
     let parallel = design.n_obs > PAR_THRESHOLD;
-    let frame = &design.frame;
 
     for (q, t) in design.terms.iter().enumerate() {
-        let levels = frame.level_column(q);
+        let levels = design.frame.level_column(q);
         let block = &mut dst[t.offset..t.offset + t.n_dofs()];
         match &*t.columns {
             [Loading::Constant] => {
                 scatter_term::<1>(block, t, levels, parallel, scratch, |i| [base(i)])
             }
             [Loading::Constant, Loading::Covariate(c0)] => {
-                let z0 = frame.loading_column(*c0 as usize);
+                let z0 = prepared.basis.loading_column(*c0 as usize);
                 scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [b, z0[i] * b]
                 })
             }
             [Loading::Constant, Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                let z0 = frame.loading_column(*c0 as usize);
-                let z1 = frame.loading_column(*c1 as usize);
+                let z0 = prepared.basis.loading_column(*c0 as usize);
+                let z1 = prepared.basis.loading_column(*c1 as usize);
                 scatter_term::<3>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [b, z0[i] * b, z1[i] * b]
                 })
             }
             [Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                let z0 = frame.loading_column(*c0 as usize);
-                let z1 = frame.loading_column(*c1 as usize);
+                let z0 = prepared.basis.loading_column(*c0 as usize);
+                let z1 = prepared.basis.loading_column(*c1 as usize);
                 scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [z0[i] * b, z1[i] * b]
@@ -60,7 +60,7 @@ pub(super) fn scatter_apply(
                             scatter_term::<1>(slot, t, levels, parallel, scratch, |i| [base(i)]);
                         }
                         Loading::Covariate(k) => {
-                            let z = frame.loading_column(*k as usize);
+                            let z = prepared.basis.loading_column(*k as usize);
                             scatter_term::<1>(slot, t, levels, parallel, scratch, move |i| {
                                 [z[i] * base(i)]
                             });

--- a/crates/within/src/operator/design/scatter.rs
+++ b/crates/within/src/operator/design/scatter.rs
@@ -20,32 +20,33 @@ pub(super) fn scatter_apply(
     let design = &prepared.design;
     debug_assert_eq!(dst.len(), design.n_dofs);
     let parallel = design.n_obs > PAR_THRESHOLD;
+    let frame = &design.frame;
 
     for (q, t) in design.terms.iter().enumerate() {
-        let levels = design.frame.level_column(q);
+        let levels = frame.level_column(q);
         let block = &mut dst[t.offset..t.offset + t.n_dofs()];
         match &*t.columns {
             [Loading::Constant] => {
                 scatter_term::<1>(block, t, levels, parallel, scratch, |i| [base(i)])
             }
             [Loading::Constant, Loading::Covariate(c0)] => {
-                let z0 = prepared.basis.loading_column(*c0 as usize);
+                let z0 = prepared.loading_column(*c0 as usize);
                 scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [b, z0[i] * b]
                 })
             }
             [Loading::Constant, Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                let z0 = prepared.basis.loading_column(*c0 as usize);
-                let z1 = prepared.basis.loading_column(*c1 as usize);
+                let z0 = prepared.loading_column(*c0 as usize);
+                let z1 = prepared.loading_column(*c1 as usize);
                 scatter_term::<3>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [b, z0[i] * b, z1[i] * b]
                 })
             }
             [Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                let z0 = prepared.basis.loading_column(*c0 as usize);
-                let z1 = prepared.basis.loading_column(*c1 as usize);
+                let z0 = prepared.loading_column(*c0 as usize);
+                let z1 = prepared.loading_column(*c1 as usize);
                 scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [z0[i] * b, z1[i] * b]
@@ -60,7 +61,7 @@ pub(super) fn scatter_apply(
                             scatter_term::<1>(slot, t, levels, parallel, scratch, |i| [base(i)]);
                         }
                         Loading::Covariate(k) => {
-                            let z = prepared.basis.loading_column(*k as usize);
+                            let z = prepared.loading_column(*k as usize);
                             scatter_term::<1>(slot, t, levels, parallel, scratch, move |i| {
                                 [z[i] * base(i)]
                             });

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -13,7 +13,7 @@ mod design_tests {
     #[test]
     fn test_design_operator_dimensions() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema);
+        let op = DesignOperator::new(&schema, None);
         assert_eq!(op.nrows(), 5);
         assert_eq!(op.ncols(), 7);
     }
@@ -21,7 +21,7 @@ mod design_tests {
     #[test]
     fn test_design_operator_adjoint() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema);
+        let op = DesignOperator::new(&schema, None);
 
         let x = vec![1.0, -0.5, 2.0, 0.3, -1.0, 0.7, 1.5];
         let r = vec![0.1, 0.2, -0.3, 0.4, -0.5];
@@ -40,7 +40,7 @@ mod design_tests {
     #[test]
     fn test_apply_unweighted_values() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema);
+        let op = DesignOperator::new(&schema, None);
         let x = vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 40.0];
         let mut y = vec![0.0; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
@@ -50,7 +50,7 @@ mod design_tests {
     #[test]
     fn test_apply_adjoint_unweighted_values() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema);
+        let op = DesignOperator::new(&schema, None);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0; 7];
         op.apply_adjoint(&r, &mut x)
@@ -79,7 +79,7 @@ mod design_tests {
         let dm = make_large_design();
         let n_dofs = dm.design.n_dofs;
         let n_rows = dm.design.n_obs;
-        let op = DesignOperator::new(&dm);
+        let op = DesignOperator::new(&dm, None);
 
         let x: Vec<f64> = (0..n_dofs).map(|i| (i as f64 * 0.17 + 1.0).sin()).collect();
         let r: Vec<f64> = (0..n_rows).map(|i| (i as f64 * 0.23 + 2.0).cos()).collect();
@@ -117,7 +117,7 @@ mod design_tests {
             "dominant factor is sorted; no perm"
         );
 
-        let op = DesignOperator::new(&dm);
+        let op = DesignOperator::new(&dm, None);
         let x: Vec<f64> = (0..dm.design.n_dofs)
             .map(|i| (i as f64 * 0.17 + 1.0).sin())
             .collect();
@@ -144,7 +144,7 @@ mod design_tests {
     #[test]
     fn test_large_design_matvec_correctness() {
         let dm = make_large_design();
-        let op = DesignOperator::new(&dm);
+        let op = DesignOperator::new(&dm, None);
 
         let mut ej = vec![0.0f64; dm.design.n_dofs];
         ej[0] = 1.0;
@@ -163,7 +163,7 @@ mod design_tests {
     #[test]
     fn test_large_design_apply_adjoint_correctness() {
         let dm = make_large_design();
-        let op = DesignOperator::new(&dm);
+        let op = DesignOperator::new(&dm, None);
 
         let ones = vec![1.0f64; dm.design.n_obs];
         let mut x = vec![0.0f64; dm.design.n_dofs];
@@ -182,7 +182,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_design_adjoint_property() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm);
+        let op = DesignOperator::new(&dm, None);
 
         let x: Vec<f64> = vec![1.0, 2.0, 3.0];
         let r: Vec<f64> = vec![0.5, 1.5, -0.5, 2.0, -1.0];
@@ -206,7 +206,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_values() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm);
+        let op = DesignOperator::new(&dm, None);
         let x = vec![10.0, 20.0, 30.0];
         let mut y = vec![0.0f64; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
@@ -216,7 +216,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_adjoint_values() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm);
+        let op = DesignOperator::new(&dm, None);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0f64; 3];
         op.apply_adjoint(&r, &mut x)
@@ -280,14 +280,14 @@ mod design_tests {
             .collect();
 
         // Baseline: a fresh operator that has never applied before.
-        let fresh = DesignOperator::new(dm);
+        let fresh = DesignOperator::new(dm, None);
         let mut baseline = vec![0.0f64; dm.design.n_dofs];
         fresh
             .apply_adjoint(&r, &mut baseline)
             .expect("apply_adjoint succeeds");
 
         // The second apply on a dirtied operator must equal the fresh baseline.
-        let op = DesignOperator::new(dm);
+        let op = DesignOperator::new(dm, None);
         let mut warmup = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&r, &mut warmup)
             .expect("apply_adjoint succeeds");
@@ -312,7 +312,9 @@ mod slope_design_tests {
         (z >> 11) as f64 / (1u64 << 52) as f64 - 1.0
     }
 
-    /// Dense design matrix in the solve basis and internal row order, the operator's reference.
+    /// Dense design matrix from the design's internal (post-sort) columns —
+    /// the reference the operator must agree with regardless of the locality
+    /// permutation.
     fn dense_matrix(prepared: &PreparedDesign<'_>) -> Vec<Vec<f64>> {
         let design = &prepared.design;
         let mut d = vec![vec![0.0; design.n_dofs]; design.n_obs];
@@ -323,7 +325,7 @@ mod slope_design_tests {
                 for (i, &lev) in levels.iter().enumerate() {
                     d[i][base + lev as usize] = match loading {
                         Loading::Constant => 1.0,
-                        Loading::Covariate(k) => prepared.basis.loading_column(*k as usize)[i],
+                        Loading::Covariate(k) => prepared.loading_column(*k as usize)[i],
                     };
                 }
             }
@@ -360,18 +362,18 @@ mod slope_design_tests {
             Effect::new(&f3, true, []).unwrap(),
             Effect::new(&f4, true, [&zs[5][..], &zs[4][..]]).unwrap(),
         ];
-        let prepared = PreparedDesign::unweighted_for_test(Design::new(effects).unwrap());
-        let dense = dense_matrix(&prepared);
+        let design = PreparedDesign::unweighted_for_test(Design::new(effects).unwrap());
+        let dense = dense_matrix(&design);
         assert!(
-            (0..prepared.design.n_dofs).all(|j| dense.iter().any(|row| row[j] != 0.0)),
+            (0..design.design.n_dofs).all(|j| dense.iter().any(|row| row[j] != 0.0)),
             "whitening zeroed a column; the arm's addressing would go untested"
         );
-        let op = DesignOperator::new(&prepared);
+        let op = DesignOperator::new(&design, None);
 
-        let x: Vec<f64> = (0..prepared.design.n_dofs)
+        let x: Vec<f64> = (0..design.design.n_dofs)
             .map(|j| noise(7_000 + j))
             .collect();
-        let mut got = vec![0.0; prepared.design.n_obs];
+        let mut got = vec![0.0; design.design.n_obs];
         op.apply(&x, &mut got).unwrap();
         let expect: Vec<f64> = dense
             .iter()
@@ -379,12 +381,10 @@ mod slope_design_tests {
             .collect();
         assert_close(&got, &expect);
 
-        let r: Vec<f64> = (0..prepared.design.n_obs)
-            .map(|i| noise(9_000 + i))
-            .collect();
-        let mut got_t = vec![0.0; prepared.design.n_dofs];
+        let r: Vec<f64> = (0..design.design.n_obs).map(|i| noise(9_000 + i)).collect();
+        let mut got_t = vec![0.0; design.design.n_dofs];
         op.apply_adjoint(&r, &mut got_t).unwrap();
-        let mut expect_t = vec![0.0; prepared.design.n_dofs];
+        let mut expect_t = vec![0.0; design.design.n_dofs];
         for (row, &ri) in dense.iter().zip(&r) {
             for (e, d) in expect_t.iter_mut().zip(row) {
                 *e += d * ri;
@@ -413,18 +413,18 @@ mod slope_design_tests {
             Effect::new(&unsorted, true, [&z[1][..]]).unwrap(),
             Effect::new(&small, true, [&z[2][..], &z[3][..]]).unwrap(),
         ];
-        let weights: Vec<f64> = (0..n).map(|i| 0.5 + noise(i).abs()).collect();
-        let prepared = PreparedDesign::new(Design::new(effects).unwrap(), Some(&weights)).unwrap();
-        let op = DesignOperator::new(&prepared);
+        let design = PreparedDesign::unweighted_for_test(Design::new(effects).unwrap());
+        let sqrt_weights: Vec<f64> = (0..n).map(|i| (0.5 + noise(i).abs()).sqrt()).collect();
+        let op = DesignOperator::new(&design, Some(&sqrt_weights));
 
-        let x: Vec<f64> = (0..prepared.design.n_dofs)
+        let x: Vec<f64> = (0..design.design.n_dofs)
             .map(|j| noise(13 * j + 1))
             .collect();
         let r: Vec<f64> = (0..n).map(|i| noise(29 * i + 5)).collect();
 
         let mut dx = vec![0.0; n];
         op.apply(&x, &mut dx).unwrap();
-        let mut dtr = vec![0.0; prepared.design.n_dofs];
+        let mut dtr = vec![0.0; design.design.n_dofs];
         op.apply_adjoint(&r, &mut dtr).unwrap();
 
         let lhs: f64 = dx.iter().zip(&r).map(|(a, b)| a * b).sum();
@@ -467,9 +467,6 @@ mod weighted_adjoint_proptests {
                 .collect();
 
             let dm = PreparedDesign::from_levels_for_test(vec![fa, fb]);
-            let dm_weighted = PreparedDesign::new(dm.design.clone(), Some(&weights)).unwrap();
-            // Internal row order, like `dx` and `r` below.
-            let sqrt_weights = dm_weighted.sqrt_weights.as_deref().unwrap();
 
             let n_dofs = dm.design.n_dofs;
             let n_rows = dm.design.n_obs;
@@ -481,17 +478,18 @@ mod weighted_adjoint_proptests {
                 .map(|i| (i as f64 * 0.29 + seed as f64 * 0.07).cos())
                 .collect();
 
-            let op_unweighted = DesignOperator::new(&dm);
+            let op_unweighted = DesignOperator::new(&dm, None);
             let mut dx = vec![0.0f64; n_rows];
             op_unweighted.apply(&x, &mut dx).unwrap();
             let lhs: f64 = dx
                 .iter()
                 .zip(r.iter())
                 .enumerate()
-                .map(|(i, (dxi, ri))| sqrt_weights[i] * sqrt_weights[i] * dxi * ri)
+                .map(|(i, (dxi, ri))| weights[i] * dxi * ri)
                 .sum();
 
-            let op_weighted = DesignOperator::new(&dm_weighted);
+            let sqrt_weights: Vec<f64> = weights.iter().map(|w| w.sqrt()).collect();
+            let op_weighted = DesignOperator::new(&dm, Some(&sqrt_weights));
             let wr = op_weighted.weighted_rhs(&r);
             let mut wdtr = vec![0.0f64; n_dofs];
             op_weighted.apply_adjoint(&wr, &mut wdtr).unwrap();

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -13,7 +13,7 @@ mod design_tests {
     #[test]
     fn test_design_operator_dimensions() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
         assert_eq!(op.nrows(), 5);
         assert_eq!(op.ncols(), 7);
     }
@@ -21,7 +21,7 @@ mod design_tests {
     #[test]
     fn test_design_operator_adjoint() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
 
         let x = vec![1.0, -0.5, 2.0, 0.3, -1.0, 0.7, 1.5];
         let r = vec![0.1, 0.2, -0.3, 0.4, -0.5];
@@ -40,7 +40,7 @@ mod design_tests {
     #[test]
     fn test_apply_unweighted_values() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
         let x = vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 40.0];
         let mut y = vec![0.0; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
@@ -50,7 +50,7 @@ mod design_tests {
     #[test]
     fn test_apply_adjoint_unweighted_values() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0; 7];
         op.apply_adjoint(&r, &mut x)
@@ -79,7 +79,7 @@ mod design_tests {
         let dm = make_large_design();
         let n_dofs = dm.design.n_dofs;
         let n_rows = dm.design.n_obs;
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
         let x: Vec<f64> = (0..n_dofs).map(|i| (i as f64 * 0.17 + 1.0).sin()).collect();
         let r: Vec<f64> = (0..n_rows).map(|i| (i as f64 * 0.23 + 2.0).cos()).collect();
@@ -117,7 +117,7 @@ mod design_tests {
             "dominant factor is sorted; no perm"
         );
 
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
         let x: Vec<f64> = (0..dm.design.n_dofs)
             .map(|i| (i as f64 * 0.17 + 1.0).sin())
             .collect();
@@ -144,7 +144,7 @@ mod design_tests {
     #[test]
     fn test_large_design_matvec_correctness() {
         let dm = make_large_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
         let mut ej = vec![0.0f64; dm.design.n_dofs];
         ej[0] = 1.0;
@@ -163,7 +163,7 @@ mod design_tests {
     #[test]
     fn test_large_design_apply_adjoint_correctness() {
         let dm = make_large_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
         let ones = vec![1.0f64; dm.design.n_obs];
         let mut x = vec![0.0f64; dm.design.n_dofs];
@@ -182,7 +182,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_design_adjoint_property() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
         let x: Vec<f64> = vec![1.0, 2.0, 3.0];
         let r: Vec<f64> = vec![0.5, 1.5, -0.5, 2.0, -1.0];
@@ -206,7 +206,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_values() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
         let x = vec![10.0, 20.0, 30.0];
         let mut y = vec![0.0f64; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
@@ -216,7 +216,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_adjoint_values() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0f64; 3];
         op.apply_adjoint(&r, &mut x)
@@ -280,14 +280,14 @@ mod design_tests {
             .collect();
 
         // Baseline: a fresh operator that has never applied before.
-        let fresh = DesignOperator::new(dm, None);
+        let fresh = DesignOperator::new(dm);
         let mut baseline = vec![0.0f64; dm.design.n_dofs];
         fresh
             .apply_adjoint(&r, &mut baseline)
             .expect("apply_adjoint succeeds");
 
         // The second apply on a dirtied operator must equal the fresh baseline.
-        let op = DesignOperator::new(dm, None);
+        let op = DesignOperator::new(dm);
         let mut warmup = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&r, &mut warmup)
             .expect("apply_adjoint succeeds");
@@ -368,7 +368,7 @@ mod slope_design_tests {
             (0..design.design.n_dofs).all(|j| dense.iter().any(|row| row[j] != 0.0)),
             "whitening zeroed a column; the arm's addressing would go untested"
         );
-        let op = DesignOperator::new(&design, None);
+        let op = DesignOperator::new(&design);
 
         let x: Vec<f64> = (0..design.design.n_dofs)
             .map(|j| noise(7_000 + j))
@@ -413,9 +413,9 @@ mod slope_design_tests {
             Effect::new(&unsorted, true, [&z[1][..]]).unwrap(),
             Effect::new(&small, true, [&z[2][..], &z[3][..]]).unwrap(),
         ];
-        let design = PreparedDesign::unweighted_for_test(Design::new(effects).unwrap());
-        let sqrt_weights: Vec<f64> = (0..n).map(|i| (0.5 + noise(i).abs()).sqrt()).collect();
-        let op = DesignOperator::new(&design, Some(&sqrt_weights));
+        let weights: Vec<f64> = (0..n).map(|i| 0.5 + noise(i).abs()).collect();
+        let design = PreparedDesign::new(Design::new(effects).unwrap(), Some(&weights)).unwrap();
+        let op = DesignOperator::new(&design);
 
         let x: Vec<f64> = (0..design.design.n_dofs)
             .map(|j| noise(13 * j + 1))
@@ -445,9 +445,8 @@ mod weighted_adjoint_proptests {
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(10))]
 
-        /// The adjoint property must hold for random weighted designs:
-        /// <D·x, W·r> == <x, D^T·W·r>, with D^T·W·r computed via
-        /// DesignOperator::apply_adjoint(W^{1/2} r) = D^T W^{1/2} (W^{1/2} r) = D^T W r.
+        /// The weighted normal-equation identity must hold for random designs:
+        /// <W^{1/2}D·x, W^{1/2}r> == <x, D^T W·r>.
         #[test]
         fn prop_weighted_adjoint_property(
             n_obs in 20usize..=200,
@@ -466,7 +465,8 @@ mod weighted_adjoint_proptests {
                 .map(|i| 0.5 + (i as f64 * 0.13 + seed as f64 * 0.41).sin().abs())
                 .collect();
 
-            let dm = PreparedDesign::from_levels_for_test(vec![fa, fb]);
+            let design = crate::domain::Design::from_levels_for_test(vec![fa, fb]);
+            let dm = PreparedDesign::new(design, Some(&weights)).unwrap();
 
             let n_dofs = dm.design.n_dofs;
             let n_rows = dm.design.n_obs;
@@ -478,26 +478,19 @@ mod weighted_adjoint_proptests {
                 .map(|i| (i as f64 * 0.29 + seed as f64 * 0.07).cos())
                 .collect();
 
-            let op_unweighted = DesignOperator::new(&dm, None);
+            let op = DesignOperator::new(&dm);
             let mut dx = vec![0.0f64; n_rows];
-            op_unweighted.apply(&x, &mut dx).unwrap();
-            let lhs: f64 = dx
-                .iter()
-                .zip(r.iter())
-                .enumerate()
-                .map(|(i, (dxi, ri))| weights[i] * dxi * ri)
-                .sum();
+            op.apply(&x, &mut dx).unwrap();
+            let weighted_r = op.weighted_rhs(&r);
+            let lhs: f64 = dx.iter().zip(&*weighted_r).map(|(dxi, ri)| dxi * ri).sum();
 
-            let sqrt_weights: Vec<f64> = weights.iter().map(|w| w.sqrt()).collect();
-            let op_weighted = DesignOperator::new(&dm, Some(&sqrt_weights));
-            let wr = op_weighted.weighted_rhs(&r);
             let mut wdtr = vec![0.0f64; n_dofs];
-            op_weighted.apply_adjoint(&wr, &mut wdtr).unwrap();
+            op.apply_adjoint(&weighted_r, &mut wdtr).unwrap();
             let rhs: f64 = x.iter().zip(wdtr.iter()).map(|(xi, wi)| xi * wi).sum();
 
             prop_assert!(
                 (lhs - rhs).abs() < 1e-8,
-                "<D·x, W·r>={lhs} != <x, D^T·W·r>={rhs}"
+                "<W^1/2 D·x, W^1/2 r>={lhs} != <x, D^T W·r>={rhs}"
             );
         }
     }

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -1,19 +1,19 @@
 mod design_tests {
-    use crate::domain::Design;
+    use crate::domain::PreparedDesign;
     use crate::linalg::dot;
     use crate::operator::DesignOperator;
     use rstest::rstest;
     use schwarz_precond::Operator;
 
-    fn make_test_design() -> Design<'static> {
+    fn make_test_design() -> PreparedDesign<'static> {
         // Sorted on the dominant factor, so construction applies no locality permutation.
-        Design::from_levels_for_test(vec![vec![0, 1, 1, 2, 0], vec![0, 0, 1, 2, 3]])
+        PreparedDesign::from_levels_for_test(vec![vec![0, 1, 1, 2, 0], vec![0, 0, 1, 2, 3]])
     }
 
     #[test]
     fn test_design_operator_dimensions() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
         assert_eq!(op.nrows(), 5);
         assert_eq!(op.ncols(), 7);
     }
@@ -21,7 +21,7 @@ mod design_tests {
     #[test]
     fn test_design_operator_adjoint() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
 
         let x = vec![1.0, -0.5, 2.0, 0.3, -1.0, 0.7, 1.5];
         let r = vec![0.1, 0.2, -0.3, 0.4, -0.5];
@@ -40,7 +40,7 @@ mod design_tests {
     #[test]
     fn test_apply_unweighted_values() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
         let x = vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 40.0];
         let mut y = vec![0.0; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
@@ -50,7 +50,7 @@ mod design_tests {
     #[test]
     fn test_apply_adjoint_unweighted_values() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0; 7];
         op.apply_adjoint(&r, &mut x)
@@ -58,18 +58,18 @@ mod design_tests {
         assert_eq!(x, vec![6.0, 5.0, 4.0, 3.0, 3.0, 4.0, 5.0]);
     }
 
-    fn make_single_factor_design() -> Design<'static> {
+    fn make_single_factor_design() -> PreparedDesign<'static> {
         // Sorted: a single-factor store is always dominated by its only factor.
-        Design::from_levels_for_test(vec![vec![0u32, 0, 1, 1, 2]])
+        PreparedDesign::from_levels_for_test(vec![vec![0u32, 0, 1, 1, 2]])
     }
 
-    fn make_large_design() -> Design<'static> {
+    fn make_large_design() -> PreparedDesign<'static> {
         // Sorted on both factors, so there is no construction-time permutation.
         let n_obs = 15_000;
         let block = 300u32;
         let fa: Vec<u32> = (0..n_obs).map(|i| i as u32 / block).collect();
         let fb = fa.clone();
-        Design::from_levels_for_test(vec![fa, fb])
+        PreparedDesign::from_levels_for_test(vec![fa, fb])
     }
 
     /// Verify <D·x, r> == <x, D^T·r> on a large design exercising the parallel
@@ -77,9 +77,9 @@ mod design_tests {
     #[test]
     fn test_large_design_adjoint_property() {
         let dm = make_large_design();
-        let n_dofs = dm.n_dofs;
-        let n_rows = dm.n_obs;
-        let op = DesignOperator::new(&dm, None);
+        let n_dofs = dm.design.n_dofs;
+        let n_rows = dm.design.n_obs;
+        let op = DesignOperator::new(&dm);
 
         let x: Vec<f64> = (0..n_dofs).map(|i| (i as f64 * 0.17 + 1.0).sin()).collect();
         let r: Vec<f64> = (0..n_rows).map(|i| (i as f64 * 0.23 + 2.0).cos()).collect();
@@ -111,20 +111,23 @@ mod design_tests {
         let n_obs = 15_000;
         let fa: Vec<u32> = (0..n_obs as u32).collect();
         let fb: Vec<u32> = (0..n_obs).map(|i| (i % 50) as u32).collect();
-        let dm = Design::from_levels_for_test(vec![fa, fb]);
-        assert!(dm.obs_perm.is_none(), "dominant factor is sorted; no perm");
+        let dm = PreparedDesign::from_levels_for_test(vec![fa, fb]);
+        assert!(
+            dm.design.obs_perm.is_none(),
+            "dominant factor is sorted; no perm"
+        );
 
-        let op = DesignOperator::new(&dm, None);
-        let x: Vec<f64> = (0..dm.n_dofs)
+        let op = DesignOperator::new(&dm);
+        let x: Vec<f64> = (0..dm.design.n_dofs)
             .map(|i| (i as f64 * 0.17 + 1.0).sin())
             .collect();
-        let r: Vec<f64> = (0..dm.n_obs)
+        let r: Vec<f64> = (0..dm.design.n_obs)
             .map(|i| (i as f64 * 0.23 + 2.0).cos())
             .collect();
 
-        let mut dx = vec![0.0f64; dm.n_obs];
+        let mut dx = vec![0.0f64; dm.design.n_obs];
         op.apply(&x, &mut dx).expect("apply succeeds");
-        let mut dtr = vec![0.0f64; dm.n_dofs];
+        let mut dtr = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&r, &mut dtr)
             .expect("apply_adjoint succeeds");
 
@@ -141,11 +144,11 @@ mod design_tests {
     #[test]
     fn test_large_design_matvec_correctness() {
         let dm = make_large_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
-        let mut ej = vec![0.0f64; dm.n_dofs];
+        let mut ej = vec![0.0f64; dm.design.n_dofs];
         ej[0] = 1.0;
-        let mut y = vec![0.0f64; dm.n_obs];
+        let mut y = vec![0.0f64; dm.design.n_obs];
         op.apply(&ej, &mut y).expect("apply succeeds");
 
         for (i, &yi) in y.iter().enumerate() {
@@ -160,14 +163,14 @@ mod design_tests {
     #[test]
     fn test_large_design_apply_adjoint_correctness() {
         let dm = make_large_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
-        let ones = vec![1.0f64; dm.n_obs];
-        let mut x = vec![0.0f64; dm.n_dofs];
+        let ones = vec![1.0f64; dm.design.n_obs];
+        let mut x = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&ones, &mut x)
             .expect("apply_adjoint succeeds");
 
-        let expected_count = (dm.n_obs / 50) as f64;
+        let expected_count = (dm.design.n_obs / 50) as f64;
         for (j, &xj) in x.iter().enumerate() {
             assert!(
                 (xj - expected_count).abs() < 1e-10,
@@ -179,15 +182,15 @@ mod design_tests {
     #[test]
     fn test_single_factor_design_adjoint_property() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
         let x: Vec<f64> = vec![1.0, 2.0, 3.0];
         let r: Vec<f64> = vec![0.5, 1.5, -0.5, 2.0, -1.0];
 
-        let mut dx = vec![0.0f64; dm.n_obs];
+        let mut dx = vec![0.0f64; dm.design.n_obs];
         op.apply(&x, &mut dx).expect("apply succeeds");
 
-        let mut dtr = vec![0.0f64; dm.n_dofs];
+        let mut dtr = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&r, &mut dtr)
             .expect("apply_adjoint succeeds");
 
@@ -203,7 +206,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_values() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
         let x = vec![10.0, 20.0, 30.0];
         let mut y = vec![0.0f64; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
@@ -213,7 +216,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_adjoint_values() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0f64; 3];
         op.apply_adjoint(&r, &mut x)
@@ -224,9 +227,9 @@ mod design_tests {
     /// Single-factor design with `level(i) = i % n_levels`; when
     /// `n_obs >= n_levels` every level is populated so the inferred level count
     /// is exactly `n_levels` (which selects the scatter strategy).
-    fn make_strategy_design(n_obs: usize, n_levels: usize) -> Design<'static> {
+    fn make_strategy_design(n_obs: usize, n_levels: usize) -> PreparedDesign<'static> {
         let f: Vec<u32> = (0..n_obs).map(|i| (i % n_levels) as u32).collect();
-        Design::from_levels_for_test(vec![f])
+        PreparedDesign::from_levels_for_test(vec![f])
     }
 
     fn assert_all_close(actual: &[f64], expected: &[f64], ctx: &str) {
@@ -259,8 +262,11 @@ mod design_tests {
         let n_obs = 150_000usize;
         let fa: Vec<u32> = (0..n_obs as u32).collect();
         let fb: Vec<u32> = (0..n_obs).map(|i| ((i * 7919) % 100_000) as u32).collect();
-        let dm = Design::from_levels_for_test(vec![fa, fb]);
-        assert!(dm.obs_perm.is_none(), "dominant factor is sorted; no perm");
+        let dm = PreparedDesign::from_levels_for_test(vec![fa, fb]);
+        assert!(
+            dm.design.obs_perm.is_none(),
+            "dominant factor is sorted; no perm"
+        );
         assert_scratch_reuse_matches_fresh(&dm, "atomic: non-dominant unsorted 100K levels");
     }
 
@@ -268,24 +274,24 @@ mod design_tests {
     /// calls (cf. the removed `SCATTER_FOLD_POOL` leak): a second call on the
     /// *same* operator must match a freshly built operator — stale values from
     /// the first call must not bleed into the second.
-    fn assert_scratch_reuse_matches_fresh(dm: &Design<'_>, ctx: &str) {
-        let r: Vec<f64> = (0..dm.n_obs)
+    fn assert_scratch_reuse_matches_fresh(dm: &PreparedDesign<'_>, ctx: &str) {
+        let r: Vec<f64> = (0..dm.design.n_obs)
             .map(|i| (i as f64 * 0.37 + 1.0).sin())
             .collect();
 
         // Baseline: a fresh operator that has never applied before.
-        let fresh = DesignOperator::new(dm, None);
-        let mut baseline = vec![0.0f64; dm.n_dofs];
+        let fresh = DesignOperator::new(dm);
+        let mut baseline = vec![0.0f64; dm.design.n_dofs];
         fresh
             .apply_adjoint(&r, &mut baseline)
             .expect("apply_adjoint succeeds");
 
         // The second apply on a dirtied operator must equal the fresh baseline.
-        let op = DesignOperator::new(dm, None);
-        let mut warmup = vec![0.0f64; dm.n_dofs];
+        let op = DesignOperator::new(dm);
+        let mut warmup = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&r, &mut warmup)
             .expect("apply_adjoint succeeds");
-        let mut reused = vec![0.0f64; dm.n_dofs];
+        let mut reused = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&r, &mut reused)
             .expect("apply_adjoint succeeds");
 
@@ -294,7 +300,7 @@ mod design_tests {
 }
 
 mod slope_design_tests {
-    use crate::domain::{Design, Effect, Loading};
+    use crate::domain::{Design, Effect, Loading, PreparedDesign};
     use crate::operator::DesignOperator;
     use schwarz_precond::Operator;
 
@@ -306,10 +312,9 @@ mod slope_design_tests {
         (z >> 11) as f64 / (1u64 << 52) as f64 - 1.0
     }
 
-    /// Dense design matrix from the design's internal (post-sort) columns —
-    /// the reference the operator must agree with regardless of the locality
-    /// permutation.
-    fn dense_matrix(design: &Design<'_>) -> Vec<Vec<f64>> {
+    /// Dense design matrix in the solve basis and internal row order, the operator's reference.
+    fn dense_matrix(prepared: &PreparedDesign<'_>) -> Vec<Vec<f64>> {
+        let design = &prepared.design;
         let mut d = vec![vec![0.0; design.n_dofs]; design.n_obs];
         for (q, t) in design.terms.iter().enumerate() {
             let levels = design.frame.level_column(q);
@@ -318,7 +323,7 @@ mod slope_design_tests {
                 for (i, &lev) in levels.iter().enumerate() {
                     d[i][base + lev as usize] = match loading {
                         Loading::Constant => 1.0,
-                        Loading::Covariate(k) => design.frame.loading_column(*k as usize)[i],
+                        Loading::Covariate(k) => prepared.basis.loading_column(*k as usize)[i],
                     };
                 }
             }
@@ -337,14 +342,15 @@ mod slope_design_tests {
 
     /// Covers every kernel arm on the sequential path: plain, fused V=1/V=2,
     /// slope-only, and the generic V=3 fallback — against the dense reference.
+    /// Four rows per level keep every whitened column nonzero, so each arm's addressing counts.
     #[test]
     fn slope_matvec_and_adjoint_match_dense_reference() {
-        let n = 6;
-        let f0 = [0u32, 1, 2, 0, 1, 2];
-        let f1 = [0u32, 0, 1, 1, 2, 2];
-        let f2 = [0u32, 1, 0, 1, 0, 1];
-        let f3 = [0u32, 0, 0, 1, 1, 1];
-        let f4 = [1u32, 0, 2, 1, 0, 2];
+        let n = 12;
+        let f0: Vec<u32> = (0..n).map(|i| (i % 3) as u32).collect();
+        let f1: Vec<u32> = (0..n).map(|i| ((i / 2) % 3) as u32).collect();
+        let f2: Vec<u32> = (0..n).map(|i| (i % 2) as u32).collect();
+        let f3: Vec<u32> = (0..n).map(|i| (i / 6) as u32).collect();
+        let f4: Vec<u32> = (0..n).map(|i| [1u32, 0, 2, 1, 0, 2][i % 6]).collect();
         let zs: Vec<Vec<f64>> = (0..6)
             .map(|k| (0..n).map(|i| noise(k * 100 + i)).collect())
             .collect();
@@ -355,12 +361,18 @@ mod slope_design_tests {
             Effect::new(&f3, true, []).unwrap(),
             Effect::new(&f4, true, [&zs[5][..], &zs[4][..]]).unwrap(),
         ];
-        let design = Design::new(effects).unwrap();
-        let dense = dense_matrix(&design);
-        let op = DesignOperator::new(&design, None);
+        let prepared = PreparedDesign::unweighted_for_test(Design::new(effects).unwrap());
+        let dense = dense_matrix(&prepared);
+        assert!(
+            (0..prepared.design.n_dofs).all(|j| dense.iter().any(|row| row[j] != 0.0)),
+            "whitening zeroed a column; the arm's addressing would go untested"
+        );
+        let op = DesignOperator::new(&prepared);
 
-        let x: Vec<f64> = (0..design.n_dofs).map(|j| noise(7_000 + j)).collect();
-        let mut got = vec![0.0; design.n_obs];
+        let x: Vec<f64> = (0..prepared.design.n_dofs)
+            .map(|j| noise(7_000 + j))
+            .collect();
+        let mut got = vec![0.0; prepared.design.n_obs];
         op.apply(&x, &mut got).unwrap();
         let expect: Vec<f64> = dense
             .iter()
@@ -368,10 +380,12 @@ mod slope_design_tests {
             .collect();
         assert_close(&got, &expect);
 
-        let r: Vec<f64> = (0..design.n_obs).map(|i| noise(9_000 + i)).collect();
-        let mut got_t = vec![0.0; design.n_dofs];
+        let r: Vec<f64> = (0..prepared.design.n_obs)
+            .map(|i| noise(9_000 + i))
+            .collect();
+        let mut got_t = vec![0.0; prepared.design.n_dofs];
         op.apply_adjoint(&r, &mut got_t).unwrap();
-        let mut expect_t = vec![0.0; design.n_dofs];
+        let mut expect_t = vec![0.0; prepared.design.n_dofs];
         for (row, &ri) in dense.iter().zip(&r) {
             for (e, d) in expect_t.iter_mut().zip(row) {
                 *e += d * ri;
@@ -400,16 +414,18 @@ mod slope_design_tests {
             Effect::new(&unsorted, true, [&z[1][..]]).unwrap(),
             Effect::new(&small, true, [&z[2][..], &z[3][..]]).unwrap(),
         ];
-        let design = Design::new(effects).unwrap();
-        let sqrt_weights: Vec<f64> = (0..n).map(|i| (0.5 + noise(i).abs()).sqrt()).collect();
-        let op = DesignOperator::new(&design, Some(&sqrt_weights));
+        let weights: Vec<f64> = (0..n).map(|i| 0.5 + noise(i).abs()).collect();
+        let prepared = PreparedDesign::new(Design::new(effects).unwrap(), Some(weights)).unwrap();
+        let op = DesignOperator::new(&prepared);
 
-        let x: Vec<f64> = (0..design.n_dofs).map(|j| noise(13 * j + 1)).collect();
+        let x: Vec<f64> = (0..prepared.design.n_dofs)
+            .map(|j| noise(13 * j + 1))
+            .collect();
         let r: Vec<f64> = (0..n).map(|i| noise(29 * i + 5)).collect();
 
         let mut dx = vec![0.0; n];
         op.apply(&x, &mut dx).unwrap();
-        let mut dtr = vec![0.0; design.n_dofs];
+        let mut dtr = vec![0.0; prepared.design.n_dofs];
         op.apply_adjoint(&r, &mut dtr).unwrap();
 
         let lhs: f64 = dx.iter().zip(&r).map(|(a, b)| a * b).sum();
@@ -422,7 +438,7 @@ mod slope_design_tests {
 }
 
 mod weighted_adjoint_proptests {
-    use crate::domain::Design;
+    use crate::domain::PreparedDesign;
     use crate::operator::DesignOperator;
     use proptest::prelude::*;
     use schwarz_precond::Operator;
@@ -451,10 +467,13 @@ mod weighted_adjoint_proptests {
                 .map(|i| 0.5 + (i as f64 * 0.13 + seed as f64 * 0.41).sin().abs())
                 .collect();
 
-            let dm = Design::from_levels_for_test(vec![fa, fb]);
+            let dm = PreparedDesign::from_levels_for_test(vec![fa, fb]);
+            let dm_weighted = PreparedDesign::new(dm.design.clone(), Some(weights)).unwrap();
+            // Internal row order, like `dx` and `r` below.
+            let weights = dm_weighted.weights.as_deref().unwrap();
 
-            let n_dofs = dm.n_dofs;
-            let n_rows = dm.n_obs;
+            let n_dofs = dm.design.n_dofs;
+            let n_rows = dm.design.n_obs;
 
             let x: Vec<f64> = (0..n_dofs)
                 .map(|i| (i as f64 * 0.37 + seed as f64 * 0.13).sin())
@@ -463,7 +482,7 @@ mod weighted_adjoint_proptests {
                 .map(|i| (i as f64 * 0.29 + seed as f64 * 0.07).cos())
                 .collect();
 
-            let op_unweighted = DesignOperator::new(&dm, None);
+            let op_unweighted = DesignOperator::new(&dm);
             let mut dx = vec![0.0f64; n_rows];
             op_unweighted.apply(&x, &mut dx).unwrap();
             let lhs: f64 = dx
@@ -473,8 +492,7 @@ mod weighted_adjoint_proptests {
                 .map(|(i, (dxi, ri))| weights[i] * dxi * ri)
                 .sum();
 
-            let sqrt_weights: Vec<f64> = weights.iter().map(|w| w.sqrt()).collect();
-            let op_weighted = DesignOperator::new(&dm, Some(&sqrt_weights));
+            let op_weighted = DesignOperator::new(&dm_weighted);
             let wr = op_weighted.weighted_rhs(&r);
             let mut wdtr = vec![0.0f64; n_dofs];
             op_weighted.apply_adjoint(&wr, &mut wdtr).unwrap();

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -469,7 +469,7 @@ mod weighted_adjoint_proptests {
             let dm = PreparedDesign::from_levels_for_test(vec![fa, fb]);
             let dm_weighted = PreparedDesign::new(dm.design.clone(), Some(weights)).unwrap();
             // Internal row order, like `dx` and `r` below.
-            let weights = dm_weighted.weights.as_deref().unwrap();
+            let sqrt_weights = dm_weighted.sqrt_weights.as_deref().unwrap();
 
             let n_dofs = dm.design.n_dofs;
             let n_rows = dm.design.n_obs;
@@ -488,7 +488,7 @@ mod weighted_adjoint_proptests {
                 .iter()
                 .zip(r.iter())
                 .enumerate()
-                .map(|(i, (dxi, ri))| weights[i] * dxi * ri)
+                .map(|(i, (dxi, ri))| sqrt_weights[i] * sqrt_weights[i] * dxi * ri)
                 .sum();
 
             let op_weighted = DesignOperator::new(&dm_weighted);

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -342,7 +342,6 @@ mod slope_design_tests {
 
     /// Covers every kernel arm on the sequential path: plain, fused V=1/V=2,
     /// slope-only, and the generic V=3 fallback — against the dense reference.
-    /// Four rows per level keep every whitened column nonzero, so each arm's addressing counts.
     #[test]
     fn slope_matvec_and_adjoint_match_dense_reference() {
         let n = 12;

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -414,7 +414,7 @@ mod slope_design_tests {
             Effect::new(&small, true, [&z[2][..], &z[3][..]]).unwrap(),
         ];
         let weights: Vec<f64> = (0..n).map(|i| 0.5 + noise(i).abs()).collect();
-        let prepared = PreparedDesign::new(Design::new(effects).unwrap(), Some(weights)).unwrap();
+        let prepared = PreparedDesign::new(Design::new(effects).unwrap(), Some(&weights)).unwrap();
         let op = DesignOperator::new(&prepared);
 
         let x: Vec<f64> = (0..prepared.design.n_dofs)
@@ -467,7 +467,7 @@ mod weighted_adjoint_proptests {
                 .collect();
 
             let dm = PreparedDesign::from_levels_for_test(vec![fa, fb]);
-            let dm_weighted = PreparedDesign::new(dm.design.clone(), Some(weights)).unwrap();
+            let dm_weighted = PreparedDesign::new(dm.design.clone(), Some(&weights)).unwrap();
             // Internal row order, like `dx` and `r` below.
             let sqrt_weights = dm_weighted.sqrt_weights.as_deref().unwrap();
 

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use crate::block_elim::BlockElimSolver;
 use crate::config::{LocalSolverConfig, PreconditionerConfig};
 use crate::domain::Loading;
-use crate::domain::{LocalDomain, PreparedDesign};
+use crate::domain::{row_weight, LocalDomain, PreparedDesign};
 use crate::{BuildError, BuildWarning};
 
 #[cfg(test)]
@@ -212,12 +212,12 @@ impl Operator for Preconditioner {
 
 fn build_diagonal(prepared: &PreparedDesign<'_>) -> Result<DiagonalPreconditioner, BuildError> {
     let design = &prepared.design;
-    let weights = prepared.weights.as_deref();
+    let sqrt_weights = prepared.sqrt_weights.as_deref();
     let mut diag = vec![0.0; design.n_dofs];
 
     for (factor_idx, term) in design.terms.iter().enumerate() {
         let levels = design.frame.level_column(factor_idx);
-        let w = |uid: usize| weights.map_or(1.0, |ws| ws[uid]);
+        let w = |uid: usize| row_weight(sqrt_weights, uid);
         for (column, loading) in term.columns.iter().enumerate() {
             let base = term.column_base(column);
             let slice = &mut diag[base..base + term.n_levels];

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -210,9 +210,11 @@ impl Operator for Preconditioner {
     }
 }
 
-fn build_diagonal(prepared: &PreparedDesign<'_>) -> Result<DiagonalPreconditioner, BuildError> {
+fn build_diagonal(
+    prepared: &PreparedDesign<'_>,
+    sqrt_weights: Option<&[f64]>,
+) -> Result<DiagonalPreconditioner, BuildError> {
     let design = &prepared.design;
-    let sqrt_weights = prepared.sqrt_weights.as_deref();
     let mut diag = vec![0.0; design.n_dofs];
 
     for (factor_idx, term) in design.terms.iter().enumerate() {
@@ -228,7 +230,7 @@ fn build_diagonal(prepared: &PreparedDesign<'_>) -> Result<DiagonalPreconditione
                     }
                 }
                 Loading::Covariate(z_col) => {
-                    let z = prepared.basis.loading_column(*z_col as usize);
+                    let z = prepared.loading_column(*z_col as usize);
                     for (uid, &level) in levels.iter().enumerate() {
                         // Keep `w * z * z` left-to-right: a zero weight kills a huge `z` first.
                         slice[level as usize] += w(uid) * z[uid] * z[uid];
@@ -255,14 +257,16 @@ fn build_diagonal(prepared: &PreparedDesign<'_>) -> Result<DiagonalPreconditione
     })
 }
 
-/// Build a [`Preconditioner`] for a prepared design, plus any warnings.
+/// Build a [`Preconditioner`] for a prepared design and optional `√w`, plus any warnings.
 pub(crate) fn build_preconditioner(
     prepared: &PreparedDesign<'_>,
+    sqrt_weights: Option<&[f64]>,
     config: Option<&PreconditionerConfig>,
 ) -> Result<(Option<Preconditioner>, Vec<BuildWarning>), BuildError> {
     use crate::domain::build_local_domains;
 
     let design = &prepared.design;
+    // Weights are pre-validated by the sole caller, whose permutation preserves length and sign.
     let default_cfg = PreconditionerConfig::default();
     let resolved = config.unwrap_or(&default_cfg);
     // Measure preconditioner build time
@@ -275,7 +279,7 @@ pub(crate) fn build_preconditioner(
             local_solver,
             reduction,
         } => {
-            let (domains, warnings) = build_local_domains(prepared, local_solver)?;
+            let (domains, warnings) = build_local_domains(prepared, sqrt_weights, local_solver)?;
             if domains.is_empty() {
                 // No factor-pair subdomains means no useful Schwarz; fall back to plain LSMR.
                 return Ok((None, warnings));
@@ -285,7 +289,7 @@ pub(crate) fn build_preconditioner(
             (Variant::Additive(preconditioner), warnings)
         }
         PreconditionerConfig::Diagonal => {
-            let preconditioner = build_diagonal(prepared)?;
+            let preconditioner = build_diagonal(prepared, sqrt_weights)?;
             (Variant::Diagonal(preconditioner), Vec::new())
         }
     };

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use crate::block_elim::BlockElimSolver;
 use crate::config::{LocalSolverConfig, PreconditionerConfig};
 use crate::domain::Loading;
-use crate::domain::{Design, LocalDomain};
+use crate::domain::{LocalDomain, PreparedDesign};
 use crate::{BuildError, BuildWarning};
 
 #[cfg(test)]
@@ -210,10 +210,9 @@ impl Operator for Preconditioner {
     }
 }
 
-fn build_diagonal(
-    design: &Design<'_>,
-    weights: Option<&[f64]>,
-) -> Result<DiagonalPreconditioner, BuildError> {
+fn build_diagonal(prepared: &PreparedDesign<'_>) -> Result<DiagonalPreconditioner, BuildError> {
+    let design = &prepared.design;
+    let weights = prepared.weights.as_deref();
     let mut diag = vec![0.0; design.n_dofs];
 
     for (factor_idx, term) in design.terms.iter().enumerate() {
@@ -229,7 +228,7 @@ fn build_diagonal(
                     }
                 }
                 Loading::Covariate(z_col) => {
-                    let z = design.frame.loading_column(*z_col as usize);
+                    let z = prepared.basis.loading_column(*z_col as usize);
                     for (uid, &level) in levels.iter().enumerate() {
                         // Keep `w * z * z` left-to-right: a zero weight kills a huge `z` first.
                         slice[level as usize] += w(uid) * z[uid] * z[uid];
@@ -256,15 +255,14 @@ fn build_diagonal(
     })
 }
 
-/// Build a [`Preconditioner`] from a design and optional weights, plus any warnings.
+/// Build a [`Preconditioner`] for a prepared design, plus any warnings.
 pub(crate) fn build_preconditioner(
-    design: &Design<'_>,
-    weights: Option<&[f64]>,
+    prepared: &PreparedDesign<'_>,
     config: Option<&PreconditionerConfig>,
 ) -> Result<(Option<Preconditioner>, Vec<BuildWarning>), BuildError> {
     use crate::domain::build_local_domains;
 
-    // Weights are pre-validated by the sole caller, whose permutation preserves length and sign.
+    let design = &prepared.design;
     let default_cfg = PreconditionerConfig::default();
     let resolved = config.unwrap_or(&default_cfg);
     // Measure preconditioner build time
@@ -277,7 +275,7 @@ pub(crate) fn build_preconditioner(
             local_solver,
             reduction,
         } => {
-            let (domains, warnings) = build_local_domains(design, weights, local_solver)?;
+            let (domains, warnings) = build_local_domains(prepared, local_solver)?;
             if domains.is_empty() {
                 // No factor-pair subdomains means no useful Schwarz; fall back to plain LSMR.
                 return Ok((None, warnings));
@@ -287,7 +285,7 @@ pub(crate) fn build_preconditioner(
             (Variant::Additive(preconditioner), warnings)
         }
         PreconditionerConfig::Diagonal => {
-            let preconditioner = build_diagonal(design, weights)?;
+            let preconditioner = build_diagonal(prepared)?;
             (Variant::Diagonal(preconditioner), Vec::new())
         }
     };

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use crate::block_elim::BlockElimSolver;
 use crate::config::{LocalSolverConfig, PreconditionerConfig};
 use crate::domain::Loading;
-use crate::domain::{row_weight, LocalDomain, PreparedDesign};
+use crate::domain::{LocalDomain, PreparedDesign};
 use crate::{BuildError, BuildWarning};
 
 #[cfg(test)]
@@ -210,16 +210,13 @@ impl Operator for Preconditioner {
     }
 }
 
-fn build_diagonal(
-    prepared: &PreparedDesign<'_>,
-    sqrt_weights: Option<&[f64]>,
-) -> Result<DiagonalPreconditioner, BuildError> {
+fn build_diagonal(prepared: &PreparedDesign<'_>) -> Result<DiagonalPreconditioner, BuildError> {
     let design = &prepared.design;
     let mut diag = vec![0.0; design.n_dofs];
 
     for (factor_idx, term) in design.terms.iter().enumerate() {
         let levels = design.frame.level_column(factor_idx);
-        let w = |uid: usize| row_weight(sqrt_weights, uid);
+        let w = |uid: usize| prepared.row_weight(uid);
         for (column, loading) in term.columns.iter().enumerate() {
             let base = term.column_base(column);
             let slice = &mut diag[base..base + term.n_levels];
@@ -257,10 +254,9 @@ fn build_diagonal(
     })
 }
 
-/// Build a [`Preconditioner`] for a prepared design and optional `√w`, plus any warnings.
+/// Build a [`Preconditioner`] for a prepared design, plus any warnings.
 pub(crate) fn build_preconditioner(
     prepared: &PreparedDesign<'_>,
-    sqrt_weights: Option<&[f64]>,
     config: Option<&PreconditionerConfig>,
 ) -> Result<(Option<Preconditioner>, Vec<BuildWarning>), BuildError> {
     use crate::domain::build_local_domains;
@@ -279,7 +275,7 @@ pub(crate) fn build_preconditioner(
             local_solver,
             reduction,
         } => {
-            let (domains, warnings) = build_local_domains(prepared, sqrt_weights, local_solver)?;
+            let (domains, warnings) = build_local_domains(prepared, local_solver)?;
             if domains.is_empty() {
                 // No factor-pair subdomains means no useful Schwarz; fall back to plain LSMR.
                 return Ok((None, warnings));
@@ -289,7 +285,7 @@ pub(crate) fn build_preconditioner(
             (Variant::Additive(preconditioner), warnings)
         }
         PreconditionerConfig::Diagonal => {
-            let preconditioner = build_diagonal(prepared, sqrt_weights)?;
+            let preconditioner = build_diagonal(prepared)?;
             (Variant::Diagonal(preconditioner), Vec::new())
         }
     };

--- a/crates/within/src/operator/schwarz/tests.rs
+++ b/crates/within/src/operator/schwarz/tests.rs
@@ -20,8 +20,8 @@ const BLOCK_ELIM_NESTED_RAYON_CHILD_ENV: &str = "WITHIN_TEST_BLOCK_ELIM_NESTED_R
 fn make_test_data() -> (PreparedDesign<'static>, Vec<LocalDomain>) {
     let design =
         PreparedDesign::from_levels_for_test(vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]);
-    let (domain_pairs, _) =
-        build_local_domains(&design, &LocalSolverConfig::default()).expect("plain domains build");
+    let (domain_pairs, _) = build_local_domains(&design, None, &LocalSolverConfig::default())
+        .expect("plain domains build");
     (design, domain_pairs)
 }
 
@@ -205,11 +205,11 @@ fn test_build_additive_with_strategy() {
     let (design, domain_pairs) = make_test_data();
     let config = LocalSolverConfig::default();
     let strategy = schwarz_precond::ReductionStrategy::default();
-    let n_dofs = design.design.n_dofs;
-    let schwarz = build_additive_with_strategy(domain_pairs, &config, strategy, n_dofs)
-        .expect("build schwarz with explicit domains");
-    let r = vec![1.0; n_dofs];
-    let mut z = vec![0.0; n_dofs];
+    let schwarz =
+        build_additive_with_strategy(domain_pairs, &config, strategy, design.design.n_dofs)
+            .expect("build schwarz with explicit domains");
+    let r = vec![1.0; design.design.n_dofs];
+    let mut z = vec![0.0; design.design.n_dofs];
     schwarz.apply(&r, &mut z).expect("schwarz apply succeeds");
 }
 

--- a/crates/within/src/operator/schwarz/tests.rs
+++ b/crates/within/src/operator/schwarz/tests.rs
@@ -20,8 +20,8 @@ const BLOCK_ELIM_NESTED_RAYON_CHILD_ENV: &str = "WITHIN_TEST_BLOCK_ELIM_NESTED_R
 fn make_test_data() -> (PreparedDesign<'static>, Vec<LocalDomain>) {
     let design =
         PreparedDesign::from_levels_for_test(vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]);
-    let (domain_pairs, _) = build_local_domains(&design, None, &LocalSolverConfig::default())
-        .expect("plain domains build");
+    let (domain_pairs, _) =
+        build_local_domains(&design, &LocalSolverConfig::default()).expect("plain domains build");
     (design, domain_pairs)
 }
 

--- a/crates/within/src/operator/schwarz/tests.rs
+++ b/crates/within/src/operator/schwarz/tests.rs
@@ -10,17 +10,18 @@ use crate::config::{
 use schwarz_precond::SubdomainCore;
 
 use crate::csr_block::CsrBlock;
-use crate::domain::{build_local_domains, Design, LocalDomain};
+use crate::domain::{build_local_domains, LocalDomain, PreparedDesign};
 use crate::domain::{CrossTab, LocalComponent};
 use crate::operator::schwarz::build_additive_with_strategy;
 use schwarz_precond::{LocalSolver, Operator, ReductionStrategy};
 
 const BLOCK_ELIM_NESTED_RAYON_CHILD_ENV: &str = "WITHIN_TEST_BLOCK_ELIM_NESTED_RAYON_CHILD";
 
-fn make_test_data() -> (Design<'static>, Vec<LocalDomain>) {
-    let design = Design::from_levels_for_test(vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]);
-    let (domain_pairs, _) = build_local_domains(&design, None, &LocalSolverConfig::default())
-        .expect("plain domains build");
+fn make_test_data() -> (PreparedDesign<'static>, Vec<LocalDomain>) {
+    let design =
+        PreparedDesign::from_levels_for_test(vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]);
+    let (domain_pairs, _) =
+        build_local_domains(&design, &LocalSolverConfig::default()).expect("plain domains build");
     (design, domain_pairs)
 }
 
@@ -204,10 +205,11 @@ fn test_build_additive_with_strategy() {
     let (design, domain_pairs) = make_test_data();
     let config = LocalSolverConfig::default();
     let strategy = schwarz_precond::ReductionStrategy::default();
-    let schwarz = build_additive_with_strategy(domain_pairs, &config, strategy, design.n_dofs)
+    let n_dofs = design.design.n_dofs;
+    let schwarz = build_additive_with_strategy(domain_pairs, &config, strategy, n_dofs)
         .expect("build schwarz with explicit domains");
-    let r = vec![1.0; design.n_dofs];
-    let mut z = vec![0.0; design.n_dofs];
+    let r = vec![1.0; n_dofs];
+    let mut z = vec![0.0; n_dofs];
     schwarz.apply(&r, &mut z).expect("schwarz apply succeeds");
 }
 

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -289,8 +289,7 @@ impl BatchSolveResult {
 ///
 /// Ownership: each observation column is borrowed or owned independently
 /// (`Cow`); a solver that outlives its inputs — e.g. one returned across the
-/// Python boundary — uses owned columns. Weights are always owned; for a
-/// one-shot weighted solve from a borrowed slice, use the free [`solve`] function.
+/// Python boundary — uses owned columns.
 pub struct Solver<'a> {
     prepared: PreparedDesign<'a>,
     preconditioner: Option<Preconditioner>,
@@ -334,16 +333,14 @@ impl<'a> Solver<'a> {
     /// - `PreconditionerConfig::Diagonal` — use diagonal/Jacobi preconditioning
     /// - [`Preconditioner`] or `&Preconditioner` — reuse a previously built one
     ///
-    /// `weights` is `None` for unweighted, or an owned `Vec<f64>` that the
-    /// solver takes ownership of (it re-reads the weights on every solve). To
-    /// solve once from a borrowed slice, use the free [`solve`] function.
+    /// `weights` is `None` for unweighted; the solver keeps only `√w` in its own order.
     ///
     /// LSMR tuning ([`LsmrOptions`]) is supplied per call to [`Solver::solve`] /
     /// [`Solver::solve_batch`], not at construction; preconditioner factorization
     /// state is the only expensive thing built here.
     pub fn new(
         design: impl IntoDesign<'a>,
-        weights: Option<Vec<f64>>,
+        weights: Option<&[f64]>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
         let prepared = PreparedDesign::new(design.into_design()?, weights)?;
@@ -453,12 +450,6 @@ impl<'a> Solver<'a> {
         })
     }
 
-    /// Per-level directions the data cannot identify, shared across all RHS:
-    /// identification depends only on the design and weights, never on `y`.
-    fn unidentified(&self) -> Vec<CoefficientAddress> {
-        self.prepared.basis.unidentified.clone()
-    }
-
     /// Solve for a single RHS vector with the given LSMR tuning.
     pub fn solve<'o>(
         &self,
@@ -473,7 +464,7 @@ impl<'a> Solver<'a> {
 
         Ok(SolveResult {
             x: solution.x,
-            unidentified: self.unidentified(),
+            unidentified: self.prepared.basis.unidentified.clone(),
             warnings: self.warnings.clone(),
             layout: CoefficientLayout::from_design(&self.prepared.design),
             demeaned: solution.demeaned,
@@ -522,7 +513,7 @@ impl<'a> Solver<'a> {
 
         Ok(BatchSolveResult {
             x,
-            unidentified: self.unidentified(),
+            unidentified: self.prepared.basis.unidentified.clone(),
             warnings: self.warnings.clone(),
             layout: CoefficientLayout::from_design(design),
             demeaned,
@@ -577,7 +568,7 @@ pub fn solve<'a, 'o>(
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<SolveResult, WithinError> {
     let t_start = Instant::now();
-    let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
+    let solver = Solver::new(design, weights, preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve(y, lsmr)?;
     // Include solver construction (preconditioner build) in setup time
@@ -598,7 +589,7 @@ pub fn solve_batch<'a, 'o>(
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<BatchSolveResult, WithinError> {
     let t_start = Instant::now();
-    let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
+    let solver = Solver::new(design, weights, preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve_batch(ys, lsmr)?;
     result.time_setup += time_setup;

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -12,7 +12,6 @@ use schwarz_precond::{lsmr as lsmr_solve, mlsmr, MlsmrOptions};
 use crate::channel::{Channel, CoefficientAddress};
 use crate::config::{LsmrOptions, PreconditionerConfig};
 use crate::domain::collinearity::detect_collinear_slopes;
-use crate::domain::level_moments::TermMoments;
 use crate::domain::{Design, Effect, PreparedDesign};
 use crate::observation::ObservationFrame;
 use crate::operator::design::gather_apply;
@@ -354,15 +353,9 @@ impl<'a> Solver<'a> {
         });
         let sw = sqrt_weights.as_deref();
 
-        // Both readers below need the raw loadings, so the moments precede whitening.
-        let moments = TermMoments::build(&design, sw);
-        let mut warnings = moments
-            .as_ref()
-            .map(|m| detect_collinear_slopes(&design, sw, m))
-            .unwrap_or_default();
-
         // Whiten the slope columns (if any) before the preconditioner reads them.
-        let prepared = PreparedDesign::new(design, moments.as_ref());
+        let prepared = PreparedDesign::new(design, sw);
+        let mut warnings = detect_collinear_slopes(&prepared, sw);
         let n_dofs = prepared.design.n_dofs;
 
         let (preconditioner, build_warnings) = match preconditioner.into() {

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -23,8 +23,8 @@ use crate::{BuildError, BuildWarning, SolveError, WithinError};
 mod tests;
 
 /// Fallible conversion into a [`Design`] for [`Solver::new`]: a categories
-/// matrix (`ArrayView2<u32>`), a list of [`Effect`] terms, or a pass-through
-/// [`Design`].
+/// matrix (`ArrayView2<u32>`), a list of [`Effect`] terms, a pass-through
+/// [`Design`], or a `&Design` whose storage the solver then shares.
 pub trait IntoDesign<'a> {
     /// Build the [`Design`], validating inputs along the way.
     fn into_design(self) -> Result<Design<'a>, BuildError>;
@@ -49,6 +49,12 @@ impl<'a> IntoDesign<'a> for ArrayView2<'a, u32> {
 impl<'a> IntoDesign<'a> for Design<'a> {
     fn into_design(self) -> Result<Design<'a>, BuildError> {
         Ok(self)
+    }
+}
+
+impl<'a> IntoDesign<'a> for &Design<'a> {
+    fn into_design(self) -> Result<Design<'a>, BuildError> {
+        Ok(self.clone())
     }
 }
 
@@ -327,8 +333,9 @@ struct RhsSolution {
 impl<'a> Solver<'a> {
     /// Construct a solver.
     ///
-    /// `design` accepts raw categories (`ArrayView2<u32>`) or a pre-built
-    /// [`Design`]. `preconditioner` accepts:
+    /// `design` accepts raw categories (`ArrayView2<u32>`), a pre-built
+    /// [`Design`], or `&Design` to share one design across solvers (an O(1)
+    /// clone of its storage). `preconditioner` accepts:
     /// - `None` — build the library default Schwarz preconditioner
     /// - `&PreconditionerConfig` / `Some(&PreconditionerConfig)` — build from a tuned config
     /// - `PreconditionerConfig::Off` — solve unpreconditioned

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -302,7 +302,7 @@ impl std::fmt::Debug for Solver<'_> {
         f.debug_struct("Solver")
             .field("n_obs", &self.prepared.design.n_obs)
             .field("n_dofs", &self.prepared.design.n_dofs)
-            .field("has_weights", &self.prepared.weights.is_some())
+            .field("has_weights", &self.prepared.sqrt_weights.is_some())
             .field("has_preconditioner", &self.preconditioner.is_some())
             .finish()
     }

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -12,6 +12,7 @@ use schwarz_precond::{lsmr as lsmr_solve, mlsmr, MlsmrOptions};
 use crate::channel::{Channel, CoefficientAddress};
 use crate::config::{LsmrOptions, PreconditionerConfig};
 use crate::domain::collinearity::detect_collinear_slopes;
+use crate::domain::level_moments::TermMoments;
 use crate::domain::{Design, Effect, PreparedDesign};
 use crate::observation::ObservationFrame;
 use crate::operator::design::gather_apply;
@@ -292,6 +293,8 @@ impl BatchSolveResult {
 /// Python boundary — uses owned columns.
 pub struct Solver<'a> {
     prepared: PreparedDesign<'a>,
+    /// `W^{1/2}` in the design's internal observation order; the only form of the weights kept.
+    sqrt_weights: Option<Vec<f64>>,
     preconditioner: Option<Preconditioner>,
     warnings: Vec<BuildWarning>,
 }
@@ -301,7 +304,7 @@ impl std::fmt::Debug for Solver<'_> {
         f.debug_struct("Solver")
             .field("n_obs", &self.prepared.design.n_obs)
             .field("n_dofs", &self.prepared.design.n_dofs)
-            .field("has_weights", &self.prepared.sqrt_weights.is_some())
+            .field("has_weights", &self.sqrt_weights.is_some())
             .field("has_preconditioner", &self.preconditioner.is_some())
             .finish()
     }
@@ -343,13 +346,28 @@ impl<'a> Solver<'a> {
         weights: Option<&[f64]>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
-        let prepared = PreparedDesign::new(design.into_design()?, weights)?;
+        let design = design.into_design()?;
+        design.validate_weights(weights)?;
+        let sqrt_weights: Option<Vec<f64>> = weights.map(|w| {
+            let w = design.permute_obs_in(w);
+            w.iter().map(|wi| wi.sqrt()).collect()
+        });
+        let sw = sqrt_weights.as_deref();
+
+        // Both readers below need the raw loadings, so the moments precede whitening.
+        let moments = TermMoments::build(&design, sw);
+        let mut warnings = moments
+            .as_ref()
+            .map(|m| detect_collinear_slopes(&design, sw, m))
+            .unwrap_or_default();
+
+        // Whiten the slope columns (if any) before the preconditioner reads them.
+        let prepared = PreparedDesign::new(design, moments.as_ref());
         let n_dofs = prepared.design.n_dofs;
-        let mut warnings = detect_collinear_slopes(&prepared);
 
         let (preconditioner, build_warnings) = match preconditioner.into() {
-            PreconditionerInput::Default => build_preconditioner(&prepared, None)?,
-            PreconditionerInput::Config(c) => build_preconditioner(&prepared, Some(&c))?,
+            PreconditionerInput::Default => build_preconditioner(&prepared, sw, None)?,
+            PreconditionerInput::Config(c) => build_preconditioner(&prepared, sw, Some(&c))?,
             PreconditionerInput::Prebuilt(p) => {
                 if p.nrows() != n_dofs || p.ncols() != n_dofs {
                     return Err(BuildError::PreconditionerDimensionMismatch {
@@ -366,6 +384,7 @@ impl<'a> Solver<'a> {
 
         Ok(Self {
             prepared,
+            sqrt_weights,
             preconditioner,
             warnings,
         })
@@ -382,15 +401,14 @@ impl<'a> Solver<'a> {
     /// `unidentified`, which the public entry points attach once (see
     /// [`RhsSolution`]).
     fn solve_rhs(&self, y: &[f64], lsmr: &LsmrOptions) -> Result<RhsSolution, SolveError> {
-        let design = &self.prepared.design;
         // `weighted_rhs` zips y with sqrt-weights, silently truncating when `y.len() > n_rows`.
-        if y.len() != design.n_obs {
+        if y.len() != self.prepared.design.n_obs {
             return Err(SolveError::InvalidInput {
                 context: "Solver::solve",
                 message: format!(
                     "response vector length ({}) does not match number of observations ({})",
                     y.len(),
-                    design.n_obs
+                    self.prepared.design.n_obs
                 ),
             });
         }
@@ -404,10 +422,10 @@ impl<'a> Solver<'a> {
         let t_start = Instant::now();
 
         // The gather is a recurring per-solve cost of the locality sort, so it counts as setup.
-        let y_internal = design.permute_obs_in(y);
+        let y_internal = self.prepared.design.permute_obs_in(y);
         let y: &[f64] = &y_internal;
 
-        let rect_op = DesignOperator::new(&self.prepared);
+        let rect_op = DesignOperator::new(&self.prepared, self.sqrt_weights.as_deref());
         let b = rect_op.weighted_rhs(y);
         let b: &[f64] = &b;
 
@@ -428,19 +446,21 @@ impl<'a> Solver<'a> {
         let time_solve = t_solve_start.elapsed().as_secs_f64();
 
         // Shapes are guaranteed here, so the bare `D x` matvec is infallible.
-        let mut demeaned = vec![0.0; design.n_obs];
+        let mut demeaned = vec![0.0; self.prepared.design.n_obs];
         gather_apply(&self.prepared, &r.x, &mut demeaned, None);
         for (d, &yi) in demeaned.iter_mut().zip(y.iter()) {
             *d = yi - *d;
         }
 
         let mut x = r.x;
-        self.prepared.basis.back_transform(&mut x);
+        if let Some(rp) = &self.prepared.reparam {
+            rp.back_transform(&mut x);
+        }
 
         Ok(RhsSolution {
             x,
             // Back to the caller's observation order (no-op if not reordered).
-            demeaned: design.permute_obs_out(demeaned),
+            demeaned: self.prepared.design.permute_obs_out(demeaned),
             converged: r.converged,
             iterations: r.iterations,
             // Read from the LSMR recurrence at no extra cost; see `SolveResult::residual`.
@@ -448,6 +468,16 @@ impl<'a> Solver<'a> {
             time_setup,
             time_solve,
         })
+    }
+
+    /// Per-level directions the data cannot identify, shared across all RHS:
+    /// identification depends only on the design and weights, never on `y`.
+    fn unidentified(&self) -> Vec<CoefficientAddress> {
+        self.prepared
+            .reparam
+            .as_ref()
+            .map(|rp| rp.unidentified.clone())
+            .unwrap_or_default()
     }
 
     /// Solve for a single RHS vector with the given LSMR tuning.
@@ -464,7 +494,7 @@ impl<'a> Solver<'a> {
 
         Ok(SolveResult {
             x: solution.x,
-            unidentified: self.prepared.basis.unidentified.clone(),
+            unidentified: self.unidentified(),
             warnings: self.warnings.clone(),
             layout: CoefficientLayout::from_design(&self.prepared.design),
             demeaned: solution.demeaned,
@@ -494,9 +524,8 @@ impl<'a> Solver<'a> {
             .map(|y| self.solve_rhs(y, lsmr))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let design = &self.prepared.design;
-        let mut x = Vec::with_capacity(design.n_dofs * n_rhs);
-        let mut demeaned = Vec::with_capacity(design.n_obs * n_rhs);
+        let mut x = Vec::with_capacity(self.prepared.design.n_dofs * n_rhs);
+        let mut demeaned = Vec::with_capacity(self.prepared.design.n_obs * n_rhs);
         let mut converged = Vec::with_capacity(n_rhs);
         let mut iterations = Vec::with_capacity(n_rhs);
         let mut residual = Vec::with_capacity(n_rhs);
@@ -513,9 +542,9 @@ impl<'a> Solver<'a> {
 
         Ok(BatchSolveResult {
             x,
-            unidentified: self.prepared.basis.unidentified.clone(),
+            unidentified: self.unidentified(),
             warnings: self.warnings.clone(),
-            layout: CoefficientLayout::from_design(design),
+            layout: CoefficientLayout::from_design(&self.prepared.design),
             demeaned,
             converged,
             iterations,
@@ -523,8 +552,8 @@ impl<'a> Solver<'a> {
             time_solve,
             time_setup: 0.0,
             time_total: t_start.elapsed().as_secs_f64(),
-            n_dofs: design.n_dofs,
-            n_obs: design.n_obs,
+            n_dofs: self.prepared.design.n_dofs,
+            n_obs: self.prepared.design.n_obs,
         })
     }
 

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -9,21 +9,18 @@ use ndarray::{ArrayView2, Axis};
 use rayon::prelude::*;
 use schwarz_precond::{lsmr as lsmr_solve, mlsmr, MlsmrOptions};
 
-use crate::channel::Channel;
+use crate::channel::{Channel, CoefficientAddress};
 use crate::config::{LsmrOptions, PreconditionerConfig};
 use crate::domain::collinearity::detect_collinear_slopes;
-use crate::domain::level_moments::TermMoments;
-use crate::domain::{Design, Effect};
+use crate::domain::{Design, Effect, PreparedDesign};
 use crate::observation::ObservationFrame;
 use crate::operator::design::gather_apply;
 use crate::operator::schwarz::{build_preconditioner, Preconditioner};
 use crate::operator::DesignOperator;
 use crate::{BuildError, BuildWarning, SolveError, WithinError};
 
-mod reparam;
 #[cfg(test)]
 mod tests;
-use reparam::SlopeReparam;
 
 /// Fallible conversion into a [`Design`] for [`Solver::new`]: a categories
 /// matrix (`ArrayView2<u32>`), a list of [`Effect`] terms, or a pass-through
@@ -109,15 +106,6 @@ impl From<&Preconditioner> for PreconditionerInput {
     fn from(p: &Preconditioner) -> Self {
         Self::Prebuilt(p.clone())
     }
-}
-
-/// One coefficient of the design: a [`Channel`] at one level of its term.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CoefficientAddress {
-    /// The coefficient column this address sits in.
-    pub channel: Channel,
-    /// Level index within the term (`0..n_levels`).
-    pub level: usize,
 }
 
 /// Translates a [`CoefficientAddress`] to its flat index in [`SolveResult::x`]
@@ -304,22 +292,17 @@ impl BatchSolveResult {
 /// Python boundary — uses owned columns. Weights are always owned; for a
 /// one-shot weighted solve from a borrowed slice, use the free [`solve`] function.
 pub struct Solver<'a> {
-    design: Design<'a>,
-    /// `sqrt(W)` in the design's internal observation order, computed once and
-    /// borrowed by the per-RHS [`DesignOperator`]s (raw weights are needed only
-    /// during construction).
-    sqrt_weights: Option<Vec<f64>>,
+    prepared: PreparedDesign<'a>,
     preconditioner: Option<Preconditioner>,
-    reparam: Option<SlopeReparam>,
     warnings: Vec<BuildWarning>,
 }
 
 impl std::fmt::Debug for Solver<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Solver")
-            .field("n_obs", &self.design.n_obs)
-            .field("n_dofs", &self.design.n_dofs)
-            .field("has_weights", &self.sqrt_weights.is_some())
+            .field("n_obs", &self.prepared.design.n_obs)
+            .field("n_dofs", &self.prepared.design.n_dofs)
+            .field("has_weights", &self.prepared.weights.is_some())
             .field("has_preconditioner", &self.preconditioner.is_some())
             .finish()
     }
@@ -363,38 +346,17 @@ impl<'a> Solver<'a> {
         weights: Option<Vec<f64>>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
-        let mut design = design.into_design()?;
-        design.validate_weights(weights.as_deref())?;
-
-        // The match keeps the unpermuted arm a plain move rather than a borrow-and-copy.
-        let weights = match &design.obs_perm {
-            Some(_) => weights.map(|w| design.permute_obs_in(&w).into_owned()),
-            None => weights,
-        };
-
-        // Both readers below need the raw loadings, so the moments precede whitening.
-        let moments = TermMoments::build(&design, weights.as_deref());
-        let mut warnings = moments
-            .as_ref()
-            .map(|m| detect_collinear_slopes(&design, weights.as_deref(), m))
-            .unwrap_or_default();
-
-        // Reparametrize the slope columns (if any) before the preconditioner reads the frame.
-        let reparam = moments
-            .as_ref()
-            .and_then(|m| SlopeReparam::build(&mut design, m));
+        let prepared = PreparedDesign::new(design.into_design()?, weights)?;
+        let n_dofs = prepared.design.n_dofs;
+        let mut warnings = detect_collinear_slopes(&prepared);
 
         let (preconditioner, build_warnings) = match preconditioner.into() {
-            PreconditionerInput::Default => {
-                build_preconditioner(&design, weights.as_deref(), None)?
-            }
-            PreconditionerInput::Config(c) => {
-                build_preconditioner(&design, weights.as_deref(), Some(&c))?
-            }
+            PreconditionerInput::Default => build_preconditioner(&prepared, None)?,
+            PreconditionerInput::Config(c) => build_preconditioner(&prepared, Some(&c))?,
             PreconditionerInput::Prebuilt(p) => {
-                if p.nrows() != design.n_dofs || p.ncols() != design.n_dofs {
+                if p.nrows() != n_dofs || p.ncols() != n_dofs {
                     return Err(BuildError::PreconditionerDimensionMismatch {
-                        expected: design.n_dofs,
+                        expected: n_dofs,
                         actual_rows: p.nrows(),
                         actual_cols: p.ncols(),
                     });
@@ -405,18 +367,9 @@ impl<'a> Solver<'a> {
 
         warnings.extend(build_warnings);
 
-        let sqrt_weights = weights.map(|mut w| {
-            for wi in &mut w {
-                *wi = wi.sqrt();
-            }
-            w
-        });
-
         Ok(Self {
-            design,
-            sqrt_weights,
+            prepared,
             preconditioner,
-            reparam,
             warnings,
         })
     }
@@ -432,14 +385,15 @@ impl<'a> Solver<'a> {
     /// `unidentified`, which the public entry points attach once (see
     /// [`RhsSolution`]).
     fn solve_rhs(&self, y: &[f64], lsmr: &LsmrOptions) -> Result<RhsSolution, SolveError> {
+        let design = &self.prepared.design;
         // `weighted_rhs` zips y with sqrt-weights, silently truncating when `y.len() > n_rows`.
-        if y.len() != self.design.n_obs {
+        if y.len() != design.n_obs {
             return Err(SolveError::InvalidInput {
                 context: "Solver::solve",
                 message: format!(
                     "response vector length ({}) does not match number of observations ({})",
                     y.len(),
-                    self.design.n_obs
+                    design.n_obs
                 ),
             });
         }
@@ -453,10 +407,10 @@ impl<'a> Solver<'a> {
         let t_start = Instant::now();
 
         // The gather is a recurring per-solve cost of the locality sort, so it counts as setup.
-        let y_internal = self.design.permute_obs_in(y);
+        let y_internal = design.permute_obs_in(y);
         let y: &[f64] = &y_internal;
 
-        let rect_op = DesignOperator::new(&self.design, self.sqrt_weights.as_deref());
+        let rect_op = DesignOperator::new(&self.prepared);
         let b = rect_op.weighted_rhs(y);
         let b: &[f64] = &b;
 
@@ -477,21 +431,19 @@ impl<'a> Solver<'a> {
         let time_solve = t_solve_start.elapsed().as_secs_f64();
 
         // Shapes are guaranteed here, so the bare `D x` matvec is infallible.
-        let mut demeaned = vec![0.0; self.design.n_obs];
-        gather_apply(&self.design, &r.x, &mut demeaned, None);
+        let mut demeaned = vec![0.0; design.n_obs];
+        gather_apply(&self.prepared, &r.x, &mut demeaned, None);
         for (d, &yi) in demeaned.iter_mut().zip(y.iter()) {
             *d = yi - *d;
         }
 
         let mut x = r.x;
-        if let Some(rp) = &self.reparam {
-            rp.back_transform(&mut x);
-        }
+        self.prepared.basis.back_transform(&mut x);
 
         Ok(RhsSolution {
             x,
             // Back to the caller's observation order (no-op if not reordered).
-            demeaned: self.design.permute_obs_out(demeaned),
+            demeaned: design.permute_obs_out(demeaned),
             converged: r.converged,
             iterations: r.iterations,
             // Read from the LSMR recurrence at no extra cost; see `SolveResult::residual`.
@@ -504,10 +456,7 @@ impl<'a> Solver<'a> {
     /// Per-level directions the data cannot identify, shared across all RHS:
     /// identification depends only on the design and weights, never on `y`.
     fn unidentified(&self) -> Vec<CoefficientAddress> {
-        self.reparam
-            .as_ref()
-            .map(|rp| rp.unidentified.clone())
-            .unwrap_or_default()
+        self.prepared.basis.unidentified.clone()
     }
 
     /// Solve for a single RHS vector with the given LSMR tuning.
@@ -526,7 +475,7 @@ impl<'a> Solver<'a> {
             x: solution.x,
             unidentified: self.unidentified(),
             warnings: self.warnings.clone(),
-            layout: CoefficientLayout::from_design(&self.design),
+            layout: CoefficientLayout::from_design(&self.prepared.design),
             demeaned: solution.demeaned,
             converged: solution.converged,
             iterations: solution.iterations,
@@ -554,8 +503,9 @@ impl<'a> Solver<'a> {
             .map(|y| self.solve_rhs(y, lsmr))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut x = Vec::with_capacity(self.design.n_dofs * n_rhs);
-        let mut demeaned = Vec::with_capacity(self.design.n_obs * n_rhs);
+        let design = &self.prepared.design;
+        let mut x = Vec::with_capacity(design.n_dofs * n_rhs);
+        let mut demeaned = Vec::with_capacity(design.n_obs * n_rhs);
         let mut converged = Vec::with_capacity(n_rhs);
         let mut iterations = Vec::with_capacity(n_rhs);
         let mut residual = Vec::with_capacity(n_rhs);
@@ -574,7 +524,7 @@ impl<'a> Solver<'a> {
             x,
             unidentified: self.unidentified(),
             warnings: self.warnings.clone(),
-            layout: CoefficientLayout::from_design(&self.design),
+            layout: CoefficientLayout::from_design(design),
             demeaned,
             converged,
             iterations,
@@ -582,8 +532,8 @@ impl<'a> Solver<'a> {
             time_solve,
             time_setup: 0.0,
             time_total: t_start.elapsed().as_secs_f64(),
-            n_dofs: self.design.n_dofs,
-            n_obs: self.design.n_obs,
+            n_dofs: design.n_dofs,
+            n_obs: design.n_obs,
         })
     }
 
@@ -594,12 +544,12 @@ impl<'a> Solver<'a> {
 
     /// Number of DOFs (coefficients).
     pub fn n_dofs(&self) -> usize {
-        self.design.n_dofs
+        self.prepared.design.n_dofs
     }
 
     /// Number of observations.
     pub fn n_obs(&self) -> usize {
-        self.design.n_obs
+        self.prepared.design.n_obs
     }
 }
 

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -298,8 +298,6 @@ impl BatchSolveResult {
 /// Python boundary — uses owned columns.
 pub struct Solver<'a> {
     prepared: PreparedDesign<'a>,
-    /// `W^{1/2}` in the design's internal observation order; the only form of the weights kept.
-    sqrt_weights: Option<Vec<f64>>,
     preconditioner: Option<Preconditioner>,
     warnings: Vec<BuildWarning>,
 }
@@ -309,7 +307,7 @@ impl std::fmt::Debug for Solver<'_> {
         f.debug_struct("Solver")
             .field("n_obs", &self.prepared.design.n_obs)
             .field("n_dofs", &self.prepared.design.n_dofs)
-            .field("has_weights", &self.sqrt_weights.is_some())
+            .field("has_weights", &self.prepared.sqrt_weights().is_some())
             .field("has_preconditioner", &self.preconditioner.is_some())
             .finish()
     }
@@ -342,7 +340,9 @@ impl<'a> Solver<'a> {
     /// - `PreconditionerConfig::Diagonal` — use diagonal/Jacobi preconditioning
     /// - [`Preconditioner`] or `&Preconditioner` — reuse a previously built one
     ///
-    /// `weights` is `None` for unweighted; the solver keeps only `√w` in its own order.
+    /// `weights` is `None` for an unweighted solve. Supplied weights are validated
+    /// in caller observation order, then retained internally only as `√w` in the
+    /// design's internal observation order.
     ///
     /// LSMR tuning ([`LsmrOptions`]) is supplied per call to [`Solver::solve`] /
     /// [`Solver::solve_batch`], not at construction; preconditioner factorization
@@ -352,22 +352,14 @@ impl<'a> Solver<'a> {
         weights: Option<&[f64]>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
-        let design = design.into_design()?;
-        design.validate_weights(weights)?;
-        let sqrt_weights: Option<Vec<f64>> = weights.map(|w| {
-            let w = design.permute_obs_in(w);
-            w.iter().map(|wi| wi.sqrt()).collect()
-        });
-        let sw = sqrt_weights.as_deref();
-
         // Whiten the slope columns (if any) before the preconditioner reads them.
-        let prepared = PreparedDesign::new(design, sw);
-        let mut warnings = detect_collinear_slopes(&prepared, sw);
+        let prepared = PreparedDesign::new(design.into_design()?, weights)?;
+        let mut warnings = detect_collinear_slopes(&prepared);
         let n_dofs = prepared.design.n_dofs;
 
         let (preconditioner, build_warnings) = match preconditioner.into() {
-            PreconditionerInput::Default => build_preconditioner(&prepared, sw, None)?,
-            PreconditionerInput::Config(c) => build_preconditioner(&prepared, sw, Some(&c))?,
+            PreconditionerInput::Default => build_preconditioner(&prepared, None)?,
+            PreconditionerInput::Config(c) => build_preconditioner(&prepared, Some(&c))?,
             PreconditionerInput::Prebuilt(p) => {
                 if p.nrows() != n_dofs || p.ncols() != n_dofs {
                     return Err(BuildError::PreconditionerDimensionMismatch {
@@ -384,7 +376,6 @@ impl<'a> Solver<'a> {
 
         Ok(Self {
             prepared,
-            sqrt_weights,
             preconditioner,
             warnings,
         })
@@ -425,7 +416,7 @@ impl<'a> Solver<'a> {
         let y_internal = self.prepared.design.permute_obs_in(y);
         let y: &[f64] = &y_internal;
 
-        let rect_op = DesignOperator::new(&self.prepared, self.sqrt_weights.as_deref());
+        let rect_op = DesignOperator::new(&self.prepared);
         let b = rect_op.weighted_rhs(y);
         let b: &[f64] = &b;
 

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -34,7 +34,7 @@ fn positive_slope_only_pair_grounds_beyond_dense_threshold() {
     ];
     let prepared = PreparedDesign::unweighted_for_test(Design::new(effects).expect("design"));
     let (domains, warnings) =
-        build_local_domains(&prepared, &LocalSolverConfig::default()).expect("domains");
+        build_local_domains(&prepared, None, &LocalSolverConfig::default()).expect("domains");
     assert!(
         domains.iter().any(|ld| {
             let ct = &ld.component.matrix.cross_tab;

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -2,7 +2,8 @@ use super::{CoefficientAddress, CoefficientLayout};
 use crate::channel::Channel;
 use crate::config::{LocalSolverConfig, DEFAULT_DENSE_SCHUR_THRESHOLD};
 use crate::domain::{build_local_domains, Design, Grounding, MatrixForm, PreparedDesign};
-use crate::Effect;
+use crate::{Effect, PreconditionerConfig, Solver};
+use std::sync::Arc;
 
 /// DGP kept in lockstep with `surplus_component_sampled_matches_exact_reduction`
 /// in `tests/slopes_routing.rs`. A positive slope-only term is not centered by
@@ -86,4 +87,30 @@ fn coefficient_layout_translates_addresses_both_ways() {
     for i in 0..layout.n_dofs() {
         assert_eq!(layout.index(layout.address(i).expect("in range")), Some(i));
     }
+}
+
+#[test]
+fn solvers_built_from_a_borrowed_design_share_its_storage() {
+    let (f, g, z) = positive_slope_only_panel();
+    let design = Design::new(vec![
+        Effect::new(&f, true, []).unwrap(),
+        Effect::new(&g, false, [&z[..]]).unwrap(),
+    ])
+    .unwrap();
+    let n = f.len();
+    let w: Vec<f64> = (0..n).map(|i| 1.0 + (i % 5) as f64).collect();
+    let y: Vec<f64> = (0..n).map(|i| (i % 7) as f64).collect();
+
+    let unweighted = Solver::new(&design, None, &PreconditionerConfig::Diagonal).unwrap();
+    let weighted = Solver::new(&design, Some(&w), &PreconditionerConfig::Diagonal).unwrap();
+
+    assert!(Arc::ptr_eq(
+        &unweighted.prepared.design.frame,
+        &design.frame
+    ));
+    assert!(Arc::ptr_eq(&weighted.prepared.design.frame, &design.frame));
+    let a = unweighted.solve(&y, None).unwrap();
+    let b = weighted.solve(&y, None).unwrap();
+    assert!(a.converged && b.converged);
+    assert_ne!(a.x, b.x);
 }

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -1,9 +1,7 @@
-use super::reparam::SlopeReparam;
 use super::{CoefficientAddress, CoefficientLayout};
 use crate::channel::Channel;
 use crate::config::{LocalSolverConfig, DEFAULT_DENSE_SCHUR_THRESHOLD};
-use crate::domain::level_moments::TermMoments;
-use crate::domain::{build_local_domains, Design, Grounding, MatrixForm};
+use crate::domain::{build_local_domains, Design, Grounding, MatrixForm, PreparedDesign};
 use crate::Effect;
 
 /// DGP kept in lockstep with `surplus_component_sampled_matches_exact_reduction`
@@ -34,11 +32,9 @@ fn positive_slope_only_pair_grounds_beyond_dense_threshold() {
         Effect::new(&f, false, [&z[..]]).expect("slope effect"),
         Effect::new(&g, true, []).expect("plain effect"),
     ];
-    let mut design = Design::new(effects).expect("design");
-    let moments = TermMoments::build(&design, None).expect("slopes");
-    let _reparam = SlopeReparam::build(&mut design, &moments);
+    let prepared = PreparedDesign::unweighted_for_test(Design::new(effects).expect("design"));
     let (domains, warnings) =
-        build_local_domains(&design, None, &LocalSolverConfig::default()).expect("domains");
+        build_local_domains(&prepared, &LocalSolverConfig::default()).expect("domains");
     assert!(
         domains.iter().any(|ld| {
             let ct = &ld.component.matrix.cross_tab;

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -35,7 +35,7 @@ fn positive_slope_only_pair_grounds_beyond_dense_threshold() {
     ];
     let prepared = PreparedDesign::unweighted_for_test(Design::new(effects).expect("design"));
     let (domains, warnings) =
-        build_local_domains(&prepared, None, &LocalSolverConfig::default()).expect("domains");
+        build_local_domains(&prepared, &LocalSolverConfig::default()).expect("domains");
     assert!(
         domains.iter().any(|ld| {
             let ct = &ld.component.matrix.cross_tab;

--- a/crates/within/tests/api_pinning.rs
+++ b/crates/within/tests/api_pinning.rs
@@ -85,13 +85,9 @@ fn solver_new_weights_call_shapes_compile() {
     let categories = cats();
     let w_vec: Vec<f64> = vec![1.0; 4];
 
-    // Bare `None` — infers, because `weights` is the concrete `Option<Vec<f64>>`
-    // (no turbofish needed). The persistent solver owns its weights; borrow-based
-    // one-shot weighting lives on the free `solve` function instead.
+    // Bare `None` infers, because `weights` is the concrete `Option<&[f64]>`.
     let _ = Solver::new(categories.view(), None, None).expect("None weights");
-
-    // Owned `Vec<f64>` weights — moved into the solver.
-    let _ = Solver::new(categories.view(), Some(w_vec), None).expect("Vec<f64> weights");
+    let _ = Solver::new(categories.view(), Some(&w_vec), None).expect("borrowed weights");
 }
 
 #[test]

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -47,7 +47,7 @@ fn test_weight_count_mismatch_error() {
     )
     .expect("frame ok");
     let design = Design::from_frame(frame).expect("valid design");
-    let result = Solver::new(design, Some(vec![1.0, 2.0]), None);
+    let result = Solver::new(design, Some(&[1.0, 2.0]), None);
     let err = result.expect_err("expected WeightCountMismatch error, got Ok");
     match err {
         BuildError::WeightCountMismatch { .. } => {}

--- a/crates/within/tests/orchestrate_solve.rs
+++ b/crates/within/tests/orchestrate_solve.rs
@@ -88,7 +88,7 @@ fn test_lsmr_least_squares_weighted_preconditioned() {
         ..Default::default()
     };
     let precond = PreconditionerConfig::default();
-    let solver = Solver::new(design, Some(weights.clone()), &precond).expect("build solver");
+    let solver = Solver::new(design, Some(&weights), &precond).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_solution_finite(&result);

--- a/crates/within/tests/properties.rs
+++ b/crates/within/tests/properties.rs
@@ -121,7 +121,7 @@ proptest! {
             maxiter: 2000,
             local_size: Some(10),
         };
-        let result = Solver::new(effects, Some(weights.clone()), PreconditionerConfig::default())
+        let result = Solver::new(effects, Some(weights), PreconditionerConfig::default())
             .expect("build solver")
             .solve(y.as_slice(), &params)
             .expect("solve");

--- a/crates/within/tests/slopes.rs
+++ b/crates/within/tests/slopes.rs
@@ -54,7 +54,7 @@ fn solve_with(
     levels: &[u32],
     z: &[f64],
     intercept: bool,
-    weights: Option<Vec<f64>>,
+    weights: Option<&[f64]>,
     y: &[f64],
     config: &PreconditionerConfig,
 ) -> SolveResult {
@@ -72,7 +72,7 @@ fn solve_single(
     levels: &[u32],
     z: &[f64],
     intercept: bool,
-    weights: Option<Vec<f64>>,
+    weights: Option<&[f64]>,
     y: &[f64],
 ) -> SolveResult {
     solve_with(
@@ -201,7 +201,7 @@ fn weighted_solve_matches_closed_form_and_masks_zero_weight_rows() {
     let w: Vec<f64> = vec![1.0, 0.5, 2.0, 1.5, 3.0, 1.0, 1.0, 1.0, 0.0];
     let y = synthetic_y(levels.len());
 
-    let r = solve_single(&levels, &z, true, Some(w.clone()), &y);
+    let r = solve_single(&levels, &z, true, Some(&w), &y);
     assert!(r.converged);
     assert_eq!(drops(&r), [(0, 2, 1)]);
     assert_eq!(r.x[3 + 2], 0.0);
@@ -222,8 +222,7 @@ fn zero_weight_garbage_does_not_poison_identification() {
     let z: Vec<f64> = vec![1.0, 2.0, 3.0, 5.0, 7.0, 1e300];
     let w: Vec<f64> = vec![1.0, 1.0, 1.0, 1.0, 1.0, 0.0];
     let y = synthetic_y(levels.len());
-    let run =
-        |config: &PreconditionerConfig| solve_with(&levels, &z, true, Some(w.clone()), &y, config);
+    let run = |config: &PreconditionerConfig| solve_with(&levels, &z, true, Some(&w), &y, config);
 
     let r = run(&PreconditionerConfig::default());
     assert!(r.unidentified.is_empty());

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -321,11 +321,11 @@ fn test_internal_locality_sort_is_transparent(#[case] weighted: bool) {
     let params = default_params();
     let precond = additive_precond();
 
-    let make_solver = |weights: Option<Vec<f64>>| {
+    let make_solver = |weights: Option<&[f64]>| {
         let design = common::make_design(vec![col0.clone(), col1.clone()]).expect("design");
         Solver::new(design, weights, &precond).expect("solver")
     };
-    let make_oracle = |weights: Option<Vec<f64>>| {
+    let make_oracle = |weights: Option<&[f64]>| {
         let frame =
             ObservationFrame::new(vec![col0.clone().into(), col1.clone().into()], Vec::new())
                 .expect("frame");
@@ -333,10 +333,12 @@ fn test_internal_locality_sort_is_transparent(#[case] weighted: bool) {
         Solver::new(design, weights, &precond).expect("oracle solver")
     };
 
-    let oracle = make_oracle(weights.clone())
+    let oracle = make_oracle(weights.as_deref())
         .solve(&y, &params)
         .expect("oracle");
-    let sorted = make_solver(weights).solve(&y, &params).expect("sorted");
+    let sorted = make_solver(weights.as_deref())
+        .solve(&y, &params)
+        .expect("sorted");
     common::assert_solutions_close(&sorted.x, &oracle.x, 1e-7);
     common::assert_solutions_close(&sorted.demeaned, &oracle.demeaned, 1e-7);
 }


### PR DESCRIPTION
Main-based replacement for the stack base: #309, #318 (which folded #323 and #324), #327 and #328. The factor-encoding thread (#314, #316, #333–#336) and the Python `Design` API (#319, #329, #332) rebase on top as before.

- `Design` shares its frame and row permutation behind an `Arc`; `Solver::new(&design, …)` (via `IntoDesign for &Design`, an O(1) clone) is the sharing API, so `Solver::from_design` (#327) and a public `SolverState` (#328) are not needed. Public API unchanged except `Solver::new` (below), within-py touched only for that.
- `PreparedDesign` pairs a `Design` with the `SlopeReparam` one weight vector determines. The whitened slope columns live on the reparam instead of overwriting the frame, so the frame is immutable after construction, `set_loading_column` goes, and the frame encapsulation of #309 is not needed. Preconditioner and `DesignOperator` read loading columns through `PreparedDesign`. This is what #318's `SolverDesign` + `LoadingOverrides` + `SolverState` did, without a borrowed view over the design.
- `Solver::new` takes `weights: Option<&[f64]>` and keeps only `√w`; moments, the collinearity screen, the cross-tab accumulation and the diagonal preconditioner read `s²` through one `row_weight` helper. Public signature change on the unreleased 0.4.0; `api_pinning.rs` pins the new form.
- The collinearity screen projects each target onto the term's whitened slope basis, so its per-level Gram–Schmidt and the shared moments table go.
- `TermReparam` keeps `intercept: bool`; the intercept-first column layout is what `Effect::new`, `Channel` and `SolveResult::x` already promise. `Design::build` rejects continuous frame columns no term claims (`BuildError::UnclaimedLoadingColumns`).
- Orthogonal to the factor-encoding thread: `TermMeta` is unchanged.

Weighted results move ≤1.6e-12 relative against main (squaring `√w` instead of reading `w`); unweighted results are bitwise identical, iteration counts equal.

Memory: the shared `Design` keeps the raw slope columns, so a whitened copy per covariate is held beside them for the solver's lifetime (+8·n_obs bytes per slope column vs main). Inherent to sharing across weight vectors.

286 Rust tests, 106 Python tests, clippy clean. 30 files, +532/−558.
