### PR TITLE
Borrow weights in Solver::new and tighten the design layout invariants

### DIFF
--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -25,7 +25,7 @@ use crate::results::{
 fn build_and_solve<'a>(
     design: impl IntoDesign<'a>,
     y: &[f64],
-    weights: Option<Vec<f64>>,
+    weights: Option<&[f64]>,
     lsmr: &LsmrOptions,
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(SolveResult, Vec<BuildWarning>), WithinError> {
@@ -42,7 +42,7 @@ fn build_and_solve<'a>(
 fn build_and_solve_batch<'a>(
     design: impl IntoDesign<'a>,
     ys: &[&[f64]],
-    weights: Option<Vec<f64>>,
+    weights: Option<&[f64]>,
     lsmr: &LsmrOptions,
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(BatchSolveResult, Vec<BuildWarning>), WithinError> {
@@ -79,19 +79,15 @@ pub fn solve<'py>(
             let cats = categories.as_array();
             run_solve_with_warnings(py, move || {
                 let y_cow = coerce_to_slice(&y_arr);
-                build_and_solve(cats, &y_cow, w_view.map(|w| w.to_vec()), &params, precond)
+                let w_cow = w_view.as_ref().map(coerce_to_slice);
+                build_and_solve(cats, &y_cow, w_cow.as_deref(), &params, precond)
             })
         }
         DesignSource::Effects(terms) => run_solve_with_warnings(py, move || {
             let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
             let y_cow = coerce_to_slice(&y_arr);
-            build_and_solve(
-                effects,
-                &y_cow,
-                w_view.map(|w| w.to_vec()),
-                &params,
-                precond,
-            )
+            let w_cow = w_view.as_ref().map(coerce_to_slice);
+            build_and_solve(effects, &y_cow, w_cow.as_deref(), &params, precond)
         }),
     }
 }
@@ -121,13 +117,8 @@ pub fn solve_batch<'py>(
             run_batch_with_warnings(py, move || {
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
-                build_and_solve_batch(
-                    cats,
-                    &col_refs,
-                    w_view.map(|w| w.to_vec()),
-                    &params,
-                    precond,
-                )
+                let w_cow = w_view.as_ref().map(coerce_to_slice);
+                build_and_solve_batch(cats, &col_refs, w_cow.as_deref(), &params, precond)
             })
         }
         DesignSource::Effects(terms) => {
@@ -138,13 +129,8 @@ pub fn solve_batch<'py>(
                 let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
-                build_and_solve_batch(
-                    effects,
-                    &col_refs,
-                    w_view.map(|w| w.to_vec()),
-                    &params,
-                    precond,
-                )
+                let w_cow = w_view.as_ref().map(coerce_to_slice);
+                build_and_solve_batch(effects, &col_refs, w_cow.as_deref(), &params, precond)
             })
         }
     }
@@ -253,7 +239,7 @@ impl PySolver {
         preconditioner: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Self> {
         let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
-        let weights_vec: Option<Vec<f64>> = weights.as_ref().map(|w| w.as_array().to_vec());
+        let w_view = weights.as_ref().map(|w| w.as_array());
         let precond = resolve_precond_input(preconditioner)?;
 
         // `BuildError` carries no Python types, so it maps to an exception once the GIL is back.
@@ -261,15 +247,17 @@ impl PySolver {
             DesignSource::Categories(categories) => {
                 let cats = categories.as_array();
                 py.detach(move || -> Result<Solver<'static>, BuildError> {
-                    Solver::new(cats.into_design()?.into_owned(), weights_vec, precond)
+                    let w_cow = w_view.as_ref().map(coerce_to_slice);
+                    Solver::new(cats.into_design()?.into_owned(), w_cow.as_deref(), precond)
                 })
             }
             DesignSource::Effects(terms) => {
                 py.detach(move || -> Result<Solver<'static>, BuildError> {
+                    let w_cow = w_view.as_ref().map(coerce_to_slice);
                     let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                     // The solver outlives the terms' buffers, so lower to owned columns first.
                     let design = Design::new(effects)?.into_owned();
-                    Solver::new(design, weights_vec, precond)
+                    Solver::new(design, w_cow.as_deref(), precond)
                 })
             }
         }

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -104,6 +104,11 @@ impl TermMeta {
     }
 }
 
+/// The Gram weight of row `obs`: the operator applies `s`, so its normal matrix carries `s²`.
+pub(crate) fn row_weight(sqrt_weights: Option<&[f64]>, obs: usize) -> f64 {
+    sqrt_weights.map_or(1.0, |s| s[obs] * s[obs])
+}
+
 /// Stable argsort of observations by a level column, ascending.
 ///
 /// Dense counting sort in `O(n_obs + n_levels)` or sparse comparison sort — same

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -219,6 +219,18 @@ impl<'a> Design<'a> {
             terms.push(meta);
         }
 
+        let claimed: usize = terms
+            .iter()
+            .flat_map(|t| t.columns.iter())
+            .filter(|c| c.covariate().is_some())
+            .count();
+        if claimed != frame.n_loading_columns() {
+            return Err(BuildError::UnclaimedLoadingColumns {
+                claimed,
+                provided: frame.n_loading_columns(),
+            });
+        }
+
         // Rejected here rather than left to panic in `to_u32`.
         if u32::try_from(offset).is_err() {
             return Err(BuildError::DofSpaceExceedsU32 { n_dofs: offset });
@@ -468,17 +480,15 @@ mod tests {
     }
 
     #[test]
-    fn continuous_column_stays_row_aligned_after_locality_sort() {
-        let design = Design::from_frame(frame(
-            vec![vec![2, 0, 1, 0]],
-            vec![vec![10.0, 20.0, 30.0, 40.0]],
-        ))
-        .unwrap();
-
-        let perm = design.obs_perm.as_ref().expect("permutation applied");
-        assert_eq!(perm, &[1, 3, 2, 0]);
-        assert_eq!(design.frame.level_column(0), [0, 0, 1, 2]);
-        assert_eq!(design.frame.loading_column(0), [20.0, 40.0, 30.0, 10.0]);
+    fn from_frame_rejects_unclaimed_loading_columns() {
+        let err = Design::from_frame(frame(vec![vec![0, 1]], vec![vec![1.0, 2.0]])).unwrap_err();
+        assert!(matches!(
+            err,
+            BuildError::UnclaimedLoadingColumns {
+                claimed: 0,
+                provided: 1
+            }
+        ));
     }
 
     #[test]

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 use rayon::prelude::*;
 
 use super::level_moments::{BasisScratch, LevelMoments, TermMoments};
-use super::Design;
+use super::{row_weight, Design};
 use crate::channel::Channel;
 use crate::BuildWarning;
 
@@ -21,7 +21,7 @@ const ROWS_PER_TASK: usize = 1 << 16;
 
 pub(crate) fn detect_collinear_slopes(
     design: &Design<'_>,
-    weights: Option<&[f64]>,
+    sqrt_weights: Option<&[f64]>,
     moments: &TermMoments,
 ) -> Vec<BuildWarning> {
     if design.n_factors() < 2 {
@@ -32,7 +32,7 @@ pub(crate) fn detect_collinear_slopes(
         .into_par_iter()
         .flat_map_iter(move |term| {
             let targets = screened_covariates(design, term);
-            residual_shares(design, weights, moments, term, &targets, budget)
+            residual_shares(design, sqrt_weights, moments, term, &targets, budget)
                 .into_iter()
                 .zip(targets)
                 .filter(|&(share, _)| share <= COLLINEARITY_TOL)
@@ -59,7 +59,7 @@ fn screened_covariates(design: &Design<'_>, term: usize) -> Vec<(Channel, u32)> 
 /// Two passes, so the share resolves below the `1e-16` a subtraction floors at.
 fn residual_shares(
     design: &Design<'_>,
-    weights: Option<&[f64]>,
+    sqrt_weights: Option<&[f64]>,
     moments: &TermMoments,
     term: usize,
     targets: &[(Channel, u32)],
@@ -85,7 +85,7 @@ fn residual_shares(
     let plan = ScreenPlan::new(budget, n_levels, stride);
     let screen = Screen {
         levels,
-        weights,
+        sqrt_weights,
         zs,
         columns,
         zeros: vec![0.0; moments.n_slopes()],
@@ -132,7 +132,7 @@ fn residual_shares(
 
 struct Screen<'a> {
     levels: &'a [u32],
-    weights: Option<&'a [f64]>,
+    sqrt_weights: Option<&'a [f64]>,
     zs: Vec<&'a [f64]>,
     columns: Vec<&'a [f64]>,
     zeros: Vec<f64>,
@@ -151,7 +151,7 @@ impl Screen<'_> {
     ) -> impl Iterator<Item = (usize, f64, usize)> + '_ {
         rows.filter_map(move |i| {
             let obs = self.order.obs(i);
-            let w = self.weights.map_or(1.0, |w| w[obs]);
+            let w = row_weight(self.sqrt_weights, obs);
             (w > 0.0).then(|| (obs, w, self.levels[obs] as usize - first))
         })
     }

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -139,7 +139,7 @@ impl CrossTab {
     /// Reuses pre-computed active flags instead of rescanning; diagonals come back separately.
     pub(crate) fn build_for_pair_with_active(
         design: &Design<'_>,
-        weights: Option<&[f64]>,
+        sqrt_weights: Option<&[f64]>,
         pair: ChannelPair,
         all_active: &[Vec<bool>],
     ) -> Option<(Self, BlockDiagonals, Vec<u32>)> {
@@ -150,7 +150,7 @@ impl CrossTab {
             design.terms[pair.cols.term].column_base(pair.cols.column),
         )?;
 
-        let (c, row_diag, col_diag) = accumulate_cross_block(design, weights, pair, &active);
+        let (c, row_diag, col_diag) = accumulate_cross_block(design, sqrt_weights, pair, &active);
         let ct = c.transpose();
         let cross_tab = CrossTab { c, ct };
         let diagonals = BlockDiagonals {

--- a/crates/within/src/domain/cross_tab/accumulate.rs
+++ b/crates/within/src/domain/cross_tab/accumulate.rs
@@ -10,7 +10,7 @@
 
 use crate::channel::ChannelPair;
 use crate::csr_block::CsrBlock;
-use crate::domain::Design;
+use crate::domain::{row_weight, Design};
 
 use super::{to_u32, ActiveLevels};
 use crate::domain::Loading as ColumnLoading;
@@ -57,7 +57,7 @@ pub(super) struct PairColumns<'a, Lq: Loading, Lr: Loading> {
     pub(super) col_levels: &'a [u32],
     pub(super) row_load: Lq,
     pub(super) col_load: Lr,
-    pub(super) weights: Option<&'a [f64]>,
+    pub(super) sqrt_weights: Option<&'a [f64]>,
 }
 
 impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
@@ -69,7 +69,7 @@ impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
         if cj == u32::MAX || ck == u32::MAX {
             return None;
         }
-        let w = self.weights.map_or(1.0, |w| w[uid]);
+        let w = row_weight(self.sqrt_weights, uid);
         let l_row = self.row_load.at(uid);
         let l_col = self.col_load.at(uid);
         Some(Contribution {
@@ -85,7 +85,7 @@ impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
 /// Accumulate into `C` plus diagonals, dispatching dense or sparse by peak transient memory.
 pub(super) fn accumulate_cross_block(
     design: &Design<'_>,
-    weights: Option<&[f64]>,
+    sqrt_weights: Option<&[f64]>,
     pair: ChannelPair,
     active: &ActiveLevels,
 ) -> (CsrBlock, Vec<f64>, Vec<f64>) {
@@ -112,7 +112,7 @@ pub(super) fn accumulate_cross_block(
                 col_levels,
                 row_load: Unit,
                 col_load: Unit,
-                weights,
+                sqrt_weights,
             },
             active,
             go_sparse,
@@ -123,7 +123,7 @@ pub(super) fn accumulate_cross_block(
                 col_levels,
                 row_load: zq,
                 col_load: Unit,
-                weights,
+                sqrt_weights,
             },
             active,
             go_sparse,
@@ -134,7 +134,7 @@ pub(super) fn accumulate_cross_block(
                 col_levels,
                 row_load: Unit,
                 col_load: zr,
-                weights,
+                sqrt_weights,
             },
             active,
             go_sparse,
@@ -145,7 +145,7 @@ pub(super) fn accumulate_cross_block(
                 col_levels,
                 row_load: zq,
                 col_load: zr,
-                weights,
+                sqrt_weights,
             },
             active,
             go_sparse,

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -332,7 +332,7 @@ fn dense_and_sparse_paths_agree_on_signed_data() {
         col_levels: design.frame.level_column(1),
         row_load: design.frame.loading_column(0),
         col_load: Unit,
-        weights: None,
+        sqrt_weights: None,
     };
     let (c_dense, dq_dense, dr_dense) = accumulate_dense_cross_block(cols, &active);
     let (c_sparse, dq_sparse, dr_sparse) = accumulate_sparse_cross_block(cols, &active);

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -35,7 +35,7 @@ pub(crate) struct LocalDomain {
 /// Same-factor channel pairs are exactly orthogonal after whitening, so never enumerated.
 pub(crate) fn build_local_domains(
     design: &Design<'_>,
-    weights: Option<&[f64]>,
+    sqrt_weights: Option<&[f64]>,
     config: &LocalSolverConfig,
 ) -> Result<(Vec<LocalDomain>, Vec<BuildWarning>), BuildError> {
     use rayon::prelude::*;
@@ -65,7 +65,7 @@ pub(crate) fn build_local_domains(
         .par_iter()
         .map(|&pair| {
             let Some((full_ct, full_diag, l2g)) =
-                CrossTab::build_for_pair_with_active(design, weights, pair, &all_active)
+                CrossTab::build_for_pair_with_active(design, sqrt_weights, pair, &all_active)
             else {
                 return Ok((Vec::new(), Vec::new()));
             };

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -3,7 +3,7 @@
 
 use rayon::prelude::*;
 
-use super::Design;
+use super::{row_weight, Design};
 
 /// Relative rank tolerance: a slope direction drops once its remaining
 /// within-level variance falls to `RANK_TOL` × its own initial variance.
@@ -14,7 +14,7 @@ pub(crate) struct TermMoments(Vec<LevelMoments>);
 
 impl TermMoments {
     /// `None` when no term carries a covariate, so nothing downstream has work.
-    pub(crate) fn build(design: &Design<'_>, weights: Option<&[f64]>) -> Option<Self> {
+    pub(crate) fn build(design: &Design<'_>, sqrt_weights: Option<&[f64]>) -> Option<Self> {
         let has_slopes = design
             .terms
             .iter()
@@ -23,7 +23,7 @@ impl TermMoments {
             Self(
                 (0..design.terms.len())
                     .into_par_iter()
-                    .map(|term| LevelMoments::build(design, term, weights))
+                    .map(|term| LevelMoments::build(design, term, sqrt_weights))
                     .collect(),
             )
         })
@@ -60,7 +60,7 @@ fn tri_len(v: usize) -> usize {
 }
 
 impl LevelMoments {
-    fn build(design: &Design<'_>, term: usize, weights: Option<&[f64]>) -> Self {
+    fn build(design: &Design<'_>, term: usize, sqrt_weights: Option<&[f64]>) -> Self {
         let meta = &design.terms[term];
         let covariates: Box<[u32]> = meta
             .columns
@@ -86,7 +86,7 @@ impl LevelMoments {
             for (zr, col) in z_row.iter_mut().zip(&zs) {
                 *zr = col[obs];
             }
-            let w = weights.map_or(1.0, |w| w[obs]);
+            let w = row_weight(sqrt_weights, obs);
             moments.observe(level as usize, &z_row, w, &mut delta);
         }
         moments

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -99,6 +99,14 @@ pub enum BuildError {
         /// The offending value.
         value: f64,
     },
+    /// The frame carries continuous columns that no term uses as a slope.
+    #[error("frame has {provided} loading columns but the terms claim {claimed}")]
+    UnclaimedLoadingColumns {
+        /// Loading columns referenced by the terms.
+        claimed: usize,
+        /// Continuous columns in the frame.
+        provided: usize,
+    },
     /// Usually raw entity IDs passed as factor codes, inflating `n_levels = max code + 1`.
     #[error("design has {n_dofs} degrees of freedom, exceeding the u32 column-index limit")]
     DofSpaceExceedsU32 {

--- a/crates/within/src/observation.rs
+++ b/crates/within/src/observation.rs
@@ -59,6 +59,10 @@ impl<'a> ObservationFrame<'a> {
         self.categorical.len()
     }
 
+    pub(crate) fn n_loading_columns(&self) -> usize {
+        self.continuous.len()
+    }
+
     /// Level codes of factor `factor`.
     pub fn level_column(&self, factor: usize) -> &[u32] {
         &self.categorical[factor]

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -332,12 +332,12 @@ mod slope_design_tests {
     /// slope-only, and the generic V=3 fallback — against the dense reference.
     #[test]
     fn slope_matvec_and_adjoint_match_dense_reference() {
-        let n = 6;
-        let f0 = [0u32, 1, 2, 0, 1, 2];
-        let f1 = [0u32, 0, 1, 1, 2, 2];
-        let f2 = [0u32, 1, 0, 1, 0, 1];
-        let f3 = [0u32, 0, 0, 1, 1, 1];
-        let f4 = [1u32, 0, 2, 1, 0, 2];
+        let n = 12;
+        let f0: Vec<u32> = (0..n).map(|i| (i % 3) as u32).collect();
+        let f1: Vec<u32> = (0..n).map(|i| ((i / 2) % 3) as u32).collect();
+        let f2: Vec<u32> = (0..n).map(|i| (i % 2) as u32).collect();
+        let f3: Vec<u32> = (0..n).map(|i| (i / 6) as u32).collect();
+        let f4: Vec<u32> = (0..n).map(|i| [1u32, 0, 2, 1, 0, 2][i % 6]).collect();
         let zs: Vec<Vec<f64>> = (0..6)
             .map(|k| (0..n).map(|i| noise(k * 100 + i)).collect())
             .collect();
@@ -350,6 +350,10 @@ mod slope_design_tests {
         ];
         let design = Design::new(effects).unwrap();
         let dense = dense_matrix(&design);
+        assert!(
+            (0..design.n_dofs).all(|j| dense.iter().any(|row| row[j] != 0.0)),
+            "whitening zeroed a column; the arm's addressing would go untested"
+        );
         let op = DesignOperator::new(&design, None);
 
         let x: Vec<f64> = (0..design.n_dofs).map(|j| noise(7_000 + j)).collect();

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use crate::block_elim::BlockElimSolver;
 use crate::config::{LocalSolverConfig, PreconditionerConfig};
 use crate::domain::Loading;
-use crate::domain::{Design, LocalDomain};
+use crate::domain::{row_weight, Design, LocalDomain};
 use crate::{BuildError, BuildWarning};
 
 #[cfg(test)]
@@ -212,13 +212,13 @@ impl Operator for Preconditioner {
 
 fn build_diagonal(
     design: &Design<'_>,
-    weights: Option<&[f64]>,
+    sqrt_weights: Option<&[f64]>,
 ) -> Result<DiagonalPreconditioner, BuildError> {
     let mut diag = vec![0.0; design.n_dofs];
 
     for (factor_idx, term) in design.terms.iter().enumerate() {
         let levels = design.frame.level_column(factor_idx);
-        let w = |uid: usize| weights.map_or(1.0, |ws| ws[uid]);
+        let w = |uid: usize| row_weight(sqrt_weights, uid);
         for (column, loading) in term.columns.iter().enumerate() {
             let base = term.column_base(column);
             let slice = &mut diag[base..base + term.n_levels];
@@ -256,10 +256,10 @@ fn build_diagonal(
     })
 }
 
-/// Build a [`Preconditioner`] from a design and optional weights, plus any warnings.
+/// Build a [`Preconditioner`] from a design and optional `√w`, plus any warnings.
 pub(crate) fn build_preconditioner(
     design: &Design<'_>,
-    weights: Option<&[f64]>,
+    sqrt_weights: Option<&[f64]>,
     config: Option<&PreconditionerConfig>,
 ) -> Result<(Option<Preconditioner>, Vec<BuildWarning>), BuildError> {
     use crate::domain::build_local_domains;
@@ -277,7 +277,7 @@ pub(crate) fn build_preconditioner(
             local_solver,
             reduction,
         } => {
-            let (domains, warnings) = build_local_domains(design, weights, local_solver)?;
+            let (domains, warnings) = build_local_domains(design, sqrt_weights, local_solver)?;
             if domains.is_empty() {
                 // No factor-pair subdomains means no useful Schwarz; fall back to plain LSMR.
                 return Ok((None, warnings));
@@ -287,7 +287,7 @@ pub(crate) fn build_preconditioner(
             (Variant::Additive(preconditioner), warnings)
         }
         PreconditionerConfig::Diagonal => {
-            let preconditioner = build_diagonal(design, weights)?;
+            let preconditioner = build_diagonal(design, sqrt_weights)?;
             (Variant::Diagonal(preconditioner), Vec::new())
         }
     };

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -304,9 +304,7 @@ impl BatchSolveResult {
 /// Python boundary — uses owned columns.
 pub struct Solver<'a> {
     design: Design<'a>,
-    /// `sqrt(W)` in the design's internal observation order, computed once and
-    /// borrowed by the per-RHS [`DesignOperator`]s (raw weights are needed only
-    /// during construction).
+    /// `W^{1/2}` in the design's internal observation order; the only form of the weights kept.
     sqrt_weights: Option<Vec<f64>>,
     preconditioner: Option<Preconditioner>,
     reparam: Option<SlopeReparam>,
@@ -362,13 +360,17 @@ impl<'a> Solver<'a> {
     ) -> Result<Self, BuildError> {
         let mut design = design.into_design()?;
         design.validate_weights(weights)?;
-        let weights = weights.map(|w| design.permute_obs_in(w));
+        let sqrt_weights: Option<Vec<f64>> = weights.map(|w| {
+            let w = design.permute_obs_in(w);
+            w.iter().map(|wi| wi.sqrt()).collect()
+        });
+        let sw = sqrt_weights.as_deref();
 
         // Both readers below need the raw loadings, so the moments precede whitening.
-        let moments = TermMoments::build(&design, weights.as_deref());
+        let moments = TermMoments::build(&design, sw);
         let mut warnings = moments
             .as_ref()
-            .map(|m| detect_collinear_slopes(&design, weights.as_deref(), m))
+            .map(|m| detect_collinear_slopes(&design, sw, m))
             .unwrap_or_default();
 
         // Reparametrize the slope columns (if any) before the preconditioner reads the frame.
@@ -377,12 +379,8 @@ impl<'a> Solver<'a> {
             .and_then(|m| SlopeReparam::build(&mut design, m));
 
         let (preconditioner, build_warnings) = match preconditioner.into() {
-            PreconditionerInput::Default => {
-                build_preconditioner(&design, weights.as_deref(), None)?
-            }
-            PreconditionerInput::Config(c) => {
-                build_preconditioner(&design, weights.as_deref(), Some(&c))?
-            }
+            PreconditionerInput::Default => build_preconditioner(&design, sw, None)?,
+            PreconditionerInput::Config(c) => build_preconditioner(&design, sw, Some(&c))?,
             PreconditionerInput::Prebuilt(p) => {
                 if p.nrows() != design.n_dofs || p.ncols() != design.n_dofs {
                     return Err(BuildError::PreconditionerDimensionMismatch {
@@ -396,8 +394,6 @@ impl<'a> Solver<'a> {
         };
 
         warnings.extend(build_warnings);
-
-        let sqrt_weights = weights.map(|w| w.iter().map(|wi| wi.sqrt()).collect());
 
         Ok(Self {
             design,

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -301,8 +301,7 @@ impl BatchSolveResult {
 ///
 /// Ownership: each observation column is borrowed or owned independently
 /// (`Cow`); a solver that outlives its inputs — e.g. one returned across the
-/// Python boundary — uses owned columns. Weights are always owned; for a
-/// one-shot weighted solve from a borrowed slice, use the free [`solve`] function.
+/// Python boundary — uses owned columns.
 pub struct Solver<'a> {
     design: Design<'a>,
     /// `sqrt(W)` in the design's internal observation order, computed once and
@@ -351,26 +350,19 @@ impl<'a> Solver<'a> {
     /// - `PreconditionerConfig::Diagonal` — use diagonal/Jacobi preconditioning
     /// - [`Preconditioner`] or `&Preconditioner` — reuse a previously built one
     ///
-    /// `weights` is `None` for unweighted, or an owned `Vec<f64>` that the
-    /// solver takes ownership of (it re-reads the weights on every solve). To
-    /// solve once from a borrowed slice, use the free [`solve`] function.
+    /// `weights` is `None` for unweighted; the solver keeps only `√w` in its own order.
     ///
     /// LSMR tuning ([`LsmrOptions`]) is supplied per call to [`Solver::solve`] /
     /// [`Solver::solve_batch`], not at construction; preconditioner factorization
     /// state is the only expensive thing built here.
     pub fn new(
         design: impl IntoDesign<'a>,
-        weights: Option<Vec<f64>>,
+        weights: Option<&[f64]>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
         let mut design = design.into_design()?;
-        design.validate_weights(weights.as_deref())?;
-
-        // The match keeps the unpermuted arm a plain move rather than a borrow-and-copy.
-        let weights = match &design.obs_perm {
-            Some(_) => weights.map(|w| design.permute_obs_in(&w).into_owned()),
-            None => weights,
-        };
+        design.validate_weights(weights)?;
+        let weights = weights.map(|w| design.permute_obs_in(w));
 
         // Both readers below need the raw loadings, so the moments precede whitening.
         let moments = TermMoments::build(&design, weights.as_deref());
@@ -405,12 +397,7 @@ impl<'a> Solver<'a> {
 
         warnings.extend(build_warnings);
 
-        let sqrt_weights = weights.map(|mut w| {
-            for wi in &mut w {
-                *wi = wi.sqrt();
-            }
-            w
-        });
+        let sqrt_weights = weights.map(|w| w.iter().map(|wi| wi.sqrt()).collect());
 
         Ok(Self {
             design,
@@ -627,7 +614,7 @@ pub fn solve<'a, 'o>(
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<SolveResult, WithinError> {
     let t_start = Instant::now();
-    let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
+    let solver = Solver::new(design, weights, preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve(y, lsmr)?;
     // Include solver construction (preconditioner build) in setup time
@@ -648,7 +635,7 @@ pub fn solve_batch<'a, 'o>(
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<BatchSolveResult, WithinError> {
     let t_start = Instant::now();
-    let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
+    let solver = Solver::new(design, weights, preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve_batch(ys, lsmr)?;
     result.time_setup += time_setup;

--- a/crates/within/src/solver/reparam.rs
+++ b/crates/within/src/solver/reparam.rs
@@ -23,10 +23,8 @@ pub(crate) struct SlopeReparam {
 struct TermReparam {
     offset: usize,
     n_levels: usize,
-    /// Coefficient column of the term's constant, if it has one.
-    intercept_column: Option<usize>,
-    /// Coefficient column of each covariate, in order.
-    slope_columns: Box<[usize]>,
+    /// Slopes start at column 1 behind an intercept, at 0 without one.
+    intercept: bool,
     transforms: Vec<LevelTransform>,
 }
 
@@ -81,15 +79,7 @@ impl TermReparam {
     ) -> Self {
         let meta = &design.terms[term];
         let (offset, n_levels) = (meta.offset, meta.n_levels);
-        let mut intercept_column = None;
-        let mut slope_columns = Vec::new();
-        for (column, loading) in meta.columns.iter().enumerate() {
-            match loading.covariate() {
-                Some(_) => slope_columns.push(column),
-                None => intercept_column = Some(column),
-            }
-        }
-        let intercept = intercept_column.is_some();
+        let intercept = meta.columns.iter().any(|l| l.covariate().is_none());
         let moments = &moments[term];
         let v = moments.n_slopes();
         let z_cols: Vec<usize> = moments.covariates().iter().map(|&c| c as usize).collect();
@@ -116,7 +106,7 @@ impl TermReparam {
                     unidentified.push(CoefficientAddress {
                         channel: Channel {
                             term,
-                            column: slope_columns[j],
+                            column: j + intercept as usize,
                         },
                         level,
                     });
@@ -150,8 +140,7 @@ impl TermReparam {
         Self {
             offset,
             n_levels,
-            intercept_column,
-            slope_columns: slope_columns.into(),
+            intercept,
             transforms,
         }
     }
@@ -159,7 +148,7 @@ impl TermReparam {
     /// Map this term's solve-basis coefficients back to the user's
     /// parametrization; slots outside the term's block are untouched.
     fn back_transform(&self, x: &mut [f64]) {
-        let v = self.slope_columns.len();
+        let v = self.transforms.first().map_or(0, |t| t.center.len());
         let mut b = vec![0.0; v];
         for (l, t) in self.transforms.iter().enumerate() {
             if t.w.is_empty() {
@@ -175,13 +164,13 @@ impl TermReparam {
             for (j, &bj) in b.iter().enumerate() {
                 x[self.slope_slot(j, l)] = bj;
             }
-            if let Some(c) = self.intercept_column {
-                x[self.offset + c * self.n_levels + l] -= dot(&b, &t.center);
+            if self.intercept {
+                x[self.offset + l] -= dot(&b, &t.center);
             }
         }
     }
 
     fn slope_slot(&self, j: usize, level: usize) -> usize {
-        self.offset + self.slope_columns[j] * self.n_levels + level
+        self.offset + (j + self.intercept as usize) * self.n_levels + level
     }
 }

--- a/crates/within/tests/api_pinning.rs
+++ b/crates/within/tests/api_pinning.rs
@@ -85,13 +85,9 @@ fn solver_new_weights_call_shapes_compile() {
     let categories = cats();
     let w_vec: Vec<f64> = vec![1.0; 4];
 
-    // Bare `None` — infers, because `weights` is the concrete `Option<Vec<f64>>`
-    // (no turbofish needed). The persistent solver owns its weights; borrow-based
-    // one-shot weighting lives on the free `solve` function instead.
+    // Bare `None` infers, because `weights` is the concrete `Option<&[f64]>`.
     let _ = Solver::new(categories.view(), None, None).expect("None weights");
-
-    // Owned `Vec<f64>` weights — moved into the solver.
-    let _ = Solver::new(categories.view(), Some(w_vec), None).expect("Vec<f64> weights");
+    let _ = Solver::new(categories.view(), Some(&w_vec), None).expect("borrowed weights");
 }
 
 #[test]

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -46,7 +46,7 @@ fn test_weight_count_mismatch_error() {
     )
     .expect("frame ok");
     let design = Design::from_frame(frame).expect("valid design");
-    let result = Solver::new(design, Some(vec![1.0, 2.0]), None);
+    let result = Solver::new(design, Some(&[1.0, 2.0]), None);
     let err = result.expect_err("expected WeightCountMismatch error, got Ok");
     match err {
         BuildError::WeightCountMismatch { .. } => {}

--- a/crates/within/tests/orchestrate_solve.rs
+++ b/crates/within/tests/orchestrate_solve.rs
@@ -88,7 +88,7 @@ fn test_lsmr_least_squares_weighted_preconditioned() {
         ..Default::default()
     };
     let precond = PreconditionerConfig::default();
-    let solver = Solver::new(design, Some(weights.clone()), &precond).expect("build solver");
+    let solver = Solver::new(design, Some(&weights), &precond).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_solution_finite(&result);

--- a/crates/within/tests/properties.rs
+++ b/crates/within/tests/properties.rs
@@ -121,7 +121,7 @@ proptest! {
             maxiter: 2000,
             local_size: Some(10),
         };
-        let result = Solver::new(effects, Some(weights.clone()), PreconditionerConfig::default())
+        let result = Solver::new(effects, Some(weights), PreconditionerConfig::default())
             .expect("build solver")
             .solve(y.as_slice(), &params)
             .expect("solve");

--- a/crates/within/tests/slopes.rs
+++ b/crates/within/tests/slopes.rs
@@ -54,7 +54,7 @@ fn solve_with(
     levels: &[u32],
     z: &[f64],
     intercept: bool,
-    weights: Option<Vec<f64>>,
+    weights: Option<&[f64]>,
     y: &[f64],
     config: &PreconditionerConfig,
 ) -> SolveResult {
@@ -72,7 +72,7 @@ fn solve_single(
     levels: &[u32],
     z: &[f64],
     intercept: bool,
-    weights: Option<Vec<f64>>,
+    weights: Option<&[f64]>,
     y: &[f64],
 ) -> SolveResult {
     solve_with(
@@ -201,7 +201,7 @@ fn weighted_solve_matches_closed_form_and_masks_zero_weight_rows() {
     let w: Vec<f64> = vec![1.0, 0.5, 2.0, 1.5, 3.0, 1.0, 1.0, 1.0, 0.0];
     let y = synthetic_y(levels.len());
 
-    let r = solve_single(&levels, &z, true, Some(w.clone()), &y);
+    let r = solve_single(&levels, &z, true, Some(&w), &y);
     assert!(r.converged);
     assert_eq!(drops(&r), [(0, 2, 1)]);
     assert_eq!(r.x[3 + 2], 0.0);
@@ -222,8 +222,7 @@ fn zero_weight_garbage_does_not_poison_identification() {
     let z: Vec<f64> = vec![1.0, 2.0, 3.0, 5.0, 7.0, 1e300];
     let w: Vec<f64> = vec![1.0, 1.0, 1.0, 1.0, 1.0, 0.0];
     let y = synthetic_y(levels.len());
-    let run =
-        |config: &PreconditionerConfig| solve_with(&levels, &z, true, Some(w.clone()), &y, config);
+    let run = |config: &PreconditionerConfig| solve_with(&levels, &z, true, Some(&w), &y, config);
 
     let r = run(&PreconditionerConfig::default());
     assert!(r.unidentified.is_empty());

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -314,11 +314,11 @@ fn test_internal_locality_sort_is_transparent() {
     let params = default_params();
     let precond = additive_precond();
 
-    let make_solver = |weights: Option<Vec<f64>>| {
+    let make_solver = |weights: Option<&[f64]>| {
         let design = common::make_design(vec![col0.clone(), col1.clone()]).expect("design");
         Solver::new(design, weights, &precond).expect("solver")
     };
-    let make_oracle = |weights: Option<Vec<f64>>| {
+    let make_oracle = |weights: Option<&[f64]>| {
         let frame =
             ObservationFrame::new(vec![col0.clone().into(), col1.clone().into()], Vec::new())
                 .expect("frame");
@@ -327,10 +327,8 @@ fn test_internal_locality_sort_is_transparent() {
     };
 
     // The weighted run also exercises the weights-permutation path.
-    for weights in [None, Some(w)] {
-        let oracle = make_oracle(weights.clone())
-            .solve(&y, &params)
-            .expect("oracle");
+    for weights in [None, Some(&w[..])] {
+        let oracle = make_oracle(weights).solve(&y, &params).expect("oracle");
         let sorted = make_solver(weights).solve(&y, &params).expect("sorted");
         common::assert_solutions_close(&sorted.x, &oracle.x, 1e-7);
         common::assert_solutions_close(&sorted.demeaned, &oracle.demeaned, 1e-7);


### PR DESCRIPTION
Independent simplifications split out of #340; both PRs are against `main` and touch `Solver::new`, so whichever lands second rebases.

- `Solver::new` takes `weights: Option<&[f64]>`. Raw weights are read only during construction, so the owned `Vec` bought nothing but a copy in `solve`, `solve_batch` and the Python `Solver`. Public signature change on the unreleased 0.4.0; `api_pinning.rs` pins the new form.
- Only `√w` is kept. The operator applies `s = √w` to rows, so the normal matrix LSMR minimizes over is `Dᵀ diag(s²) D`; moments, the collinearity screen, the cross-tab accumulation and the diagonal preconditioner read `s²` through one `row_weight` helper instead of a second raw-weights vector. Single-threaded A/B against main on a 40k-row 3FE + 2-slope design: unweighted bitwise identical, weighted coefficients move 1.6e-12 relative, iteration counts equal (13 and 153). An earlier 5M-row interleaved run showed setup and solve time unchanged.
- `TermReparam` keeps `intercept: bool` instead of re-deriving `intercept_column` and `slope_columns`. The intercept-first column layout is what `Effect::new`, `Channel` and `SolveResult::x` already promise.
- `Design::build` rejects continuous frame columns no term claims (`BuildError::UnclaimedLoadingColumns`) instead of silently ignoring them. The test that relied on such a column duplicated `observation::columns_stay_row_aligned_under_permutation` and is dropped.
- The kernel-arm test uses four rows per level, so no whitened column is all zeros and every arm's addressing is exercised; it now asserts that.

284 Rust tests, 106 Python tests, clippy clean.
