### PR TITLE
Let the collinearity screen reuse the whitened columns

### DIFF
--- a/crates/within-py/src/api.rs
+++ b/crates/within-py/src/api.rs
@@ -25,7 +25,7 @@ use crate::results::{
 fn build_and_solve<'a>(
     design: impl IntoDesign<'a>,
     y: &[f64],
-    weights: Option<&[f64]>,
+    weights: Option<Vec<f64>>,
     lsmr: &LsmrOptions,
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(SolveResult, Vec<BuildWarning>), WithinError> {
@@ -42,7 +42,7 @@ fn build_and_solve<'a>(
 fn build_and_solve_batch<'a>(
     design: impl IntoDesign<'a>,
     ys: &[&[f64]],
-    weights: Option<&[f64]>,
+    weights: Option<Vec<f64>>,
     lsmr: &LsmrOptions,
     precond: impl Into<PreconditionerInput>,
 ) -> Result<(BatchSolveResult, Vec<BuildWarning>), WithinError> {
@@ -79,15 +79,19 @@ pub fn solve<'py>(
             let cats = categories.as_array();
             run_solve_with_warnings(py, move || {
                 let y_cow = coerce_to_slice(&y_arr);
-                let w_cow = w_view.as_ref().map(coerce_to_slice);
-                build_and_solve(cats, &y_cow, w_cow.as_deref(), &params, precond)
+                build_and_solve(cats, &y_cow, w_view.map(|w| w.to_vec()), &params, precond)
             })
         }
         DesignSource::Effects(terms) => run_solve_with_warnings(py, move || {
             let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
             let y_cow = coerce_to_slice(&y_arr);
-            let w_cow = w_view.as_ref().map(coerce_to_slice);
-            build_and_solve(effects, &y_cow, w_cow.as_deref(), &params, precond)
+            build_and_solve(
+                effects,
+                &y_cow,
+                w_view.map(|w| w.to_vec()),
+                &params,
+                precond,
+            )
         }),
     }
 }
@@ -117,8 +121,13 @@ pub fn solve_batch<'py>(
             run_batch_with_warnings(py, move || {
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
-                let w_cow = w_view.as_ref().map(coerce_to_slice);
-                build_and_solve_batch(cats, &col_refs, w_cow.as_deref(), &params, precond)
+                build_and_solve_batch(
+                    cats,
+                    &col_refs,
+                    w_view.map(|w| w.to_vec()),
+                    &params,
+                    precond,
+                )
             })
         }
         DesignSource::Effects(terms) => {
@@ -129,8 +138,13 @@ pub fn solve_batch<'py>(
                 let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                 let columns = extract_columns(&y_arr);
                 let col_refs = column_refs(&columns);
-                let w_cow = w_view.as_ref().map(coerce_to_slice);
-                build_and_solve_batch(effects, &col_refs, w_cow.as_deref(), &params, precond)
+                build_and_solve_batch(
+                    effects,
+                    &col_refs,
+                    w_view.map(|w| w.to_vec()),
+                    &params,
+                    precond,
+                )
             })
         }
     }
@@ -239,7 +253,7 @@ impl PySolver {
         preconditioner: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Self> {
         let weights = weights.map(|w| readonly_f64_1d("weights", w)).transpose()?;
-        let w_view = weights.as_ref().map(|w| w.as_array());
+        let weights_vec: Option<Vec<f64>> = weights.as_ref().map(|w| w.as_array().to_vec());
         let precond = resolve_precond_input(preconditioner)?;
 
         // `BuildError` carries no Python types, so it maps to an exception once the GIL is back.
@@ -247,8 +261,7 @@ impl PySolver {
             DesignSource::Categories(categories) => {
                 let cats = categories.as_array();
                 py.detach(move || -> Result<Solver<'static>, BuildError> {
-                    let w_cow = w_view.as_ref().map(coerce_to_slice);
-                    Solver::new(cats.into_design()?.into_owned(), w_cow.as_deref(), precond)
+                    Solver::new(cats.into_design()?.into_owned(), weights_vec, precond)
                 })
             }
             DesignSource::Effects(terms) => {
@@ -256,8 +269,7 @@ impl PySolver {
                     let effects: Vec<_> = terms.iter().map(PyEffect::as_effect).collect();
                     // The solver outlives the terms' buffers, so lower to owned columns first.
                     let design = Design::new(effects)?.into_owned();
-                    let w_cow = w_view.as_ref().map(coerce_to_slice);
-                    Solver::new(design, w_cow.as_deref(), precond)
+                    Solver::new(design, weights_vec, precond)
                 })
             }
         }

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -4,7 +4,7 @@ pub(crate) mod collinearity;
 pub(crate) mod cross_tab;
 mod effect;
 pub(crate) mod factor_pairs;
-pub(crate) mod level_moments;
+mod level_moments;
 mod prepared;
 mod reparam;
 
@@ -95,6 +95,19 @@ pub(crate) struct TermMeta {
 }
 
 impl TermMeta {
+    /// Frame columns of the term's covariates, in coefficient-column order.
+    pub(crate) fn covariates(&self) -> impl Iterator<Item = u32> + '_ {
+        self.columns.iter().filter_map(|c| c.covariate().copied())
+    }
+
+    pub(crate) fn has_slopes(&self) -> bool {
+        self.covariates().next().is_some()
+    }
+
+    pub(crate) fn has_intercept(&self) -> bool {
+        self.columns.iter().any(|c| c.covariate().is_none())
+    }
+
     pub fn n_columns(&self) -> usize {
         self.columns.len()
     }

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -4,13 +4,13 @@ pub(crate) mod collinearity;
 pub(crate) mod cross_tab;
 mod effect;
 pub(crate) mod factor_pairs;
-mod level_moments;
+pub(crate) mod level_moments;
 mod prepared;
-mod slope_basis;
+mod reparam;
 
 pub(crate) use cross_tab::{find_all_active_levels, BlockDiagonals, CrossTab};
-pub(crate) use prepared::{row_weight, PreparedDesign};
-use slope_basis::SlopeBasis;
+pub(crate) use prepared::PreparedDesign;
+use reparam::SlopeReparam;
 
 pub use effect::Effect;
 
@@ -95,19 +95,6 @@ pub(crate) struct TermMeta {
 }
 
 impl TermMeta {
-    /// Frame columns of the term's covariates, in coefficient-column order.
-    pub(crate) fn covariates(&self) -> impl Iterator<Item = u32> + '_ {
-        self.columns.iter().filter_map(|c| c.covariate().copied())
-    }
-
-    pub(crate) fn has_slopes(&self) -> bool {
-        self.covariates().next().is_some()
-    }
-
-    pub(crate) fn has_intercept(&self) -> bool {
-        self.columns.iter().any(|c| c.covariate().is_none())
-    }
-
     pub fn n_columns(&self) -> usize {
         self.columns.len()
     }

--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -237,14 +237,6 @@ impl<'a> Design<'a> {
             terms.push(meta);
         }
 
-        let claimed: usize = terms.iter().map(|t| t.covariates().count()).sum();
-        if claimed != frame.n_loading_columns() {
-            return Err(BuildError::UnclaimedLoadingColumns {
-                claimed,
-                provided: frame.n_loading_columns(),
-            });
-        }
-
         // Rejected here rather than left to panic in `to_u32`.
         if u32::try_from(offset).is_err() {
             return Err(BuildError::DofSpaceExceedsU32 { n_dofs: offset });
@@ -283,6 +275,27 @@ impl<'a> Design<'a> {
             n_dofs: self.n_dofs,
             obs_perm: self.obs_perm,
         }
+    }
+
+    /// Validate that an optional weight slice matches this design's observation count.
+    pub(crate) fn validate_weights(&self, weights: Option<&[f64]>) -> Result<(), BuildError> {
+        if let Some(w) = weights {
+            if w.len() != self.n_obs {
+                return Err(BuildError::WeightCountMismatch {
+                    expected: self.n_obs,
+                    got: w.len(),
+                });
+            }
+            // `wi >= 0.0` already rejects NaN; `is_finite` additionally rejects `+∞`.
+            if let Some((index, &value)) = w
+                .iter()
+                .enumerate()
+                .find(|&(_, &wi)| !(wi >= 0.0 && wi.is_finite()))
+            {
+                return Err(BuildError::InvalidWeight { index, value });
+            }
+        }
+        Ok(())
     }
 
     /// Caller order → internal order: `out[k] = v[obs_perm[k]]`; borrows when unpermuted.
@@ -409,14 +422,30 @@ mod tests {
     }
 
     #[test]
-    fn from_frame_rejects_unclaimed_loading_columns() {
-        let err = Design::from_frame(frame(vec![vec![0, 1]], vec![vec![1.0, 2.0]])).unwrap_err();
+    fn validate_weights_checks_count_and_finiteness() {
+        let design = Design::from_frame(frame(vec![vec![0, 0, 0, 0, 0]], vec![])).unwrap();
+        assert!(design.validate_weights(None).is_ok());
+        assert!(design
+            .validate_weights(Some(&[1.0, 2.0, 3.0, 4.0, 5.0]))
+            .is_ok());
+        // Zero weights are valid (an excluded observation).
+        assert!(design
+            .validate_weights(Some(&[0.0, 1.0, 2.0, 3.0, 4.0]))
+            .is_ok());
+        // Length mismatch.
+        assert!(design.validate_weights(Some(&[1.0, 2.0])).is_err());
+        // Negative / non-finite weights are rejected with the offending index.
         assert!(matches!(
-            err,
-            BuildError::UnclaimedLoadingColumns {
-                claimed: 0,
-                provided: 1
-            }
+            design.validate_weights(Some(&[1.0, -2.0, 3.0, 4.0, 5.0])),
+            Err(BuildError::InvalidWeight { index: 1, .. })
+        ));
+        assert!(matches!(
+            design.validate_weights(Some(&[1.0, 2.0, f64::NAN, 4.0, 5.0])),
+            Err(BuildError::InvalidWeight { index: 2, .. })
+        ));
+        assert!(matches!(
+            design.validate_weights(Some(&[1.0, 2.0, 3.0, f64::INFINITY, 5.0])),
+            Err(BuildError::InvalidWeight { index: 3, .. })
         ));
     }
 
@@ -454,6 +483,20 @@ mod tests {
         assert!(design.obs_perm.is_none());
         assert!(design.terms[0].sorted);
         assert!(!design.terms[1].sorted);
+    }
+
+    #[test]
+    fn continuous_column_stays_row_aligned_after_locality_sort() {
+        let design = Design::from_frame(frame(
+            vec![vec![2, 0, 1, 0]],
+            vec![vec![10.0, 20.0, 30.0, 40.0]],
+        ))
+        .unwrap();
+
+        let perm = design.obs_perm.as_deref().expect("permutation applied");
+        assert_eq!(perm, [1, 3, 2, 0]);
+        assert_eq!(design.frame.level_column(0), [0, 0, 1, 2]);
+        assert_eq!(design.frame.loading_column(0), [20.0, 40.0, 30.0, 10.0]);
     }
 
     #[test]

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -5,7 +5,8 @@ use std::ops::Range;
 
 use rayon::prelude::*;
 
-use super::{row_weight, Design, PreparedDesign, TermMeta};
+use super::level_moments::{BasisScratch, LevelMoments, TermMoments};
+use super::Design;
 use crate::channel::Channel;
 use crate::BuildWarning;
 
@@ -18,9 +19,12 @@ const TABLE_BUDGET_BYTES: usize = 64 << 20;
 /// Rows one residual task claims; small enough that work stealing balances the tail.
 const ROWS_PER_TASK: usize = 1 << 16;
 
-pub(crate) fn detect_collinear_slopes(prepared: &PreparedDesign<'_>) -> Vec<BuildWarning> {
-    let design = &prepared.design;
-    if design.n_factors() < 2 || !design.terms.iter().any(TermMeta::has_slopes) {
+pub(crate) fn detect_collinear_slopes(
+    design: &Design<'_>,
+    weights: Option<&[f64]>,
+    moments: &TermMoments,
+) -> Vec<BuildWarning> {
+    if design.n_factors() < 2 {
         return Vec::new();
     }
     let budget = TABLE_BUDGET_BYTES / std::mem::size_of::<f64>() / design.n_factors();
@@ -28,7 +32,7 @@ pub(crate) fn detect_collinear_slopes(prepared: &PreparedDesign<'_>) -> Vec<Buil
         .into_par_iter()
         .flat_map_iter(move |term| {
             let targets = screened_covariates(design, term);
-            residual_shares(prepared, term, &targets, budget)
+            residual_shares(design, weights, moments, term, &targets, budget)
                 .into_iter()
                 .zip(targets)
                 .filter(|&(share, _)| share <= COLLINEARITY_TOL)
@@ -54,7 +58,9 @@ fn screened_covariates(design: &Design<'_>, term: usize) -> Vec<(Channel, u32)> 
 
 /// Two passes, so the share resolves below the `1e-16` a subtraction floors at.
 fn residual_shares(
-    prepared: &PreparedDesign<'_>,
+    design: &Design<'_>,
+    weights: Option<&[f64]>,
+    moments: &TermMoments,
     term: usize,
     targets: &[(Channel, u32)],
     budget: usize,
@@ -63,37 +69,36 @@ fn residual_shares(
     if m == 0 {
         return Vec::new();
     }
-    let (design, sqrt_weights) = (&prepared.design, prepared.sqrt_weights.as_deref());
-    let meta = &design.terms[term];
+    let moments = &moments[term];
     let levels = design.frame.level_column(term);
-    let us: Vec<&[f64]> = meta
+    let zs: Vec<&[f64]> = moments
         .covariates()
-        .map(|c| prepared.basis.loading_column(c as usize))
+        .iter()
+        .map(|&c| design.frame.loading_column(c as usize))
         .collect();
-    let intercept = meta.has_intercept();
     let columns: Vec<&[f64]> = targets
         .iter()
         .map(|&(_, c)| design.frame.loading_column(c as usize))
         .collect();
-    let stride = columns.len() * (us.len() + 1);
-    let n_levels = meta.n_levels;
+    let stride = columns.len() * (zs.len() + 1);
+    let n_levels = moments.n_levels();
     let plan = ScreenPlan::new(budget, n_levels, stride);
     let screen = Screen {
         levels,
-        sqrt_weights,
-        us,
+        weights,
+        zs,
         columns,
-        intercept,
+        zeros: vec![0.0; moments.n_slopes()],
+        moments,
         stride,
         // Grouping gathers every column, so it must buy back more than the one block.
-        order: match meta.sorted || plan.per_block == n_levels {
+        order: match design.terms[term].sorted || plan.per_block == n_levels {
             true => RowOrder::AsIs,
             false => RowOrder::Grouped(super::stable_argsort(levels, n_levels)),
         },
     };
 
     let mut table = vec![0.0f64; plan.per_block * stride];
-    let mut level_weight = vec![0.0f64; plan.per_block];
     let mut residual = vec![0.0f64; m];
     let mut variations = Variations {
         w_sum: 0.0,
@@ -105,14 +110,13 @@ fn residual_shares(
             levels: levels_block,
         };
         let table = &mut table[..block.levels.len() * stride];
-        let level_weight = &mut level_weight[..block.levels.len()];
         table.fill(0.0);
-        level_weight.fill(0.0);
-        screen.accumulate_cross(&block, table, level_weight, &mut variations);
-        screen.to_coefficients(table, level_weight);
+        screen.accumulate_cross(&block, table, &mut variations);
+        screen.to_coefficients(&block, table);
         screen.accumulate_residual(&block, table, &mut residual);
     }
 
+    let intercept = moments.intercept();
     residual
         .iter()
         .zip(&variations.stats)
@@ -128,13 +132,13 @@ fn residual_shares(
 
 struct Screen<'a> {
     levels: &'a [u32],
-    sqrt_weights: Option<&'a [f64]>,
-    /// The term's slope columns in the solve basis.
-    us: Vec<&'a [f64]>,
+    weights: Option<&'a [f64]>,
+    zs: Vec<&'a [f64]>,
     columns: Vec<&'a [f64]>,
-    intercept: bool,
+    zeros: Vec<f64>,
+    moments: &'a LevelMoments,
     order: RowOrder,
-    /// One level's row of the table: `[Σw·c, Σw·u·c]` per target.
+    /// One level's row of the table: `[Σw·c, Σw·z·c]` per target.
     stride: usize,
 }
 
@@ -147,26 +151,27 @@ impl Screen<'_> {
     ) -> impl Iterator<Item = (usize, f64, usize)> + '_ {
         rows.filter_map(move |i| {
             let obs = self.order.obs(i);
-            let w = row_weight(self.sqrt_weights, obs);
+            let w = self.weights.map_or(1.0, |w| w[obs]);
             (w > 0.0).then(|| (obs, w, self.levels[obs] as usize - first))
         })
     }
 
+    /// Without an intercept the level's span holds no constant, so `z` enters uncentered.
+    fn center(&self, level: usize) -> &[f64] {
+        match self.moments.intercept() {
+            true => self.moments.mean(level),
+            false => &self.zeros,
+        }
+    }
+
     /// Each target's total variation rides this pass, since the rows are already loaded.
-    fn accumulate_cross(
-        &self,
-        block: &Block,
-        table: &mut [f64],
-        level_weight: &mut [f64],
-        variations: &mut Variations,
-    ) {
-        let v = self.us.len();
+    fn accumulate_cross(&self, block: &Block, table: &mut [f64], variations: &mut Variations) {
+        let v = self.zs.len();
         let stride = self.stride;
         let Variations { w_sum, stats } = variations;
         let mut running = *w_sum;
         for (obs, w, row) in self.active_rows(block.levels.start, block.rows.clone()) {
             running += w;
-            level_weight[row] += w;
             // Every target shares the running weight, so the Welford ratio is taken once.
             let ratio = w / running;
             for ((slot, column), stat) in table[row * stride..][..stride]
@@ -178,25 +183,58 @@ impl Screen<'_> {
                 stat.observe(c, w, ratio);
                 let wc = w * c;
                 slot[0] += wc;
-                for (s, u) in slot[1..].iter_mut().zip(&self.us) {
-                    *s += wc * u[obs];
+                for (s, z) in slot[1..].iter_mut().zip(&self.zs) {
+                    *s += wc * z[obs];
                 }
             }
         }
         *w_sum = running;
     }
 
-    /// `Σw·c` becomes the constant `c̄`; `Σw·u·c` is already the slope since `u` is orthonormal.
-    fn to_coefficients(&self, table: &mut [f64], level_weight: &[f64]) {
-        let v = self.us.len();
-        for (row, &w_sum) in table.chunks_exact_mut(self.stride).zip(level_weight) {
-            for slot in row.chunks_exact_mut(v + 1) {
-                slot[0] = match self.intercept && w_sum > 0.0 {
-                    true => slot[0] / w_sum,
-                    false => 0.0,
-                };
-            }
-        }
+    /// Rewrites a level's cross moments as the coefficients `[c̄, β]` of `c`'s fit on its span.
+    fn to_coefficients(&self, block: &Block, table: &mut [f64]) {
+        let v = self.zs.len();
+        let intercept = self.moments.intercept();
+        table
+            .par_chunks_exact_mut(self.stride)
+            .enumerate()
+            .for_each_init(
+                || (BasisScratch::new(v), vec![0.0f64; v]),
+                |(scratch, d), (offset, row)| {
+                    let level = block.levels.start + offset;
+                    let w_sum = self.moments.w_sum(level);
+                    if w_sum <= 0.0 {
+                        debug_assert!(
+                            row.iter().all(|&x| x == 0.0),
+                            "level {level} carries cross moments the term's weights deny"
+                        );
+                        return;
+                    }
+                    if v > 0 {
+                        self.moments.basis(level, scratch);
+                    }
+                    let center = self.center(level);
+                    for slot in row.chunks_exact_mut(v + 1) {
+                        let sum_wc = slot[0];
+                        for ((dj, &xj), &cj) in d.iter_mut().zip(&slot[1..]).zip(center) {
+                            *dj = xj - sum_wc * cj;
+                        }
+                        slot[0] = match intercept {
+                            true => sum_wc / w_sum,
+                            false => 0.0,
+                        };
+                        slot[1..].fill(0.0);
+                        if v > 0 {
+                            for q in scratch.basis.chunks_exact(v) {
+                                let projection = crate::linalg::dot(q, d);
+                                for (b, &qj) in slot[1..].iter_mut().zip(q) {
+                                    *b += projection * qj;
+                                }
+                            }
+                        }
+                    }
+                },
+            );
     }
 
     /// Adds each target's `Σw·(c − ĉ)²` from the coefficients left in `table`.
@@ -206,7 +244,7 @@ impl Screen<'_> {
         if block.rows.is_empty() {
             return;
         }
-        let v = self.us.len();
+        let v = self.zs.len();
         let stride = self.stride;
         let first = block.levels.start;
         let tasks = block.rows.len().div_ceil(ROWS_PER_TASK);
@@ -214,20 +252,23 @@ impl Screen<'_> {
             .into_par_iter()
             .map_init(
                 || vec![0.0f64; v],
-                |u_row, task| {
+                |dz, task| {
                     let mut totals = vec![0.0f64; self.columns.len()];
                     let start = block.rows.start + task * ROWS_PER_TASK;
                     let rows = start..(start + ROWS_PER_TASK).min(block.rows.end);
                     for (obs, w, row) in self.active_rows(first, rows) {
-                        for (uj, u) in u_row.iter_mut().zip(&self.us) {
-                            *uj = u[obs];
+                        for (dzj, (z, &cj)) in dz
+                            .iter_mut()
+                            .zip(self.zs.iter().zip(self.center(first + row)))
+                        {
+                            *dzj = z[obs] - cj;
                         }
                         for ((slot, column), total) in table[row * stride..][..stride]
                             .chunks_exact(v + 1)
                             .zip(&self.columns)
                             .zip(&mut totals)
                         {
-                            let r = column[obs] - slot[0] - crate::linalg::dot(&slot[1..], u_row);
+                            let r = column[obs] - slot[0] - crate::linalg::dot(&slot[1..], dz);
                             *total += w * r * r;
                         }
                     }

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -5,8 +5,7 @@ use std::ops::Range;
 
 use rayon::prelude::*;
 
-use super::level_moments::{BasisScratch, LevelMoments, TermMoments};
-use super::Design;
+use super::{Design, PreparedDesign, TermMeta};
 use crate::channel::Channel;
 use crate::BuildWarning;
 
@@ -20,11 +19,11 @@ const TABLE_BUDGET_BYTES: usize = 64 << 20;
 const ROWS_PER_TASK: usize = 1 << 16;
 
 pub(crate) fn detect_collinear_slopes(
-    design: &Design<'_>,
+    prepared: &PreparedDesign<'_>,
     weights: Option<&[f64]>,
-    moments: &TermMoments,
 ) -> Vec<BuildWarning> {
-    if design.n_factors() < 2 {
+    let design = &prepared.design;
+    if design.n_factors() < 2 || !design.terms.iter().any(TermMeta::has_slopes) {
         return Vec::new();
     }
     let budget = TABLE_BUDGET_BYTES / std::mem::size_of::<f64>() / design.n_factors();
@@ -32,7 +31,7 @@ pub(crate) fn detect_collinear_slopes(
         .into_par_iter()
         .flat_map_iter(move |term| {
             let targets = screened_covariates(design, term);
-            residual_shares(design, weights, moments, term, &targets, budget)
+            residual_shares(prepared, weights, term, &targets, budget)
                 .into_iter()
                 .zip(targets)
                 .filter(|&(share, _)| share <= COLLINEARITY_TOL)
@@ -58,9 +57,8 @@ fn screened_covariates(design: &Design<'_>, term: usize) -> Vec<(Channel, u32)> 
 
 /// Two passes, so the share resolves below the `1e-16` a subtraction floors at.
 fn residual_shares(
-    design: &Design<'_>,
+    prepared: &PreparedDesign<'_>,
     weights: Option<&[f64]>,
-    moments: &TermMoments,
     term: usize,
     targets: &[(Channel, u32)],
     budget: usize,
@@ -69,36 +67,37 @@ fn residual_shares(
     if m == 0 {
         return Vec::new();
     }
-    let moments = &moments[term];
+    let design = &prepared.design;
+    let meta = &design.terms[term];
     let levels = design.frame.level_column(term);
-    let zs: Vec<&[f64]> = moments
+    let us: Vec<&[f64]> = meta
         .covariates()
-        .iter()
-        .map(|&c| design.frame.loading_column(c as usize))
+        .map(|c| prepared.loading_column(c as usize))
         .collect();
+    let intercept = meta.has_intercept();
     let columns: Vec<&[f64]> = targets
         .iter()
         .map(|&(_, c)| design.frame.loading_column(c as usize))
         .collect();
-    let stride = columns.len() * (zs.len() + 1);
-    let n_levels = moments.n_levels();
+    let stride = columns.len() * (us.len() + 1);
+    let n_levels = meta.n_levels;
     let plan = ScreenPlan::new(budget, n_levels, stride);
     let screen = Screen {
         levels,
         weights,
-        zs,
+        us,
         columns,
-        zeros: vec![0.0; moments.n_slopes()],
-        moments,
+        intercept,
         stride,
         // Grouping gathers every column, so it must buy back more than the one block.
-        order: match design.terms[term].sorted || plan.per_block == n_levels {
+        order: match meta.sorted || plan.per_block == n_levels {
             true => RowOrder::AsIs,
             false => RowOrder::Grouped(super::stable_argsort(levels, n_levels)),
         },
     };
 
     let mut table = vec![0.0f64; plan.per_block * stride];
+    let mut level_weight = vec![0.0f64; plan.per_block];
     let mut residual = vec![0.0f64; m];
     let mut variations = Variations {
         w_sum: 0.0,
@@ -110,13 +109,14 @@ fn residual_shares(
             levels: levels_block,
         };
         let table = &mut table[..block.levels.len() * stride];
+        let level_weight = &mut level_weight[..block.levels.len()];
         table.fill(0.0);
-        screen.accumulate_cross(&block, table, &mut variations);
-        screen.to_coefficients(&block, table);
+        level_weight.fill(0.0);
+        screen.accumulate_cross(&block, table, level_weight, &mut variations);
+        screen.to_coefficients(table, level_weight);
         screen.accumulate_residual(&block, table, &mut residual);
     }
 
-    let intercept = moments.intercept();
     residual
         .iter()
         .zip(&variations.stats)
@@ -133,12 +133,12 @@ fn residual_shares(
 struct Screen<'a> {
     levels: &'a [u32],
     weights: Option<&'a [f64]>,
-    zs: Vec<&'a [f64]>,
+    /// The term's slope columns in the solve basis.
+    us: Vec<&'a [f64]>,
     columns: Vec<&'a [f64]>,
-    zeros: Vec<f64>,
-    moments: &'a LevelMoments,
+    intercept: bool,
     order: RowOrder,
-    /// One level's row of the table: `[Σw·c, Σw·z·c]` per target.
+    /// One level's row of the table: `[Σw·c, Σw·u·c]` per target.
     stride: usize,
 }
 
@@ -156,22 +156,21 @@ impl Screen<'_> {
         })
     }
 
-    /// Without an intercept the level's span holds no constant, so `z` enters uncentered.
-    fn center(&self, level: usize) -> &[f64] {
-        match self.moments.intercept() {
-            true => self.moments.mean(level),
-            false => &self.zeros,
-        }
-    }
-
     /// Each target's total variation rides this pass, since the rows are already loaded.
-    fn accumulate_cross(&self, block: &Block, table: &mut [f64], variations: &mut Variations) {
-        let v = self.zs.len();
+    fn accumulate_cross(
+        &self,
+        block: &Block,
+        table: &mut [f64],
+        level_weight: &mut [f64],
+        variations: &mut Variations,
+    ) {
+        let v = self.us.len();
         let stride = self.stride;
         let Variations { w_sum, stats } = variations;
         let mut running = *w_sum;
         for (obs, w, row) in self.active_rows(block.levels.start, block.rows.clone()) {
             running += w;
+            level_weight[row] += w;
             // Every target shares the running weight, so the Welford ratio is taken once.
             let ratio = w / running;
             for ((slot, column), stat) in table[row * stride..][..stride]
@@ -183,58 +182,25 @@ impl Screen<'_> {
                 stat.observe(c, w, ratio);
                 let wc = w * c;
                 slot[0] += wc;
-                for (s, z) in slot[1..].iter_mut().zip(&self.zs) {
-                    *s += wc * z[obs];
+                for (s, u) in slot[1..].iter_mut().zip(&self.us) {
+                    *s += wc * u[obs];
                 }
             }
         }
         *w_sum = running;
     }
 
-    /// Rewrites a level's cross moments as the coefficients `[c̄, β]` of `c`'s fit on its span.
-    fn to_coefficients(&self, block: &Block, table: &mut [f64]) {
-        let v = self.zs.len();
-        let intercept = self.moments.intercept();
-        table
-            .par_chunks_exact_mut(self.stride)
-            .enumerate()
-            .for_each_init(
-                || (BasisScratch::new(v), vec![0.0f64; v]),
-                |(scratch, d), (offset, row)| {
-                    let level = block.levels.start + offset;
-                    let w_sum = self.moments.w_sum(level);
-                    if w_sum <= 0.0 {
-                        debug_assert!(
-                            row.iter().all(|&x| x == 0.0),
-                            "level {level} carries cross moments the term's weights deny"
-                        );
-                        return;
-                    }
-                    if v > 0 {
-                        self.moments.basis(level, scratch);
-                    }
-                    let center = self.center(level);
-                    for slot in row.chunks_exact_mut(v + 1) {
-                        let sum_wc = slot[0];
-                        for ((dj, &xj), &cj) in d.iter_mut().zip(&slot[1..]).zip(center) {
-                            *dj = xj - sum_wc * cj;
-                        }
-                        slot[0] = match intercept {
-                            true => sum_wc / w_sum,
-                            false => 0.0,
-                        };
-                        slot[1..].fill(0.0);
-                        if v > 0 {
-                            for q in scratch.basis.chunks_exact(v) {
-                                let projection = crate::linalg::dot(q, d);
-                                for (b, &qj) in slot[1..].iter_mut().zip(q) {
-                                    *b += projection * qj;
-                                }
-                            }
-                        }
-                    }
-                },
-            );
+    /// `Σw·c` becomes the constant `c̄`; `Σw·u·c` is already the slope since `u` is orthonormal.
+    fn to_coefficients(&self, table: &mut [f64], level_weight: &[f64]) {
+        let v = self.us.len();
+        for (row, &w_sum) in table.chunks_exact_mut(self.stride).zip(level_weight) {
+            for slot in row.chunks_exact_mut(v + 1) {
+                slot[0] = match self.intercept && w_sum > 0.0 {
+                    true => slot[0] / w_sum,
+                    false => 0.0,
+                };
+            }
+        }
     }
 
     /// Adds each target's `Σw·(c − ĉ)²` from the coefficients left in `table`.
@@ -244,7 +210,7 @@ impl Screen<'_> {
         if block.rows.is_empty() {
             return;
         }
-        let v = self.zs.len();
+        let v = self.us.len();
         let stride = self.stride;
         let first = block.levels.start;
         let tasks = block.rows.len().div_ceil(ROWS_PER_TASK);
@@ -252,23 +218,20 @@ impl Screen<'_> {
             .into_par_iter()
             .map_init(
                 || vec![0.0f64; v],
-                |dz, task| {
+                |u_row, task| {
                     let mut totals = vec![0.0f64; self.columns.len()];
                     let start = block.rows.start + task * ROWS_PER_TASK;
                     let rows = start..(start + ROWS_PER_TASK).min(block.rows.end);
                     for (obs, w, row) in self.active_rows(first, rows) {
-                        for (dzj, (z, &cj)) in dz
-                            .iter_mut()
-                            .zip(self.zs.iter().zip(self.center(first + row)))
-                        {
-                            *dzj = z[obs] - cj;
+                        for (uj, u) in u_row.iter_mut().zip(&self.us) {
+                            *uj = u[obs];
                         }
                         for ((slot, column), total) in table[row * stride..][..stride]
                             .chunks_exact(v + 1)
                             .zip(&self.columns)
                             .zip(&mut totals)
                         {
-                            let r = column[obs] - slot[0] - crate::linalg::dot(&slot[1..], dz);
+                            let r = column[obs] - slot[0] - crate::linalg::dot(&slot[1..], u_row);
                             *total += w * r * r;
                         }
                     }

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -5,9 +5,8 @@ use crate::Effect;
 const FULL_TABLE: usize = 1 << 24;
 
 fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usize)> {
-    let prepared =
-        PreparedDesign::new(design.clone(), weights.map(<[f64]>::to_vec)).expect("valid weights");
-    detect_collinear_slopes(&prepared)
+    let moments = TermMoments::build(design, weights).expect("design carries slopes");
+    detect_collinear_slopes(design, weights, &moments)
         .into_iter()
         .map(|w| match w {
             BuildWarning::CollinearSlopeCovariate { slope, term, .. } => (slope, term),
@@ -18,13 +17,9 @@ fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usi
 
 /// The shares `term`'s screen reports, in target-channel order.
 fn shares(design: &Design<'_>, term: usize, budget: usize) -> Vec<f64> {
+    let moments = TermMoments::build(design, None).expect("design carries slopes");
     let targets = screened_covariates(design, term);
-    residual_shares(
-        &PreparedDesign::unweighted_for_test(design.clone()),
-        term,
-        &targets,
-        budget,
-    )
+    residual_shares(design, None, &moments, term, &targets, budget)
 }
 
 fn two_factor_levels(n: usize) -> (Vec<u32>, Vec<u32>) {
@@ -169,6 +164,8 @@ fn zero_weight_rows_are_excluded_from_the_screen() {
         Effect::new(&b, true, [&spoiled[..]]).unwrap(),
     ])
     .unwrap();
+    // The screen reads frame order, so caller weights go through the locality permutation.
+    let weights = design.permute_obs_in(&weights).into_owned();
     assert!(!warn_pairs(&design, Some(&weights)).is_empty());
     assert_eq!(warn_pairs(&design, None), Vec::new());
 }

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -5,7 +5,8 @@ use crate::Effect;
 const FULL_TABLE: usize = 1 << 24;
 
 fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usize)> {
-    let prepared = PreparedDesign::new(design.clone(), weights).expect("valid weights");
+    let prepared =
+        PreparedDesign::new(design.clone(), weights.map(<[f64]>::to_vec)).expect("valid weights");
     detect_collinear_slopes(&prepared)
         .into_iter()
         .map(|w| match w {

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -5,8 +5,8 @@ use crate::Effect;
 const FULL_TABLE: usize = 1 << 24;
 
 fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usize)> {
-    let moments = TermMoments::build(design, weights).expect("design carries slopes");
-    detect_collinear_slopes(design, weights, &moments)
+    let prepared = PreparedDesign::new(design.clone(), weights);
+    detect_collinear_slopes(&prepared, weights)
         .into_iter()
         .map(|w| match w {
             BuildWarning::CollinearSlopeCovariate { slope, term, .. } => (slope, term),
@@ -17,9 +17,9 @@ fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usi
 
 /// The shares `term`'s screen reports, in target-channel order.
 fn shares(design: &Design<'_>, term: usize, budget: usize) -> Vec<f64> {
-    let moments = TermMoments::build(design, None).expect("design carries slopes");
+    let prepared = PreparedDesign::unweighted_for_test(design.clone());
     let targets = screened_covariates(design, term);
-    residual_shares(design, None, &moments, term, &targets, budget)
+    residual_shares(&prepared, None, term, &targets, budget)
 }
 
 fn two_factor_levels(n: usize) -> (Vec<u32>, Vec<u32>) {

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -139,6 +139,7 @@ impl CrossTab {
     /// Reuses pre-computed active flags instead of rescanning; diagonals come back separately.
     pub(crate) fn build_for_pair_with_active(
         prepared: &PreparedDesign<'_>,
+        weights: Option<&[f64]>,
         pair: ChannelPair,
         all_active: &[Vec<bool>],
     ) -> Option<(Self, BlockDiagonals, Vec<u32>)> {
@@ -150,7 +151,7 @@ impl CrossTab {
             design.terms[pair.cols.term].column_base(pair.cols.column),
         )?;
 
-        let (c, row_diag, col_diag) = accumulate_cross_block(prepared, pair, &active);
+        let (c, row_diag, col_diag) = accumulate_cross_block(prepared, weights, pair, &active);
         let ct = c.transpose();
         let cross_tab = CrossTab { c, ct };
         let diagonals = BlockDiagonals {

--- a/crates/within/src/domain/cross_tab/accumulate.rs
+++ b/crates/within/src/domain/cross_tab/accumulate.rs
@@ -10,7 +10,7 @@
 
 use crate::channel::ChannelPair;
 use crate::csr_block::CsrBlock;
-use crate::domain::{row_weight, PreparedDesign};
+use crate::domain::PreparedDesign;
 
 use super::{to_u32, ActiveLevels};
 use crate::domain::Loading as ColumnLoading;
@@ -57,7 +57,7 @@ pub(super) struct PairColumns<'a, Lq: Loading, Lr: Loading> {
     pub(super) col_levels: &'a [u32],
     pub(super) row_load: Lq,
     pub(super) col_load: Lr,
-    pub(super) sqrt_weights: Option<&'a [f64]>,
+    pub(super) weights: Option<&'a [f64]>,
 }
 
 impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
@@ -69,7 +69,7 @@ impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
         if cj == u32::MAX || ck == u32::MAX {
             return None;
         }
-        let w = row_weight(self.sqrt_weights, uid);
+        let w = self.weights.map_or(1.0, |w| w[uid]);
         let l_row = self.row_load.at(uid);
         let l_col = self.col_load.at(uid);
         Some(Contribution {
@@ -85,11 +85,11 @@ impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
 /// Accumulate into `C` plus diagonals, dispatching dense or sparse by peak transient memory.
 pub(super) fn accumulate_cross_block(
     prepared: &PreparedDesign<'_>,
+    weights: Option<&[f64]>,
     pair: ChannelPair,
     active: &ActiveLevels,
 ) -> (CsrBlock, Vec<f64>, Vec<f64>) {
     let design = &prepared.design;
-    let sqrt_weights = prepared.sqrt_weights.as_deref();
     // Dispatching on cell count alone would pick sparse where it uses MORE memory.
     let table_size = active.n_rows.saturating_mul(active.n_cols);
     let dense_cost = table_size.saturating_mul(8);
@@ -100,7 +100,7 @@ pub(super) fn accumulate_cross_block(
     let col_levels = design.frame.level_column(pair.cols.term);
     let load = |col: ColumnLoading<u32>| {
         col.covariate()
-            .map(|&c| prepared.basis.loading_column(c as usize))
+            .map(|&c| prepared.loading_column(c as usize))
     };
     // One arm per loading combination; closures aren't generic, so the literals repeat.
     match (
@@ -113,7 +113,7 @@ pub(super) fn accumulate_cross_block(
                 col_levels,
                 row_load: Unit,
                 col_load: Unit,
-                sqrt_weights,
+                weights,
             },
             active,
             go_sparse,
@@ -124,7 +124,7 @@ pub(super) fn accumulate_cross_block(
                 col_levels,
                 row_load: zq,
                 col_load: Unit,
-                sqrt_weights,
+                weights,
             },
             active,
             go_sparse,
@@ -135,7 +135,7 @@ pub(super) fn accumulate_cross_block(
                 col_levels,
                 row_load: Unit,
                 col_load: zr,
-                sqrt_weights,
+                weights,
             },
             active,
             go_sparse,
@@ -146,7 +146,7 @@ pub(super) fn accumulate_cross_block(
                 col_levels,
                 row_load: zq,
                 col_load: zr,
-                sqrt_weights,
+                weights,
             },
             active,
             go_sparse,

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -3,9 +3,10 @@ use proptest::prelude::*;
 use super::accumulate::{
     accumulate_dense_cross_block, accumulate_sparse_cross_block, PairColumns, Unit,
 };
-use super::{build_compact_mapping, find_all_active_levels, CrossTab};
+use super::{build_compact_mapping, CrossTab};
 use crate::channel::{Channel, ChannelPair};
 use crate::csr_block::CsrBlock;
+use crate::domain::find_all_active_levels;
 use crate::domain::{Design, Effect, PreparedDesign};
 
 impl CrossTab {
@@ -22,6 +23,10 @@ const INTERCEPT_PAIR: ChannelPair = ChannelPair {
     cols: Channel { term: 1, column: 0 },
 };
 
+fn design_of(columns: Vec<Vec<u32>>) -> PreparedDesign<'static> {
+    PreparedDesign::from_levels_for_test(columns)
+}
+
 #[test]
 fn test_cross_tab_sparse_accumulation_path() {
     // n_rows * n_cols > 5M triggers the sparse path; few observations keep both paths equal.
@@ -36,20 +41,19 @@ fn test_cross_tab_sparse_accumulation_path() {
     }
 
     // Sparse path (large level counts)
-    let design_sparse = PreparedDesign::from_levels_for_test(vec![fa.clone(), fb.clone()]);
+    let design_sparse = design_of(vec![fa.clone(), fb.clone()]);
     let active_sparse = find_all_active_levels(&design_sparse.design);
     let (ct_sparse, diag_sparse, _) =
-        CrossTab::build_for_pair_with_active(&design_sparse, INTERCEPT_PAIR, &active_sparse)
+        CrossTab::build_for_pair_with_active(&design_sparse, None, INTERCEPT_PAIR, &active_sparse)
             .expect("sparse cross tab should build");
 
     // Dense reference: collapse levels so n_rows * n_cols <= 5M.
     let fa_small: Vec<u32> = fa.iter().map(|&x| x % 100).collect();
     let fb_small: Vec<u32> = fb.iter().map(|&x| x % 100).collect();
-    let design_dense =
-        PreparedDesign::from_levels_for_test(vec![fa_small.clone(), fb_small.clone()]);
+    let design_dense = design_of(vec![fa_small.clone(), fb_small.clone()]);
     let active_dense = find_all_active_levels(&design_dense.design);
     let (_ct_dense, diag_dense, _) =
-        CrossTab::build_for_pair_with_active(&design_dense, INTERCEPT_PAIR, &active_dense)
+        CrossTab::build_for_pair_with_active(&design_dense, None, INTERCEPT_PAIR, &active_dense)
             .expect("dense cross tab should build");
 
     // Each observation appears exactly once in its row/col bucket.
@@ -113,10 +117,10 @@ fn test_extract_component_two_components() {
     // Two disconnected bipartite components: q/r levels {0,1} and {2,3}.
     let fa = vec![0u32, 0, 1, 1, 2, 2, 3, 3];
     let fb = vec![0u32, 1, 0, 1, 2, 3, 2, 3];
-    let design = PreparedDesign::from_levels_for_test(vec![fa, fb]);
+    let design = design_of(vec![fa, fb]);
     let all_active = find_all_active_levels(&design.design);
     let (ct, parent_diag, _) =
-        CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
+        CrossTab::build_for_pair_with_active(&design, None, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
     let components = ct.bipartite_connected_components();
@@ -225,9 +229,9 @@ proptest! {
             fb.push((s % n_cols as u64) as u32);
         }
 
-        let design = PreparedDesign::from_levels_for_test(vec![fa, fb]);
+        let design = design_of(vec![fa, fb]);
         let all_active = find_all_active_levels(&design.design);
-        let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
+        let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, None, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
         let components = ct.bipartite_connected_components();
@@ -275,7 +279,7 @@ fn test_find_all_active_levels_with_gaps() {
     // Factor 0 has 5 levels but only 0, 2, 4 appear; factor 1 uses all 3.
     let fa = vec![0u32, 2, 4, 0, 2, 4];
     let fb = vec![0u32, 1, 2, 0, 1, 2];
-    let design = PreparedDesign::from_levels_for_test(vec![fa, fb]);
+    let design = design_of(vec![fa, fb]);
 
     let active = find_all_active_levels(&design.design);
 
@@ -325,7 +329,7 @@ fn dense_and_sparse_paths_agree_on_signed_data() {
         col_levels: design.frame.level_column(1),
         row_load: design.frame.loading_column(0),
         col_load: Unit,
-        sqrt_weights: None,
+        weights: None,
     };
     let (c_dense, dq_dense, dr_dense) = accumulate_dense_cross_block(cols, &active);
     let (c_sparse, dq_sparse, dr_sparse) = accumulate_sparse_cross_block(cols, &active);

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -12,7 +12,7 @@ use crate::channel::{Channel, ChannelPair};
 use crate::config::LocalSolverConfig;
 use crate::{BuildError, BuildWarning};
 
-use super::{find_all_active_levels, BlockDiagonals, CrossTab, PreparedDesign, TermMeta};
+use super::{find_all_active_levels, BlockDiagonals, CrossTab, PreparedDesign};
 
 mod sddm;
 use crate::domain::Loading;
@@ -35,6 +35,7 @@ pub(crate) struct LocalDomain {
 /// Same-factor channel pairs are exactly orthogonal after whitening, so never enumerated.
 pub(crate) fn build_local_domains(
     prepared: &PreparedDesign<'_>,
+    weights: Option<&[f64]>,
     config: &LocalSolverConfig,
 ) -> Result<(Vec<LocalDomain>, Vec<BuildWarning>), BuildError> {
     use rayon::prelude::*;
@@ -60,13 +61,13 @@ pub(crate) fn build_local_domains(
                 .map(move |&cols| ChannelPair { rows, cols })
         })
         .collect();
-
     let all_active = find_all_active_levels(design);
+
     let per_pair: Vec<(Vec<LocalDomain>, Vec<BuildWarning>)> = pairs
         .par_iter()
         .map(|&pair| {
             let Some((full_ct, full_diag, l2g)) =
-                CrossTab::build_for_pair_with_active(prepared, pair, &all_active)
+                CrossTab::build_for_pair_with_active(prepared, weights, pair, &all_active)
             else {
                 return Ok((Vec::new(), Vec::new()));
             };
@@ -88,7 +89,10 @@ pub(crate) fn build_local_domains(
     }
 
     // A slope channel breaks `1/√c`'s equal-informativeness assumption (#94), so stay uniform.
-    if !design.terms.iter().any(TermMeta::has_slopes) {
+    if !channels
+        .iter()
+        .any(|&c| design.loading(c).covariate().is_some())
+    {
         compute_partition_weights(&mut domain_pairs, design.n_dofs);
     }
 
@@ -217,8 +221,8 @@ mod tests {
     #[test]
     fn test_full_cover_domain_count() {
         let dm = make_test_design();
-        let (domain_pairs, _) =
-            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
+        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
+            .expect("plain domains build");
         // 3 factor pairs; each pair may produce multiple components
         assert!(domain_pairs.len() >= 3);
     }
@@ -226,8 +230,8 @@ mod tests {
     #[test]
     fn test_partition_of_unity() {
         let dm = make_test_design();
-        let (domain_pairs, _) =
-            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
+        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
+            .expect("plain domains build");
         let n_dofs = dm.design.n_dofs;
         // Two-sided PoU: squared weights must sum to 1 at every DOF.
         let mut weight_sq_sum = vec![0.0; n_dofs];
@@ -257,10 +261,9 @@ mod tests {
             Effect::new(&levels_c, true, []).expect("effect c"),
         ])
         .expect("valid slope design");
-        let n_dofs = design.n_dofs;
         let design = PreparedDesign::unweighted_for_test(design);
 
-        let (domain_pairs, _) = build_local_domains(&design, &LocalSolverConfig::default())
+        let (domain_pairs, _) = build_local_domains(&design, None, &LocalSolverConfig::default())
             .expect("slope domains build");
 
         for ld in &domain_pairs {
@@ -274,7 +277,7 @@ mod tests {
         }
 
         // Non-vacuity: without a shared DOF, uniform vs 1/√c weights are indistinguishable.
-        let mut counts = vec![0u32; n_dofs];
+        let mut counts = vec![0u32; design.design.n_dofs];
         for ld in &domain_pairs {
             for &idx in ld.core.global_indices() {
                 counts[idx as usize] += 1;
@@ -289,8 +292,8 @@ mod tests {
     #[test]
     fn test_domains_cover_all_dofs() {
         let dm = make_test_design();
-        let (domain_pairs, _) =
-            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
+        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
+            .expect("plain domains build");
         let mut covered = vec![false; dm.design.n_dofs];
         for ld in &domain_pairs {
             for &idx in ld.core.global_indices() {

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -1,7 +1,4 @@
-//! Per-level weighted moments of a term's loading columns, built once and read
-//! by both the collinearity screen and the slope whitening.
-
-use rayon::prelude::*;
+//! Per-level weighted moments of a term's loading columns, the input to slope whitening.
 
 use super::Design;
 
@@ -9,40 +6,10 @@ use super::Design;
 /// within-level variance falls to `RANK_TOL` × its own initial variance.
 pub(crate) const RANK_TOL: f64 = 1e-10;
 
-/// Every term's [`LevelMoments`], indexed by term.
-pub(crate) struct TermMoments(Vec<LevelMoments>);
-
-impl TermMoments {
-    /// `None` when no term carries a covariate, so nothing downstream has work.
-    pub(crate) fn build(design: &Design<'_>, weights: Option<&[f64]>) -> Option<Self> {
-        let has_slopes = design
-            .terms
-            .iter()
-            .any(|t| t.columns.iter().any(|c| c.covariate().is_some()));
-        has_slopes.then(|| {
-            Self(
-                (0..design.terms.len())
-                    .into_par_iter()
-                    .map(|term| LevelMoments::build(design, term, weights))
-                    .collect(),
-            )
-        })
-    }
-}
-
-impl std::ops::Index<usize> for TermMoments {
-    type Output = LevelMoments;
-
-    fn index(&self, term: usize) -> &LevelMoments {
-        &self.0[term]
-    }
-}
-
 /// One-pass weighted within-level moments (multivariate Welford); structural
 /// zeros stay exact, so rank drops survive a zero tolerance.
 pub(crate) struct LevelMoments {
-    /// Frame columns of the term's covariates, in coefficient-column order.
-    covariates: Box<[u32]>,
+    v: usize,
     intercept: bool,
     w_sum: Vec<f64>,
     mean: Vec<f64>,
@@ -60,26 +27,20 @@ fn tri_len(v: usize) -> usize {
 }
 
 impl LevelMoments {
-    fn build(design: &Design<'_>, term: usize, weights: Option<&[f64]>) -> Self {
+    pub(crate) fn build(design: &Design<'_>, term: usize, weights: Option<&[f64]>) -> Self {
         let meta = &design.terms[term];
-        let covariates: Box<[u32]> = meta
-            .columns
-            .iter()
-            .filter_map(|c| c.covariate().copied())
+        let zs: Vec<&[f64]> = meta
+            .covariates()
+            .map(|c| design.frame.loading_column(c as usize))
             .collect();
-        let v = covariates.len();
+        let v = zs.len();
         let mut moments = Self {
-            intercept: v < meta.columns.len(),
+            v,
+            intercept: meta.has_intercept(),
             w_sum: vec![0.0; meta.n_levels],
             mean: vec![0.0; meta.n_levels * v],
             comoment: vec![0.0; meta.n_levels * tri_len(v)],
-            covariates,
         };
-        let zs: Vec<&[f64]> = moments
-            .covariates
-            .iter()
-            .map(|&c| design.frame.loading_column(c as usize))
-            .collect();
         let mut z_row = vec![0.0; v];
         let mut delta = vec![0.0; v];
         for (obs, &level) in design.frame.level_column(term).iter().enumerate() {
@@ -96,7 +57,7 @@ impl LevelMoments {
         if w <= 0.0 {
             return;
         }
-        let v = self.n_slopes();
+        let v = self.v;
         self.w_sum[level] += w;
         let ratio = w / self.w_sum[level];
         let mean = &mut self.mean[level * v..][..v];
@@ -113,29 +74,12 @@ impl LevelMoments {
         }
     }
 
-    pub(crate) fn n_slopes(&self) -> usize {
-        self.covariates.len()
-    }
-
-    /// Frame columns of the term's covariates, in coefficient-column order.
-    pub(crate) fn covariates(&self) -> &[u32] {
-        &self.covariates
-    }
-
-    pub(crate) fn intercept(&self) -> bool {
-        self.intercept
-    }
-
-    pub(crate) fn n_levels(&self) -> usize {
-        self.w_sum.len()
-    }
-
     pub(crate) fn w_sum(&self, level: usize) -> f64 {
         self.w_sum[level]
     }
 
     pub(crate) fn mean(&self, level: usize) -> &[f64] {
-        let v = self.n_slopes();
+        let v = self.v;
         &self.mean[level * v..][..v]
     }
 
@@ -143,7 +87,7 @@ impl LevelMoments {
     /// left in `scratch` so a sweep over levels allocates nothing. `G` is
     /// centered against a pinned intercept, raw (`M2 + w·μμᵀ`) without one.
     pub(crate) fn basis(&self, level: usize, scratch: &mut BasisScratch) {
-        let v = self.n_slopes();
+        let v = self.v;
         let com = &self.comoment[level * tri_len(v)..][..tri_len(v)];
         let mean = self.mean(level);
         let w = self.w_sum[level];

--- a/crates/within/src/domain/level_moments.rs
+++ b/crates/within/src/domain/level_moments.rs
@@ -1,15 +1,48 @@
-//! Per-level weighted moments of a term's loading columns, the input to slope whitening.
+//! Per-level weighted moments of a term's loading columns, built once and read
+//! by both the collinearity screen and the slope whitening.
 
-use super::{row_weight, Design};
+use rayon::prelude::*;
+
+use super::Design;
 
 /// Relative rank tolerance: a slope direction drops once its remaining
 /// within-level variance falls to `RANK_TOL` × its own initial variance.
 pub(crate) const RANK_TOL: f64 = 1e-10;
 
+/// Every term's [`LevelMoments`], indexed by term.
+pub(crate) struct TermMoments(Vec<LevelMoments>);
+
+impl TermMoments {
+    /// `None` when no term carries a covariate, so nothing downstream has work.
+    pub(crate) fn build(design: &Design<'_>, weights: Option<&[f64]>) -> Option<Self> {
+        let has_slopes = design
+            .terms
+            .iter()
+            .any(|t| t.columns.iter().any(|c| c.covariate().is_some()));
+        has_slopes.then(|| {
+            Self(
+                (0..design.terms.len())
+                    .into_par_iter()
+                    .map(|term| LevelMoments::build(design, term, weights))
+                    .collect(),
+            )
+        })
+    }
+}
+
+impl std::ops::Index<usize> for TermMoments {
+    type Output = LevelMoments;
+
+    fn index(&self, term: usize) -> &LevelMoments {
+        &self.0[term]
+    }
+}
+
 /// One-pass weighted within-level moments (multivariate Welford); structural
 /// zeros stay exact, so rank drops survive a zero tolerance.
 pub(crate) struct LevelMoments {
-    v: usize,
+    /// Frame columns of the term's covariates, in coefficient-column order.
+    covariates: Box<[u32]>,
     intercept: bool,
     w_sum: Vec<f64>,
     mean: Vec<f64>,
@@ -27,27 +60,33 @@ fn tri_len(v: usize) -> usize {
 }
 
 impl LevelMoments {
-    pub(crate) fn build(design: &Design<'_>, term: usize, sqrt_weights: Option<&[f64]>) -> Self {
+    fn build(design: &Design<'_>, term: usize, weights: Option<&[f64]>) -> Self {
         let meta = &design.terms[term];
-        let zs: Vec<&[f64]> = meta
-            .covariates()
-            .map(|c| design.frame.loading_column(c as usize))
+        let covariates: Box<[u32]> = meta
+            .columns
+            .iter()
+            .filter_map(|c| c.covariate().copied())
             .collect();
-        let v = zs.len();
+        let v = covariates.len();
         let mut moments = Self {
-            v,
-            intercept: meta.has_intercept(),
+            intercept: v < meta.columns.len(),
             w_sum: vec![0.0; meta.n_levels],
             mean: vec![0.0; meta.n_levels * v],
             comoment: vec![0.0; meta.n_levels * tri_len(v)],
+            covariates,
         };
+        let zs: Vec<&[f64]> = moments
+            .covariates
+            .iter()
+            .map(|&c| design.frame.loading_column(c as usize))
+            .collect();
         let mut z_row = vec![0.0; v];
         let mut delta = vec![0.0; v];
         for (obs, &level) in design.frame.level_column(term).iter().enumerate() {
             for (zr, col) in z_row.iter_mut().zip(&zs) {
                 *zr = col[obs];
             }
-            let w = row_weight(sqrt_weights, obs);
+            let w = weights.map_or(1.0, |w| w[obs]);
             moments.observe(level as usize, &z_row, w, &mut delta);
         }
         moments
@@ -57,7 +96,7 @@ impl LevelMoments {
         if w <= 0.0 {
             return;
         }
-        let v = self.v;
+        let v = self.n_slopes();
         self.w_sum[level] += w;
         let ratio = w / self.w_sum[level];
         let mean = &mut self.mean[level * v..][..v];
@@ -74,12 +113,29 @@ impl LevelMoments {
         }
     }
 
+    pub(crate) fn n_slopes(&self) -> usize {
+        self.covariates.len()
+    }
+
+    /// Frame columns of the term's covariates, in coefficient-column order.
+    pub(crate) fn covariates(&self) -> &[u32] {
+        &self.covariates
+    }
+
+    pub(crate) fn intercept(&self) -> bool {
+        self.intercept
+    }
+
+    pub(crate) fn n_levels(&self) -> usize {
+        self.w_sum.len()
+    }
+
     pub(crate) fn w_sum(&self, level: usize) -> f64 {
         self.w_sum[level]
     }
 
     pub(crate) fn mean(&self, level: usize) -> &[f64] {
-        let v = self.v;
+        let v = self.n_slopes();
         &self.mean[level * v..][..v]
     }
 
@@ -87,7 +143,7 @@ impl LevelMoments {
     /// left in `scratch` so a sweep over levels allocates nothing. `G` is
     /// centered against a pinned intercept, raw (`M2 + w·μμᵀ`) without one.
     pub(crate) fn basis(&self, level: usize, scratch: &mut BasisScratch) {
-        let v = self.v;
+        let v = self.n_slopes();
         let com = &self.comoment[level * tri_len(v)..][..tri_len(v)];
         let mean = self.mean(level);
         let w = self.w_sum[level];

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -1,37 +1,27 @@
-use super::{Design, SlopeBasis};
-use crate::BuildError;
+use super::level_moments::TermMoments;
+use super::{Design, SlopeReparam};
 
-/// A [`Design`] plus what one weight vector determines: the row scaling and the slope basis.
+/// A [`Design`] plus the whitened slope basis one weight vector determines.
 pub(crate) struct PreparedDesign<'a> {
     pub(crate) design: Design<'a>,
-    /// `W^{1/2}` in internal observation order; `None` is unweighted.
-    pub(crate) sqrt_weights: Option<Vec<f64>>,
-    pub(crate) basis: SlopeBasis,
+    /// `None` for slope-free designs.
+    pub(crate) reparam: Option<SlopeReparam>,
 }
 
 impl<'a> PreparedDesign<'a> {
-    pub(crate) fn new(design: Design<'a>, weights: Option<Vec<f64>>) -> Result<Self, BuildError> {
-        design.validate_weights(weights.as_deref())?;
-        let sqrt_weights = weights.map(|w| {
-            let mut w = match &design.obs_perm {
-                Some(_) => design.permute_obs_in(&w).into_owned(),
-                None => w,
-            };
-            w.iter_mut().for_each(|wi| *wi = wi.sqrt());
-            w
-        });
-        let basis = SlopeBasis::build(&design, sqrt_weights.as_deref());
-        Ok(Self {
-            design,
-            sqrt_weights,
-            basis,
-        })
+    pub(crate) fn new(design: Design<'a>, moments: Option<&TermMoments>) -> Self {
+        let reparam = moments.and_then(|m| SlopeReparam::build(&design, m));
+        Self { design, reparam }
     }
-}
 
-/// The Gram weight of row `obs`: the operator applies `s`, so its normal matrix carries `s²`.
-pub(crate) fn row_weight(sqrt_weights: Option<&[f64]>, obs: usize) -> f64 {
-    sqrt_weights.map_or(1.0, |s| s[obs] * s[obs])
+    /// Loading column `column` in the solve basis.
+    pub(crate) fn loading_column(&self, column: usize) -> &[f64] {
+        // Only slope terms reference loading columns, and any slope term makes `reparam` `Some`.
+        self.reparam
+            .as_ref()
+            .expect("loading column on a slope-free design")
+            .loading_column(column)
+    }
 }
 
 #[cfg(test)]
@@ -41,7 +31,8 @@ mod tests {
     impl<'a> PreparedDesign<'a> {
         /// Unweighted, whitened like a solver would.
         pub(crate) fn unweighted_for_test(design: Design<'a>) -> Self {
-            Self::new(design, None).expect("unweighted preparation cannot fail")
+            let moments = TermMoments::build(&design, None);
+            Self::new(design, moments.as_ref())
         }
     }
 

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -10,8 +10,16 @@ pub(crate) struct PreparedDesign<'a> {
 }
 
 impl<'a> PreparedDesign<'a> {
-    pub(crate) fn new(design: Design<'a>, weights: Option<&[f64]>) -> Result<Self, BuildError> {
-        let sqrt_weights = weights.map(|w| sqrt_weights(&design, w)).transpose()?;
+    pub(crate) fn new(design: Design<'a>, weights: Option<Vec<f64>>) -> Result<Self, BuildError> {
+        design.validate_weights(weights.as_deref())?;
+        let sqrt_weights = weights.map(|w| {
+            let mut w = match &design.obs_perm {
+                Some(_) => design.permute_obs_in(&w).into_owned(),
+                None => w,
+            };
+            w.iter_mut().for_each(|wi| *wi = wi.sqrt());
+            w
+        });
         let basis = SlopeBasis::build(&design, sqrt_weights.as_deref());
         Ok(Self {
             design,
@@ -19,28 +27,6 @@ impl<'a> PreparedDesign<'a> {
             basis,
         })
     }
-}
-
-/// Validated `√w` in internal observation order.
-fn sqrt_weights(design: &Design<'_>, w: &[f64]) -> Result<Vec<f64>, BuildError> {
-    if w.len() != design.n_obs {
-        return Err(BuildError::WeightCountMismatch {
-            expected: design.n_obs,
-            got: w.len(),
-        });
-    }
-    // `wi >= 0.0` already rejects NaN; `is_finite` additionally rejects `+∞`.
-    if let Some((index, &value)) = w
-        .iter()
-        .enumerate()
-        .find(|&(_, &wi)| !(wi >= 0.0 && wi.is_finite()))
-    {
-        return Err(BuildError::InvalidWeight { index, value });
-    }
-    Ok(match &design.obs_perm {
-        None => w.iter().map(|wi| wi.sqrt()).collect(),
-        Some(perm) => perm.iter().map(|&i| w[i as usize].sqrt()).collect(),
-    })
 }
 
 /// The Gram weight of row `obs`: the operator applies `s`, so its normal matrix carries `s²`.
@@ -63,42 +49,5 @@ mod tests {
         pub(crate) fn from_levels_for_test(columns: Vec<Vec<u32>>) -> Self {
             Self::unweighted_for_test(Design::from_levels_for_test(columns))
         }
-    }
-
-    #[test]
-    fn weights_are_checked_for_count_and_finiteness() {
-        let design = Design::from_levels_for_test(vec![vec![0, 0, 0, 0, 0]]);
-        let check = |w: &[f64]| sqrt_weights(&design, w);
-        assert!(check(&[1.0, 2.0, 3.0, 4.0, 5.0]).is_ok());
-        // Zero weights are valid (an excluded observation).
-        assert!(check(&[0.0, 1.0, 2.0, 3.0, 4.0]).is_ok());
-        assert!(matches!(
-            check(&[1.0, 2.0]),
-            Err(BuildError::WeightCountMismatch {
-                expected: 5,
-                got: 2
-            })
-        ));
-        // Negative / non-finite weights are rejected with the offending index.
-        assert!(matches!(
-            check(&[1.0, -2.0, 3.0, 4.0, 5.0]),
-            Err(BuildError::InvalidWeight { index: 1, .. })
-        ));
-        assert!(matches!(
-            check(&[1.0, 2.0, f64::NAN, 4.0, 5.0]),
-            Err(BuildError::InvalidWeight { index: 2, .. })
-        ));
-        assert!(matches!(
-            check(&[1.0, 2.0, 3.0, f64::INFINITY, 5.0]),
-            Err(BuildError::InvalidWeight { index: 3, .. })
-        ));
-    }
-
-    #[test]
-    fn sqrt_weights_follow_the_locality_permutation() {
-        // Dominant factor [2,0,1,0] argsorts to [1,3,2,0].
-        let design = Design::from_levels_for_test(vec![vec![2, 0, 1, 0]]);
-        let s = sqrt_weights(&design, &[1.0, 4.0, 9.0, 16.0]).unwrap();
-        assert_eq!(s, [2.0, 4.0, 3.0, 1.0]);
     }
 }

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -1,4 +1,3 @@
-use super::level_moments::TermMoments;
 use super::{Design, SlopeReparam};
 
 /// A [`Design`] plus the whitened slope basis one weight vector determines.
@@ -9,8 +8,8 @@ pub(crate) struct PreparedDesign<'a> {
 }
 
 impl<'a> PreparedDesign<'a> {
-    pub(crate) fn new(design: Design<'a>, moments: Option<&TermMoments>) -> Self {
-        let reparam = moments.and_then(|m| SlopeReparam::build(&design, m));
+    pub(crate) fn new(design: Design<'a>, weights: Option<&[f64]>) -> Self {
+        let reparam = SlopeReparam::build(&design, weights);
         Self { design, reparam }
     }
 
@@ -31,8 +30,7 @@ mod tests {
     impl<'a> PreparedDesign<'a> {
         /// Unweighted, whitened like a solver would.
         pub(crate) fn unweighted_for_test(design: Design<'a>) -> Self {
-            let moments = TermMoments::build(&design, None);
-            Self::new(design, moments.as_ref())
+            Self::new(design, None)
         }
     }
 

--- a/crates/within/src/domain/reparam.rs
+++ b/crates/within/src/domain/reparam.rs
@@ -1,8 +1,6 @@
-//! Within-level orthonormal basis of a design's varying-slope terms.
+//! Within-level reparametrization of a design's varying-slope terms.
 
-use rayon::prelude::*;
-
-use super::level_moments::{BasisScratch, LevelMoments};
+use super::level_moments::{BasisScratch, TermMoments};
 use super::Design;
 use crate::channel::{Channel, CoefficientAddress};
 use crate::linalg::dot;
@@ -10,9 +8,11 @@ use crate::linalg::dot;
 #[cfg(test)]
 mod tests;
 
-/// Per-level basis making each slope term's within-level Gram the identity; empty without slopes.
-pub(crate) struct SlopeBasis {
-    terms: Vec<TermBasis>,
+/// Per-level change of basis making each slope-bearing term's within-level
+/// Gram the identity; [`Self::back_transform`] restores the user's
+/// parametrization.
+pub(crate) struct SlopeReparam {
+    terms: Vec<TermReparam>,
     /// The frame's loading columns in the solve basis, indexed like the frame's.
     loadings: Vec<Vec<f64>>,
     /// Directions the data cannot identify, ascending in `(term, level, column)`.
@@ -20,7 +20,7 @@ pub(crate) struct SlopeBasis {
 }
 
 /// One slope-bearing term's whitening state.
-struct TermBasis {
+struct TermReparam {
     offset: usize,
     n_levels: usize,
     /// Coefficient column of the term's constant, if it has one.
@@ -38,31 +38,39 @@ struct LevelTransform {
     center: Box<[f64]>,
 }
 
-impl SlopeBasis {
-    pub(crate) fn build(design: &Design<'_>, sqrt_weights: Option<&[f64]>) -> Self {
+impl SlopeReparam {
+    /// Orthonormalize every slope-bearing term's loading columns into `loadings`;
+    /// `None` for slope-free designs. Unidentified directions become
+    /// exact-zero columns, so the minimal-norm solve leaves exact-`0`
+    /// coefficients.
+    pub(crate) fn build(design: &Design<'_>, moments: &TermMoments) -> Option<Self> {
         let mut loadings = vec![Vec::new(); design.frame.n_loading_columns()];
-        let slope_terms: Vec<usize> = (0..design.terms.len())
-            .filter(|&t| design.terms[t].has_slopes())
-            .collect();
-        let moments: Vec<LevelMoments> = slope_terms
-            .par_iter()
-            .map(|&term| LevelMoments::build(design, term, sqrt_weights))
-            .collect();
+        let mut terms = Vec::new();
         let mut unidentified = Vec::new();
-        let terms = slope_terms
-            .iter()
-            .zip(&moments)
-            .map(|(&term, moments)| {
-                TermBasis::build(design, term, moments, &mut loadings, &mut unidentified)
-            })
-            .collect();
-        Self {
+        for term in 0..design.terms.len() {
+            if !design.terms[term]
+                .columns
+                .iter()
+                .any(|c| c.covariate().is_some())
+            {
+                continue;
+            }
+            terms.push(TermReparam::build(
+                design,
+                term,
+                moments,
+                &mut loadings,
+                &mut unidentified,
+            ));
+        }
+        (!terms.is_empty()).then_some(Self {
             terms,
             loadings,
             unidentified,
-        }
+        })
     }
 
+    /// Loading column `column` in the solve basis.
     pub(crate) fn loading_column(&self, column: usize) -> &[f64] {
         &self.loadings[column]
     }
@@ -75,26 +83,30 @@ impl SlopeBasis {
     }
 }
 
-impl TermBasis {
-    /// Whitens one term into `loadings`; unidentified directions append in `(level, column)` order.
+impl TermReparam {
+    /// Whiten one term's loading columns into `loadings`, appending its
+    /// unidentified directions ascending in `(level, column)`.
     fn build(
         design: &Design<'_>,
         term: usize,
-        moments: &LevelMoments,
+        moments: &TermMoments,
         loadings: &mut [Vec<f64>],
         unidentified: &mut Vec<CoefficientAddress>,
     ) -> Self {
         let meta = &design.terms[term];
         let (offset, n_levels) = (meta.offset, meta.n_levels);
-        let intercept_column = meta.columns.iter().position(|l| l.covariate().is_none());
-        let (slope_columns, z_cols): (Vec<usize>, Vec<usize>) = meta
-            .columns
-            .iter()
-            .enumerate()
-            .filter_map(|(col, l)| l.covariate().map(|&z| (col, z as usize)))
-            .unzip();
+        let mut intercept_column = None;
+        let mut slope_columns = Vec::new();
+        for (column, loading) in meta.columns.iter().enumerate() {
+            match loading.covariate() {
+                Some(_) => slope_columns.push(column),
+                None => intercept_column = Some(column),
+            }
+        }
         let intercept = intercept_column.is_some();
-        let v = slope_columns.len();
+        let moments = &moments[term];
+        let v = moments.n_slopes();
+        let z_cols: Vec<usize> = moments.covariates().iter().map(|&c| c as usize).collect();
         let levels = design.frame.level_column(term);
         let zs: Vec<&[f64]> = z_cols
             .iter()

--- a/crates/within/src/domain/reparam.rs
+++ b/crates/within/src/domain/reparam.rs
@@ -1,6 +1,8 @@
 //! Within-level reparametrization of a design's varying-slope terms.
 
-use super::level_moments::{BasisScratch, TermMoments};
+use rayon::prelude::*;
+
+use super::level_moments::{BasisScratch, LevelMoments};
 use super::Design;
 use crate::channel::{Channel, CoefficientAddress};
 use crate::linalg::dot;
@@ -43,26 +45,23 @@ impl SlopeReparam {
     /// `None` for slope-free designs. Unidentified directions become
     /// exact-zero columns, so the minimal-norm solve leaves exact-`0`
     /// coefficients.
-    pub(crate) fn build(design: &Design<'_>, moments: &TermMoments) -> Option<Self> {
+    pub(crate) fn build(design: &Design<'_>, weights: Option<&[f64]>) -> Option<Self> {
         let mut loadings = vec![Vec::new(); design.frame.n_loading_columns()];
-        let mut terms = Vec::new();
+        let slope_terms: Vec<usize> = (0..design.terms.len())
+            .filter(|&t| design.terms[t].has_slopes())
+            .collect();
+        let moments: Vec<LevelMoments> = slope_terms
+            .par_iter()
+            .map(|&term| LevelMoments::build(design, term, weights))
+            .collect();
         let mut unidentified = Vec::new();
-        for term in 0..design.terms.len() {
-            if !design.terms[term]
-                .columns
-                .iter()
-                .any(|c| c.covariate().is_some())
-            {
-                continue;
-            }
-            terms.push(TermReparam::build(
-                design,
-                term,
-                moments,
-                &mut loadings,
-                &mut unidentified,
-            ));
-        }
+        let terms: Vec<TermReparam> = slope_terms
+            .iter()
+            .zip(&moments)
+            .map(|(&term, moments)| {
+                TermReparam::build(design, term, moments, &mut loadings, &mut unidentified)
+            })
+            .collect();
         (!terms.is_empty()).then_some(Self {
             terms,
             loadings,
@@ -84,29 +83,25 @@ impl SlopeReparam {
 }
 
 impl TermReparam {
-    /// Whiten one term's loading columns into `loadings`, appending its
-    /// unidentified directions ascending in `(level, column)`.
+    /// Whitens one term into `loadings`; unidentified directions append in `(level, column)` order.
     fn build(
         design: &Design<'_>,
         term: usize,
-        moments: &TermMoments,
+        moments: &LevelMoments,
         loadings: &mut [Vec<f64>],
         unidentified: &mut Vec<CoefficientAddress>,
     ) -> Self {
         let meta = &design.terms[term];
         let (offset, n_levels) = (meta.offset, meta.n_levels);
-        let mut intercept_column = None;
-        let mut slope_columns = Vec::new();
-        for (column, loading) in meta.columns.iter().enumerate() {
-            match loading.covariate() {
-                Some(_) => slope_columns.push(column),
-                None => intercept_column = Some(column),
-            }
-        }
+        let intercept_column = meta.columns.iter().position(|l| l.covariate().is_none());
+        let (slope_columns, z_cols): (Vec<usize>, Vec<usize>) = meta
+            .columns
+            .iter()
+            .enumerate()
+            .filter_map(|(col, l)| l.covariate().map(|&z| (col, z as usize)))
+            .unzip();
         let intercept = intercept_column.is_some();
-        let moments = &moments[term];
-        let v = moments.n_slopes();
-        let z_cols: Vec<usize> = moments.covariates().iter().map(|&c| c as usize).collect();
+        let v = slope_columns.len();
         let levels = design.frame.level_column(term);
         let zs: Vec<&[f64]> = z_cols
             .iter()

--- a/crates/within/src/domain/reparam/tests.rs
+++ b/crates/within/src/domain/reparam/tests.rs
@@ -2,7 +2,6 @@
 //! not reachable through the public API.
 
 use crate::channel::Channel;
-use crate::domain::level_moments::TermMoments;
 use crate::domain::Effect;
 
 use super::*;
@@ -27,18 +26,15 @@ fn three_term_effects() -> Vec<Effect<'static>> {
 #[test]
 fn build_whitens_each_slope_bearing_term() {
     let design = Design::new(three_term_effects()).unwrap();
-    let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&design, &moments).unwrap();
-    assert!(rp.unidentified.is_empty());
+    let basis = SlopeReparam::build(&design, None).unwrap();
+    assert!(basis.unidentified.is_empty());
 
     for term in [0, 2] {
         let meta = &design.terms[term];
         let levels = design.frame.level_column(term);
         let us: Vec<&[f64]> = meta
-            .columns
-            .iter()
-            .filter_map(|c| c.covariate())
-            .map(|&k| rp.loading_column(k as usize))
+            .covariates()
+            .map(|k| basis.loading_column(k as usize))
             .collect();
         for level in 0..meta.n_levels {
             let obs: Vec<usize> = (0..levels.len())
@@ -61,6 +57,12 @@ fn build_whitens_each_slope_bearing_term() {
 }
 
 #[test]
+fn slope_free_design_has_no_reparam() {
+    let design = Design::from_levels_for_test(vec![vec![0, 1, 0], vec![0, 0, 1]]);
+    assert!(SlopeReparam::build(&design, None).is_none());
+}
+
+#[test]
 fn unidentified_directions_ascend_across_terms() {
     // Index-order term iteration keeps the list ascending without any sort.
     let f0 = [0u32, 0, 1, 1, 2, 2];
@@ -72,10 +74,9 @@ fn unidentified_directions_ascend_across_terms() {
         Effect::new(&f1, true, [&z1[..]]).unwrap(),
     ];
     let design = Design::new(effects).unwrap();
-    let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&design, &moments).unwrap();
+    let basis = SlopeReparam::build(&design, None).unwrap();
     assert_eq!(
-        rp.unidentified,
+        basis.unidentified,
         vec![
             CoefficientAddress {
                 channel: Channel { term: 0, column: 1 },
@@ -92,12 +93,11 @@ fn unidentified_directions_ascend_across_terms() {
 #[test]
 fn back_transform_leaves_other_terms_untouched() {
     let design = Design::new(three_term_effects()).unwrap();
-    let moments = TermMoments::build(&design, None).unwrap();
-    let rp = SlopeReparam::build(&design, &moments).unwrap();
+    let basis = SlopeReparam::build(&design, None).unwrap();
 
     let mut x: Vec<f64> = (0..design.n_dofs).map(|i| 1.0 + i as f64).collect();
     let before = x.clone();
-    rp.back_transform(&mut x);
+    basis.back_transform(&mut x);
 
     // Plain term 1 sits between the two slope-bearing blocks.
     let (t1, t2) = (design.terms[1].offset, design.terms[2].offset);

--- a/crates/within/src/domain/reparam/tests.rs
+++ b/crates/within/src/domain/reparam/tests.rs
@@ -2,6 +2,7 @@
 //! not reachable through the public API.
 
 use crate::channel::Channel;
+use crate::domain::level_moments::TermMoments;
 use crate::domain::Effect;
 
 use super::*;
@@ -26,15 +27,18 @@ fn three_term_effects() -> Vec<Effect<'static>> {
 #[test]
 fn build_whitens_each_slope_bearing_term() {
     let design = Design::new(three_term_effects()).unwrap();
-    let basis = SlopeBasis::build(&design, None);
-    assert!(basis.unidentified.is_empty());
+    let moments = TermMoments::build(&design, None).unwrap();
+    let rp = SlopeReparam::build(&design, &moments).unwrap();
+    assert!(rp.unidentified.is_empty());
 
     for term in [0, 2] {
         let meta = &design.terms[term];
         let levels = design.frame.level_column(term);
         let us: Vec<&[f64]> = meta
-            .covariates()
-            .map(|k| basis.loading_column(k as usize))
+            .columns
+            .iter()
+            .filter_map(|c| c.covariate())
+            .map(|&k| rp.loading_column(k as usize))
             .collect();
         for level in 0..meta.n_levels {
             let obs: Vec<usize> = (0..levels.len())
@@ -57,15 +61,6 @@ fn build_whitens_each_slope_bearing_term() {
 }
 
 #[test]
-fn slope_free_design_gets_an_empty_basis() {
-    let design = Design::from_levels_for_test(vec![vec![0, 1, 0], vec![0, 0, 1]]);
-    let basis = SlopeBasis::build(&design, None);
-    assert!(basis.terms.is_empty());
-    assert!(basis.loadings.is_empty());
-    assert!(basis.unidentified.is_empty());
-}
-
-#[test]
 fn unidentified_directions_ascend_across_terms() {
     // Index-order term iteration keeps the list ascending without any sort.
     let f0 = [0u32, 0, 1, 1, 2, 2];
@@ -77,9 +72,10 @@ fn unidentified_directions_ascend_across_terms() {
         Effect::new(&f1, true, [&z1[..]]).unwrap(),
     ];
     let design = Design::new(effects).unwrap();
-    let basis = SlopeBasis::build(&design, None);
+    let moments = TermMoments::build(&design, None).unwrap();
+    let rp = SlopeReparam::build(&design, &moments).unwrap();
     assert_eq!(
-        basis.unidentified,
+        rp.unidentified,
         vec![
             CoefficientAddress {
                 channel: Channel { term: 0, column: 1 },
@@ -96,11 +92,12 @@ fn unidentified_directions_ascend_across_terms() {
 #[test]
 fn back_transform_leaves_other_terms_untouched() {
     let design = Design::new(three_term_effects()).unwrap();
-    let basis = SlopeBasis::build(&design, None);
+    let moments = TermMoments::build(&design, None).unwrap();
+    let rp = SlopeReparam::build(&design, &moments).unwrap();
 
     let mut x: Vec<f64> = (0..design.n_dofs).map(|i| 1.0 + i as f64).collect();
     let before = x.clone();
-    basis.back_transform(&mut x);
+    rp.back_transform(&mut x);
 
     // Plain term 1 sits between the two slope-bearing blocks.
     let (t1, t2) = (design.terms[1].offset, design.terms[2].offset);

--- a/crates/within/src/domain/slope_basis.rs
+++ b/crates/within/src/domain/slope_basis.rs
@@ -23,8 +23,10 @@ pub(crate) struct SlopeBasis {
 struct TermBasis {
     offset: usize,
     n_levels: usize,
-    /// Slopes start at column 1 behind an intercept, at 0 without one.
-    intercept: bool,
+    /// Coefficient column of the term's constant, if it has one.
+    intercept_column: Option<usize>,
+    /// Coefficient column of each covariate, in order.
+    slope_columns: Box<[usize]>,
     transforms: Vec<LevelTransform>,
 }
 
@@ -84,9 +86,15 @@ impl TermBasis {
     ) -> Self {
         let meta = &design.terms[term];
         let (offset, n_levels) = (meta.offset, meta.n_levels);
-        let intercept = meta.has_intercept();
-        let z_cols: Vec<usize> = meta.covariates().map(|c| c as usize).collect();
-        let v = z_cols.len();
+        let intercept_column = meta.columns.iter().position(|l| l.covariate().is_none());
+        let (slope_columns, z_cols): (Vec<usize>, Vec<usize>) = meta
+            .columns
+            .iter()
+            .enumerate()
+            .filter_map(|(col, l)| l.covariate().map(|&z| (col, z as usize)))
+            .unzip();
+        let intercept = intercept_column.is_some();
+        let v = slope_columns.len();
         let levels = design.frame.level_column(term);
         let zs: Vec<&[f64]> = z_cols
             .iter()
@@ -110,7 +118,7 @@ impl TermBasis {
                     unidentified.push(CoefficientAddress {
                         channel: Channel {
                             term,
-                            column: j + intercept as usize,
+                            column: slope_columns[j],
                         },
                         level,
                     });
@@ -144,7 +152,8 @@ impl TermBasis {
         Self {
             offset,
             n_levels,
-            intercept,
+            intercept_column,
+            slope_columns: slope_columns.into(),
             transforms,
         }
     }
@@ -152,7 +161,7 @@ impl TermBasis {
     /// Map this term's solve-basis coefficients back to the user's
     /// parametrization; slots outside the term's block are untouched.
     fn back_transform(&self, x: &mut [f64]) {
-        let v = self.transforms.first().map_or(0, |t| t.center.len());
+        let v = self.slope_columns.len();
         let mut b = vec![0.0; v];
         for (l, t) in self.transforms.iter().enumerate() {
             if t.w.is_empty() {
@@ -168,13 +177,13 @@ impl TermBasis {
             for (j, &bj) in b.iter().enumerate() {
                 x[self.slope_slot(j, l)] = bj;
             }
-            if self.intercept {
-                x[self.offset + l] -= dot(&b, &t.center);
+            if let Some(c) = self.intercept_column {
+                x[self.offset + c * self.n_levels + l] -= dot(&b, &t.center);
             }
         }
     }
 
     fn slope_slot(&self, j: usize, level: usize) -> usize {
-        self.offset + (j + self.intercept as usize) * self.n_levels + level
+        self.offset + self.slope_columns[j] * self.n_levels + level
     }
 }

--- a/crates/within/src/error.rs
+++ b/crates/within/src/error.rs
@@ -99,14 +99,6 @@ pub enum BuildError {
         /// The offending value.
         value: f64,
     },
-    /// The frame carries continuous columns that no term uses as a slope.
-    #[error("frame has {provided} loading columns but the terms claim {claimed}")]
-    UnclaimedLoadingColumns {
-        /// Loading columns referenced by the terms.
-        claimed: usize,
-        /// Continuous columns in the frame.
-        provided: usize,
-    },
     /// Usually raw entity IDs passed as factor codes, inflating `n_levels = max code + 1`.
     #[error("design has {n_dofs} degrees of freedom, exceeding the u32 column-index limit")]
     DofSpaceExceedsU32 {

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -22,6 +22,7 @@ const PAR_THRESHOLD: usize = 10_000;
 /// Design operator `D` or `W^{1/2} D`, whose normal equations `AᵀA = DᵀWD` recover the Gramian.
 pub(crate) struct DesignOperator<'a> {
     prepared: &'a PreparedDesign<'a>,
+    sqrt_weights: Option<&'a [f64]>,
     /// Sized once to the largest term's block, so it allocates per operator, not per iteration.
     scatter_scratch: Vec<AtomicF64>,
     /// Debug-only reentry sentinel: a concurrent `apply_adjoint` would race the scratch writes.
@@ -30,11 +31,22 @@ pub(crate) struct DesignOperator<'a> {
 }
 
 impl<'a> DesignOperator<'a> {
-    pub(crate) fn new(prepared: &'a PreparedDesign<'a>) -> Self {
+    /// `sqrt_weights` must be pre-square-rooted and `design.n_obs` long.
+    pub(crate) fn new(prepared: &'a PreparedDesign<'a>, sqrt_weights: Option<&'a [f64]>) -> Self {
         let design = &prepared.design;
+        if let Some(sw) = sqrt_weights {
+            assert_eq!(
+                sw.len(),
+                design.n_obs,
+                "sqrt-weights length {} does not match design.n_obs {}",
+                sw.len(),
+                design.n_obs
+            );
+        }
         let max_block = design.terms.iter().map(|t| t.n_dofs()).max().unwrap_or(0);
         Self {
             prepared,
+            sqrt_weights,
             scatter_scratch: (0..max_block).map(|_| AtomicF64::new(0.0)).collect(),
             #[cfg(debug_assertions)]
             adjoint_active: AtomicBool::new(false),
@@ -43,7 +55,7 @@ impl<'a> DesignOperator<'a> {
 
     /// Observation-space RHS `b = W^{1/2} y`; borrows unweighted, owns weighted.
     pub(crate) fn weighted_rhs<'y>(&self, y: &'y [f64]) -> Cow<'y, [f64]> {
-        match self.prepared.sqrt_weights.as_deref() {
+        match self.sqrt_weights {
             None => Cow::Borrowed(y),
             Some(sw) => Cow::Owned(y.iter().zip(sw).map(|(&yi, &swi)| swi * yi).collect()),
         }
@@ -84,20 +96,20 @@ impl Operator for DesignOperator<'_> {
     }
 
     fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
-        debug_assert_eq!(x.len(), self.ncols());
-        debug_assert_eq!(y.len(), self.nrows());
-        gather_apply(self.prepared, x, y, self.prepared.sqrt_weights.as_deref());
+        debug_assert_eq!(x.len(), self.prepared.design.n_dofs);
+        debug_assert_eq!(y.len(), self.prepared.design.n_obs);
+        gather_apply(self.prepared, x, y, self.sqrt_weights);
         Ok(())
     }
 
     fn apply_adjoint(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
         #[cfg(debug_assertions)]
         let _guard = ReentryGuard::acquire(&self.adjoint_active);
-        debug_assert_eq!(x.len(), self.nrows());
-        debug_assert_eq!(y.len(), self.ncols());
+        debug_assert_eq!(x.len(), self.prepared.design.n_obs);
+        debug_assert_eq!(y.len(), self.prepared.design.n_dofs);
         y.fill(0.0);
         // No lock needed: `solve_batch` builds one operator per RHS, so calls are sequential.
-        match self.prepared.sqrt_weights.as_deref() {
+        match self.sqrt_weights {
             Some(sw) => scatter_apply(self.prepared, &self.scatter_scratch, y, &|i| sw[i] * x[i]),
             None => scatter_apply(self.prepared, &self.scatter_scratch, y, &|i| x[i]),
         }
@@ -118,11 +130,14 @@ mod reentry_guard_tests {
     #[test]
     #[should_panic(expected = "concurrently")]
     fn apply_adjoint_detects_in_flight_reentry() {
-        let prepared = PreparedDesign::from_levels_for_test(vec![vec![0, 1, 0]]);
-        let op = DesignOperator::new(&prepared);
+        let design = PreparedDesign::from_levels_for_test(vec![vec![0, 1, 0]]);
+        let op = DesignOperator::new(&design, None);
         // Simulate a sibling `apply_adjoint` already in flight on this operator.
         op.adjoint_active.store(true, Ordering::Release);
-        op.apply_adjoint(&vec![0.0; op.nrows()], &mut vec![0.0; op.ncols()])
-            .expect("unreachable: the guard panics before returning");
+        op.apply_adjoint(
+            &vec![0.0; op.prepared.design.n_obs],
+            &mut vec![0.0; op.prepared.design.n_dofs],
+        )
+        .expect("unreachable: the guard panics before returning");
     }
 }

--- a/crates/within/src/operator/design/gather.rs
+++ b/crates/within/src/operator/design/gather.rs
@@ -20,33 +20,34 @@ pub(crate) fn gather_apply(
 
     dst.fill(0.0);
 
+    let frame = &design.frame;
     for_each_chunk(dst, |chunk, row_start| {
         for (q, t) in design.terms.iter().enumerate() {
             let (offset, n_levels) = (t.offset, t.n_levels);
-            let levels = design.frame.level_column(q);
+            let levels = frame.level_column(q);
             let col = |c: usize| &src[offset + c * n_levels..offset + (c + 1) * n_levels];
             match &*t.columns {
                 [Loading::Constant] => gather_term(chunk, row_start, levels, [col(0)], |_| [1.0]),
                 [Loading::Constant, Loading::Covariate(c0)] => {
-                    let z0 = prepared.basis.loading_column(*c0 as usize);
+                    let z0 = prepared.loading_column(*c0 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1)], |i| [1.0, z0[i]])
                 }
                 [Loading::Constant, Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                    let z0 = prepared.basis.loading_column(*c0 as usize);
-                    let z1 = prepared.basis.loading_column(*c1 as usize);
+                    let z0 = prepared.loading_column(*c0 as usize);
+                    let z1 = prepared.loading_column(*c1 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1), col(2)], |i| {
                         [1.0, z0[i], z1[i]]
                     })
                 }
                 [Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                    let z0 = prepared.basis.loading_column(*c0 as usize);
-                    let z1 = prepared.basis.loading_column(*c1 as usize);
+                    let z0 = prepared.loading_column(*c0 as usize);
+                    let z1 = prepared.loading_column(*c1 as usize);
                     gather_term(chunk, row_start, levels, [col(0), col(1)], |i| {
                         [z0[i], z1[i]]
                     })
                 }
                 [Loading::Covariate(c0)] => {
-                    let z0 = prepared.basis.loading_column(*c0 as usize);
+                    let z0 = prepared.loading_column(*c0 as usize);
                     gather_term(chunk, row_start, levels, [col(0)], |i| [z0[i]])
                 }
                 columns => {
@@ -60,7 +61,7 @@ pub(crate) fn gather_apply(
                             acc += match loading {
                                 Loading::Constant => coef,
                                 Loading::Covariate(k) => {
-                                    coef * prepared.basis.loading_column(*k as usize)[i]
+                                    coef * prepared.loading_column(*k as usize)[i]
                                 }
                             };
                         }

--- a/crates/within/src/operator/design/scatter.rs
+++ b/crates/within/src/operator/design/scatter.rs
@@ -20,32 +20,33 @@ pub(super) fn scatter_apply(
     let design = &prepared.design;
     debug_assert_eq!(dst.len(), design.n_dofs);
     let parallel = design.n_obs > PAR_THRESHOLD;
+    let frame = &design.frame;
 
     for (q, t) in design.terms.iter().enumerate() {
-        let levels = design.frame.level_column(q);
+        let levels = frame.level_column(q);
         let block = &mut dst[t.offset..t.offset + t.n_dofs()];
         match &*t.columns {
             [Loading::Constant] => {
                 scatter_term::<1>(block, t, levels, parallel, scratch, |i| [base(i)])
             }
             [Loading::Constant, Loading::Covariate(c0)] => {
-                let z0 = prepared.basis.loading_column(*c0 as usize);
+                let z0 = prepared.loading_column(*c0 as usize);
                 scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [b, z0[i] * b]
                 })
             }
             [Loading::Constant, Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                let z0 = prepared.basis.loading_column(*c0 as usize);
-                let z1 = prepared.basis.loading_column(*c1 as usize);
+                let z0 = prepared.loading_column(*c0 as usize);
+                let z1 = prepared.loading_column(*c1 as usize);
                 scatter_term::<3>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [b, z0[i] * b, z1[i] * b]
                 })
             }
             [Loading::Covariate(c0), Loading::Covariate(c1)] => {
-                let z0 = prepared.basis.loading_column(*c0 as usize);
-                let z1 = prepared.basis.loading_column(*c1 as usize);
+                let z0 = prepared.loading_column(*c0 as usize);
+                let z1 = prepared.loading_column(*c1 as usize);
                 scatter_term::<2>(block, t, levels, parallel, scratch, |i| {
                     let b = base(i);
                     [z0[i] * b, z1[i] * b]
@@ -60,7 +61,7 @@ pub(super) fn scatter_apply(
                             scatter_term::<1>(slot, t, levels, parallel, scratch, |i| [base(i)]);
                         }
                         Loading::Covariate(k) => {
-                            let z = prepared.basis.loading_column(*k as usize);
+                            let z = prepared.loading_column(*k as usize);
                             scatter_term::<1>(slot, t, levels, parallel, scratch, move |i| {
                                 [z[i] * base(i)]
                             });

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -12,7 +12,7 @@ mod design_tests {
     #[test]
     fn test_design_operator_dimensions() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema);
+        let op = DesignOperator::new(&schema, None);
         assert_eq!(op.nrows(), 5);
         assert_eq!(op.ncols(), 7);
     }
@@ -20,7 +20,7 @@ mod design_tests {
     #[test]
     fn test_design_operator_adjoint() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema);
+        let op = DesignOperator::new(&schema, None);
 
         let x = vec![1.0, -0.5, 2.0, 0.3, -1.0, 0.7, 1.5];
         let r = vec![0.1, 0.2, -0.3, 0.4, -0.5];
@@ -39,7 +39,7 @@ mod design_tests {
     #[test]
     fn test_apply_unweighted_values() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema);
+        let op = DesignOperator::new(&schema, None);
         let x = vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 40.0];
         let mut y = vec![0.0; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
@@ -49,7 +49,7 @@ mod design_tests {
     #[test]
     fn test_apply_adjoint_unweighted_values() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema);
+        let op = DesignOperator::new(&schema, None);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0; 7];
         op.apply_adjoint(&r, &mut x)
@@ -78,7 +78,7 @@ mod design_tests {
         let dm = make_large_design();
         let n_dofs = dm.design.n_dofs;
         let n_rows = dm.design.n_obs;
-        let op = DesignOperator::new(&dm);
+        let op = DesignOperator::new(&dm, None);
 
         let x: Vec<f64> = (0..n_dofs).map(|i| (i as f64 * 0.17 + 1.0).sin()).collect();
         let r: Vec<f64> = (0..n_rows).map(|i| (i as f64 * 0.23 + 2.0).cos()).collect();
@@ -116,7 +116,7 @@ mod design_tests {
             "dominant factor is sorted; no perm"
         );
 
-        let op = DesignOperator::new(&dm);
+        let op = DesignOperator::new(&dm, None);
         let x: Vec<f64> = (0..dm.design.n_dofs)
             .map(|i| (i as f64 * 0.17 + 1.0).sin())
             .collect();
@@ -143,7 +143,7 @@ mod design_tests {
     #[test]
     fn test_large_design_matvec_correctness() {
         let dm = make_large_design();
-        let op = DesignOperator::new(&dm);
+        let op = DesignOperator::new(&dm, None);
 
         let mut ej = vec![0.0f64; dm.design.n_dofs];
         ej[0] = 1.0;
@@ -162,7 +162,7 @@ mod design_tests {
     #[test]
     fn test_large_design_apply_adjoint_correctness() {
         let dm = make_large_design();
-        let op = DesignOperator::new(&dm);
+        let op = DesignOperator::new(&dm, None);
 
         let ones = vec![1.0f64; dm.design.n_obs];
         let mut x = vec![0.0f64; dm.design.n_dofs];
@@ -181,7 +181,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_design_adjoint_property() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm);
+        let op = DesignOperator::new(&dm, None);
 
         let x: Vec<f64> = vec![1.0, 2.0, 3.0];
         let r: Vec<f64> = vec![0.5, 1.5, -0.5, 2.0, -1.0];
@@ -205,7 +205,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_values() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm);
+        let op = DesignOperator::new(&dm, None);
         let x = vec![10.0, 20.0, 30.0];
         let mut y = vec![0.0f64; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
@@ -215,7 +215,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_adjoint_values() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm);
+        let op = DesignOperator::new(&dm, None);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0f64; 3];
         op.apply_adjoint(&r, &mut x)
@@ -273,14 +273,14 @@ mod design_tests {
             .collect();
 
         // Baseline: a fresh operator that has never applied before.
-        let fresh = DesignOperator::new(dm);
+        let fresh = DesignOperator::new(dm, None);
         let mut baseline = vec![0.0f64; dm.design.n_dofs];
         fresh
             .apply_adjoint(&r, &mut baseline)
             .expect("apply_adjoint succeeds");
 
         // The second apply on a dirtied operator must equal the fresh baseline.
-        let op = DesignOperator::new(dm);
+        let op = DesignOperator::new(dm, None);
         let mut warmup = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&r, &mut warmup)
             .expect("apply_adjoint succeeds");
@@ -305,7 +305,9 @@ mod slope_design_tests {
         (z >> 11) as f64 / (1u64 << 52) as f64 - 1.0
     }
 
-    /// Dense design matrix in the solve basis and internal row order, the operator's reference.
+    /// Dense design matrix from the design's internal (post-sort) columns —
+    /// the reference the operator must agree with regardless of the locality
+    /// permutation.
     fn dense_matrix(prepared: &PreparedDesign<'_>) -> Vec<Vec<f64>> {
         let design = &prepared.design;
         let mut d = vec![vec![0.0; design.n_dofs]; design.n_obs];
@@ -316,7 +318,7 @@ mod slope_design_tests {
                 for (i, &lev) in levels.iter().enumerate() {
                     d[i][base + lev as usize] = match loading {
                         Loading::Constant => 1.0,
-                        Loading::Covariate(k) => prepared.basis.loading_column(*k as usize)[i],
+                        Loading::Covariate(k) => prepared.loading_column(*k as usize)[i],
                     };
                 }
             }
@@ -337,12 +339,12 @@ mod slope_design_tests {
     /// slope-only, and the generic V=3 fallback — against the dense reference.
     #[test]
     fn slope_matvec_and_adjoint_match_dense_reference() {
-        let n = 12;
-        let f0: Vec<u32> = (0..n).map(|i| (i % 3) as u32).collect();
-        let f1: Vec<u32> = (0..n).map(|i| ((i / 2) % 3) as u32).collect();
-        let f2: Vec<u32> = (0..n).map(|i| (i % 2) as u32).collect();
-        let f3: Vec<u32> = (0..n).map(|i| (i / 6) as u32).collect();
-        let f4: Vec<u32> = (0..n).map(|i| [1u32, 0, 2, 1, 0, 2][i % 6]).collect();
+        let n = 6;
+        let f0 = [0u32, 1, 2, 0, 1, 2];
+        let f1 = [0u32, 0, 1, 1, 2, 2];
+        let f2 = [0u32, 1, 0, 1, 0, 1];
+        let f3 = [0u32, 0, 0, 1, 1, 1];
+        let f4 = [1u32, 0, 2, 1, 0, 2];
         let zs: Vec<Vec<f64>> = (0..6)
             .map(|k| (0..n).map(|i| noise(k * 100 + i)).collect())
             .collect();
@@ -353,18 +355,14 @@ mod slope_design_tests {
             Effect::new(&f3, true, []).unwrap(),
             Effect::new(&f4, true, [&zs[5][..], &zs[4][..]]).unwrap(),
         ];
-        let prepared = PreparedDesign::unweighted_for_test(Design::new(effects).unwrap());
-        let dense = dense_matrix(&prepared);
-        assert!(
-            (0..prepared.design.n_dofs).all(|j| dense.iter().any(|row| row[j] != 0.0)),
-            "whitening zeroed a column; the arm's addressing would go untested"
-        );
-        let op = DesignOperator::new(&prepared);
+        let design = PreparedDesign::unweighted_for_test(Design::new(effects).unwrap());
+        let dense = dense_matrix(&design);
+        let op = DesignOperator::new(&design, None);
 
-        let x: Vec<f64> = (0..prepared.design.n_dofs)
+        let x: Vec<f64> = (0..design.design.n_dofs)
             .map(|j| noise(7_000 + j))
             .collect();
-        let mut got = vec![0.0; prepared.design.n_obs];
+        let mut got = vec![0.0; design.design.n_obs];
         op.apply(&x, &mut got).unwrap();
         let expect: Vec<f64> = dense
             .iter()
@@ -372,12 +370,10 @@ mod slope_design_tests {
             .collect();
         assert_close(&got, &expect);
 
-        let r: Vec<f64> = (0..prepared.design.n_obs)
-            .map(|i| noise(9_000 + i))
-            .collect();
-        let mut got_t = vec![0.0; prepared.design.n_dofs];
+        let r: Vec<f64> = (0..design.design.n_obs).map(|i| noise(9_000 + i)).collect();
+        let mut got_t = vec![0.0; design.design.n_dofs];
         op.apply_adjoint(&r, &mut got_t).unwrap();
-        let mut expect_t = vec![0.0; prepared.design.n_dofs];
+        let mut expect_t = vec![0.0; design.design.n_dofs];
         for (row, &ri) in dense.iter().zip(&r) {
             for (e, d) in expect_t.iter_mut().zip(row) {
                 *e += d * ri;
@@ -406,18 +402,18 @@ mod slope_design_tests {
             Effect::new(&unsorted, true, [&z[1][..]]).unwrap(),
             Effect::new(&small, true, [&z[2][..], &z[3][..]]).unwrap(),
         ];
-        let weights: Vec<f64> = (0..n).map(|i| 0.5 + noise(i).abs()).collect();
-        let prepared = PreparedDesign::new(Design::new(effects).unwrap(), Some(weights)).unwrap();
-        let op = DesignOperator::new(&prepared);
+        let design = PreparedDesign::unweighted_for_test(Design::new(effects).unwrap());
+        let sqrt_weights: Vec<f64> = (0..n).map(|i| (0.5 + noise(i).abs()).sqrt()).collect();
+        let op = DesignOperator::new(&design, Some(&sqrt_weights));
 
-        let x: Vec<f64> = (0..prepared.design.n_dofs)
+        let x: Vec<f64> = (0..design.design.n_dofs)
             .map(|j| noise(13 * j + 1))
             .collect();
         let r: Vec<f64> = (0..n).map(|i| noise(29 * i + 5)).collect();
 
         let mut dx = vec![0.0; n];
         op.apply(&x, &mut dx).unwrap();
-        let mut dtr = vec![0.0; prepared.design.n_dofs];
+        let mut dtr = vec![0.0; design.design.n_dofs];
         op.apply_adjoint(&r, &mut dtr).unwrap();
 
         let lhs: f64 = dx.iter().zip(&r).map(|(a, b)| a * b).sum();
@@ -460,9 +456,6 @@ mod weighted_adjoint_proptests {
                 .collect();
 
             let dm = PreparedDesign::from_levels_for_test(vec![fa, fb]);
-            let dm_weighted = PreparedDesign::new(dm.design.clone(), Some(weights)).unwrap();
-            // Internal row order, like `dx` and `r` below.
-            let sqrt_weights = dm_weighted.sqrt_weights.as_deref().unwrap();
 
             let n_dofs = dm.design.n_dofs;
             let n_rows = dm.design.n_obs;
@@ -474,17 +467,18 @@ mod weighted_adjoint_proptests {
                 .map(|i| (i as f64 * 0.29 + seed as f64 * 0.07).cos())
                 .collect();
 
-            let op_unweighted = DesignOperator::new(&dm);
+            let op_unweighted = DesignOperator::new(&dm, None);
             let mut dx = vec![0.0f64; n_rows];
             op_unweighted.apply(&x, &mut dx).unwrap();
             let lhs: f64 = dx
                 .iter()
                 .zip(r.iter())
                 .enumerate()
-                .map(|(i, (dxi, ri))| sqrt_weights[i] * sqrt_weights[i] * dxi * ri)
+                .map(|(i, (dxi, ri))| weights[i] * dxi * ri)
                 .sum();
 
-            let op_weighted = DesignOperator::new(&dm_weighted);
+            let sqrt_weights: Vec<f64> = weights.iter().map(|w| w.sqrt()).collect();
+            let op_weighted = DesignOperator::new(&dm, Some(&sqrt_weights));
             let wr = op_weighted.weighted_rhs(&r);
             let mut wdtr = vec![0.0f64; n_dofs];
             op_weighted.apply_adjoint(&wr, &mut wdtr).unwrap();

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -407,7 +407,7 @@ mod slope_design_tests {
             Effect::new(&small, true, [&z[2][..], &z[3][..]]).unwrap(),
         ];
         let weights: Vec<f64> = (0..n).map(|i| 0.5 + noise(i).abs()).collect();
-        let prepared = PreparedDesign::new(Design::new(effects).unwrap(), Some(&weights)).unwrap();
+        let prepared = PreparedDesign::new(Design::new(effects).unwrap(), Some(weights)).unwrap();
         let op = DesignOperator::new(&prepared);
 
         let x: Vec<f64> = (0..prepared.design.n_dofs)
@@ -460,7 +460,7 @@ mod weighted_adjoint_proptests {
                 .collect();
 
             let dm = PreparedDesign::from_levels_for_test(vec![fa, fb]);
-            let dm_weighted = PreparedDesign::new(dm.design.clone(), Some(&weights)).unwrap();
+            let dm_weighted = PreparedDesign::new(dm.design.clone(), Some(weights)).unwrap();
             // Internal row order, like `dx` and `r` below.
             let sqrt_weights = dm_weighted.sqrt_weights.as_deref().unwrap();
 

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use crate::block_elim::BlockElimSolver;
 use crate::config::{LocalSolverConfig, PreconditionerConfig};
 use crate::domain::Loading;
-use crate::domain::{row_weight, LocalDomain, PreparedDesign};
+use crate::domain::{LocalDomain, PreparedDesign};
 use crate::{BuildError, BuildWarning};
 
 #[cfg(test)]
@@ -210,14 +210,16 @@ impl Operator for Preconditioner {
     }
 }
 
-fn build_diagonal(prepared: &PreparedDesign<'_>) -> Result<DiagonalPreconditioner, BuildError> {
+fn build_diagonal(
+    prepared: &PreparedDesign<'_>,
+    weights: Option<&[f64]>,
+) -> Result<DiagonalPreconditioner, BuildError> {
     let design = &prepared.design;
-    let sqrt_weights = prepared.sqrt_weights.as_deref();
     let mut diag = vec![0.0; design.n_dofs];
 
     for (factor_idx, term) in design.terms.iter().enumerate() {
         let levels = design.frame.level_column(factor_idx);
-        let w = |uid: usize| row_weight(sqrt_weights, uid);
+        let w = |uid: usize| weights.map_or(1.0, |ws| ws[uid]);
         for (column, loading) in term.columns.iter().enumerate() {
             let base = term.column_base(column);
             let slice = &mut diag[base..base + term.n_levels];
@@ -228,7 +230,7 @@ fn build_diagonal(prepared: &PreparedDesign<'_>) -> Result<DiagonalPreconditione
                     }
                 }
                 Loading::Covariate(z_col) => {
-                    let z = prepared.basis.loading_column(*z_col as usize);
+                    let z = prepared.loading_column(*z_col as usize);
                     for (uid, &level) in levels.iter().enumerate() {
                         // Keep `w * z * z` left-to-right: a zero weight kills a huge `z` first.
                         slice[level as usize] += w(uid) * z[uid] * z[uid];
@@ -255,14 +257,16 @@ fn build_diagonal(prepared: &PreparedDesign<'_>) -> Result<DiagonalPreconditione
     })
 }
 
-/// Build a [`Preconditioner`] for a prepared design, plus any warnings.
+/// Build a [`Preconditioner`] for a prepared design and optional weights, plus any warnings.
 pub(crate) fn build_preconditioner(
     prepared: &PreparedDesign<'_>,
+    weights: Option<&[f64]>,
     config: Option<&PreconditionerConfig>,
 ) -> Result<(Option<Preconditioner>, Vec<BuildWarning>), BuildError> {
     use crate::domain::build_local_domains;
 
     let design = &prepared.design;
+    // Weights are pre-validated by the sole caller, whose permutation preserves length and sign.
     let default_cfg = PreconditionerConfig::default();
     let resolved = config.unwrap_or(&default_cfg);
     // Measure preconditioner build time
@@ -275,7 +279,7 @@ pub(crate) fn build_preconditioner(
             local_solver,
             reduction,
         } => {
-            let (domains, warnings) = build_local_domains(prepared, local_solver)?;
+            let (domains, warnings) = build_local_domains(prepared, weights, local_solver)?;
             if domains.is_empty() {
                 // No factor-pair subdomains means no useful Schwarz; fall back to plain LSMR.
                 return Ok((None, warnings));
@@ -285,7 +289,7 @@ pub(crate) fn build_preconditioner(
             (Variant::Additive(preconditioner), warnings)
         }
         PreconditionerConfig::Diagonal => {
-            let preconditioner = build_diagonal(prepared)?;
+            let preconditioner = build_diagonal(prepared, weights)?;
             (Variant::Diagonal(preconditioner), Vec::new())
         }
     };

--- a/crates/within/src/operator/schwarz/tests.rs
+++ b/crates/within/src/operator/schwarz/tests.rs
@@ -20,8 +20,8 @@ const BLOCK_ELIM_NESTED_RAYON_CHILD_ENV: &str = "WITHIN_TEST_BLOCK_ELIM_NESTED_R
 fn make_test_data() -> (PreparedDesign<'static>, Vec<LocalDomain>) {
     let design =
         PreparedDesign::from_levels_for_test(vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]);
-    let (domain_pairs, _) =
-        build_local_domains(&design, &LocalSolverConfig::default()).expect("plain domains build");
+    let (domain_pairs, _) = build_local_domains(&design, None, &LocalSolverConfig::default())
+        .expect("plain domains build");
     (design, domain_pairs)
 }
 
@@ -206,11 +206,11 @@ fn test_build_additive_with_strategy() {
     let (design, domain_pairs) = make_test_data();
     let config = LocalSolverConfig::default();
     let strategy = schwarz_precond::ReductionStrategy::default();
-    let n_dofs = design.design.n_dofs;
-    let schwarz = build_additive_with_strategy(domain_pairs, &config, strategy, n_dofs)
-        .expect("build schwarz with explicit domains");
-    let r = vec![1.0; n_dofs];
-    let mut z = vec![0.0; n_dofs];
+    let schwarz =
+        build_additive_with_strategy(domain_pairs, &config, strategy, design.design.n_dofs)
+            .expect("build schwarz with explicit domains");
+    let r = vec![1.0; design.design.n_dofs];
+    let mut z = vec![0.0; design.design.n_dofs];
     schwarz.apply(&r, &mut z).expect("schwarz apply succeeds");
 }
 

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -289,7 +289,8 @@ impl BatchSolveResult {
 ///
 /// Ownership: each observation column is borrowed or owned independently
 /// (`Cow`); a solver that outlives its inputs — e.g. one returned across the
-/// Python boundary — uses owned columns.
+/// Python boundary — uses owned columns. Weights are always owned; for a
+/// one-shot weighted solve from a borrowed slice, use the free [`solve`] function.
 pub struct Solver<'a> {
     prepared: PreparedDesign<'a>,
     preconditioner: Option<Preconditioner>,
@@ -333,14 +334,16 @@ impl<'a> Solver<'a> {
     /// - `PreconditionerConfig::Diagonal` — use diagonal/Jacobi preconditioning
     /// - [`Preconditioner`] or `&Preconditioner` — reuse a previously built one
     ///
-    /// `weights` is `None` for unweighted; the solver keeps only `√w` in its own order.
+    /// `weights` is `None` for unweighted, or an owned `Vec<f64>` that the
+    /// solver takes ownership of (it re-reads the weights on every solve). To
+    /// solve once from a borrowed slice, use the free [`solve`] function.
     ///
     /// LSMR tuning ([`LsmrOptions`]) is supplied per call to [`Solver::solve`] /
     /// [`Solver::solve_batch`], not at construction; preconditioner factorization
     /// state is the only expensive thing built here.
     pub fn new(
         design: impl IntoDesign<'a>,
-        weights: Option<&[f64]>,
+        weights: Option<Vec<f64>>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
         let prepared = PreparedDesign::new(design.into_design()?, weights)?;
@@ -450,6 +453,12 @@ impl<'a> Solver<'a> {
         })
     }
 
+    /// Per-level directions the data cannot identify, shared across all RHS:
+    /// identification depends only on the design and weights, never on `y`.
+    fn unidentified(&self) -> Vec<CoefficientAddress> {
+        self.prepared.basis.unidentified.clone()
+    }
+
     /// Solve for a single RHS vector with the given LSMR tuning.
     pub fn solve<'o>(
         &self,
@@ -464,7 +473,7 @@ impl<'a> Solver<'a> {
 
         Ok(SolveResult {
             x: solution.x,
-            unidentified: self.prepared.basis.unidentified.clone(),
+            unidentified: self.unidentified(),
             warnings: self.warnings.clone(),
             layout: CoefficientLayout::from_design(&self.prepared.design),
             demeaned: solution.demeaned,
@@ -513,7 +522,7 @@ impl<'a> Solver<'a> {
 
         Ok(BatchSolveResult {
             x,
-            unidentified: self.prepared.basis.unidentified.clone(),
+            unidentified: self.unidentified(),
             warnings: self.warnings.clone(),
             layout: CoefficientLayout::from_design(design),
             demeaned,
@@ -568,7 +577,7 @@ pub fn solve<'a, 'o>(
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<SolveResult, WithinError> {
     let t_start = Instant::now();
-    let solver = Solver::new(design, weights, preconditioner)?;
+    let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve(y, lsmr)?;
     // Include solver construction (preconditioner build) in setup time
@@ -589,7 +598,7 @@ pub fn solve_batch<'a, 'o>(
     preconditioner: impl Into<PreconditionerInput>,
 ) -> Result<BatchSolveResult, WithinError> {
     let t_start = Instant::now();
-    let solver = Solver::new(design, weights, preconditioner)?;
+    let solver = Solver::new(design, weights.map(|w| w.to_vec()), preconditioner)?;
     let time_setup = t_start.elapsed().as_secs_f64();
     let mut result = solver.solve_batch(ys, lsmr)?;
     result.time_setup += time_setup;

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -12,6 +12,7 @@ use schwarz_precond::{lsmr as lsmr_solve, mlsmr, MlsmrOptions};
 use crate::channel::{Channel, CoefficientAddress};
 use crate::config::{LsmrOptions, PreconditionerConfig};
 use crate::domain::collinearity::detect_collinear_slopes;
+use crate::domain::level_moments::TermMoments;
 use crate::domain::{Design, Effect, PreparedDesign};
 use crate::observation::ObservationFrame;
 use crate::operator::design::gather_apply;
@@ -293,6 +294,10 @@ impl BatchSolveResult {
 /// one-shot weighted solve from a borrowed slice, use the free [`solve`] function.
 pub struct Solver<'a> {
     prepared: PreparedDesign<'a>,
+    /// `sqrt(W)` in the design's internal observation order, computed once and
+    /// borrowed by the per-RHS [`DesignOperator`]s (raw weights are needed only
+    /// during construction).
+    sqrt_weights: Option<Vec<f64>>,
     preconditioner: Option<Preconditioner>,
     warnings: Vec<BuildWarning>,
 }
@@ -302,7 +307,7 @@ impl std::fmt::Debug for Solver<'_> {
         f.debug_struct("Solver")
             .field("n_obs", &self.prepared.design.n_obs)
             .field("n_dofs", &self.prepared.design.n_dofs)
-            .field("has_weights", &self.prepared.sqrt_weights.is_some())
+            .field("has_weights", &self.sqrt_weights.is_some())
             .field("has_preconditioner", &self.preconditioner.is_some())
             .finish()
     }
@@ -346,13 +351,33 @@ impl<'a> Solver<'a> {
         weights: Option<Vec<f64>>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
-        let prepared = PreparedDesign::new(design.into_design()?, weights)?;
+        let design = design.into_design()?;
+        design.validate_weights(weights.as_deref())?;
+
+        // The match keeps the unpermuted arm a plain move rather than a borrow-and-copy.
+        let weights = match &design.obs_perm {
+            Some(_) => weights.map(|w| design.permute_obs_in(&w).into_owned()),
+            None => weights,
+        };
+
+        // Both readers below need the raw loadings, so the moments precede whitening.
+        let moments = TermMoments::build(&design, weights.as_deref());
+        let mut warnings = moments
+            .as_ref()
+            .map(|m| detect_collinear_slopes(&design, weights.as_deref(), m))
+            .unwrap_or_default();
+
+        // Whiten the slope columns (if any) before the preconditioner reads them.
+        let prepared = PreparedDesign::new(design, moments.as_ref());
         let n_dofs = prepared.design.n_dofs;
-        let mut warnings = detect_collinear_slopes(&prepared);
 
         let (preconditioner, build_warnings) = match preconditioner.into() {
-            PreconditionerInput::Default => build_preconditioner(&prepared, None)?,
-            PreconditionerInput::Config(c) => build_preconditioner(&prepared, Some(&c))?,
+            PreconditionerInput::Default => {
+                build_preconditioner(&prepared, weights.as_deref(), None)?
+            }
+            PreconditionerInput::Config(c) => {
+                build_preconditioner(&prepared, weights.as_deref(), Some(&c))?
+            }
             PreconditionerInput::Prebuilt(p) => {
                 if p.nrows() != n_dofs || p.ncols() != n_dofs {
                     return Err(BuildError::PreconditionerDimensionMismatch {
@@ -367,8 +392,16 @@ impl<'a> Solver<'a> {
 
         warnings.extend(build_warnings);
 
+        let sqrt_weights = weights.map(|mut w| {
+            for wi in &mut w {
+                *wi = wi.sqrt();
+            }
+            w
+        });
+
         Ok(Self {
             prepared,
+            sqrt_weights,
             preconditioner,
             warnings,
         })
@@ -385,15 +418,14 @@ impl<'a> Solver<'a> {
     /// `unidentified`, which the public entry points attach once (see
     /// [`RhsSolution`]).
     fn solve_rhs(&self, y: &[f64], lsmr: &LsmrOptions) -> Result<RhsSolution, SolveError> {
-        let design = &self.prepared.design;
         // `weighted_rhs` zips y with sqrt-weights, silently truncating when `y.len() > n_rows`.
-        if y.len() != design.n_obs {
+        if y.len() != self.prepared.design.n_obs {
             return Err(SolveError::InvalidInput {
                 context: "Solver::solve",
                 message: format!(
                     "response vector length ({}) does not match number of observations ({})",
                     y.len(),
-                    design.n_obs
+                    self.prepared.design.n_obs
                 ),
             });
         }
@@ -407,10 +439,10 @@ impl<'a> Solver<'a> {
         let t_start = Instant::now();
 
         // The gather is a recurring per-solve cost of the locality sort, so it counts as setup.
-        let y_internal = design.permute_obs_in(y);
+        let y_internal = self.prepared.design.permute_obs_in(y);
         let y: &[f64] = &y_internal;
 
-        let rect_op = DesignOperator::new(&self.prepared);
+        let rect_op = DesignOperator::new(&self.prepared, self.sqrt_weights.as_deref());
         let b = rect_op.weighted_rhs(y);
         let b: &[f64] = &b;
 
@@ -431,19 +463,21 @@ impl<'a> Solver<'a> {
         let time_solve = t_solve_start.elapsed().as_secs_f64();
 
         // Shapes are guaranteed here, so the bare `D x` matvec is infallible.
-        let mut demeaned = vec![0.0; design.n_obs];
+        let mut demeaned = vec![0.0; self.prepared.design.n_obs];
         gather_apply(&self.prepared, &r.x, &mut demeaned, None);
         for (d, &yi) in demeaned.iter_mut().zip(y.iter()) {
             *d = yi - *d;
         }
 
         let mut x = r.x;
-        self.prepared.basis.back_transform(&mut x);
+        if let Some(rp) = &self.prepared.reparam {
+            rp.back_transform(&mut x);
+        }
 
         Ok(RhsSolution {
             x,
             // Back to the caller's observation order (no-op if not reordered).
-            demeaned: design.permute_obs_out(demeaned),
+            demeaned: self.prepared.design.permute_obs_out(demeaned),
             converged: r.converged,
             iterations: r.iterations,
             // Read from the LSMR recurrence at no extra cost; see `SolveResult::residual`.
@@ -456,7 +490,11 @@ impl<'a> Solver<'a> {
     /// Per-level directions the data cannot identify, shared across all RHS:
     /// identification depends only on the design and weights, never on `y`.
     fn unidentified(&self) -> Vec<CoefficientAddress> {
-        self.prepared.basis.unidentified.clone()
+        self.prepared
+            .reparam
+            .as_ref()
+            .map(|rp| rp.unidentified.clone())
+            .unwrap_or_default()
     }
 
     /// Solve for a single RHS vector with the given LSMR tuning.
@@ -503,9 +541,8 @@ impl<'a> Solver<'a> {
             .map(|y| self.solve_rhs(y, lsmr))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let design = &self.prepared.design;
-        let mut x = Vec::with_capacity(design.n_dofs * n_rhs);
-        let mut demeaned = Vec::with_capacity(design.n_obs * n_rhs);
+        let mut x = Vec::with_capacity(self.prepared.design.n_dofs * n_rhs);
+        let mut demeaned = Vec::with_capacity(self.prepared.design.n_obs * n_rhs);
         let mut converged = Vec::with_capacity(n_rhs);
         let mut iterations = Vec::with_capacity(n_rhs);
         let mut residual = Vec::with_capacity(n_rhs);
@@ -524,7 +561,7 @@ impl<'a> Solver<'a> {
             x,
             unidentified: self.unidentified(),
             warnings: self.warnings.clone(),
-            layout: CoefficientLayout::from_design(design),
+            layout: CoefficientLayout::from_design(&self.prepared.design),
             demeaned,
             converged,
             iterations,
@@ -532,8 +569,8 @@ impl<'a> Solver<'a> {
             time_solve,
             time_setup: 0.0,
             time_total: t_start.elapsed().as_secs_f64(),
-            n_dofs: design.n_dofs,
-            n_obs: design.n_obs,
+            n_dofs: self.prepared.design.n_dofs,
+            n_obs: self.prepared.design.n_obs,
         })
     }
 

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -12,7 +12,6 @@ use schwarz_precond::{lsmr as lsmr_solve, mlsmr, MlsmrOptions};
 use crate::channel::{Channel, CoefficientAddress};
 use crate::config::{LsmrOptions, PreconditionerConfig};
 use crate::domain::collinearity::detect_collinear_slopes;
-use crate::domain::level_moments::TermMoments;
 use crate::domain::{Design, Effect, PreparedDesign};
 use crate::observation::ObservationFrame;
 use crate::operator::design::gather_apply;
@@ -360,15 +359,9 @@ impl<'a> Solver<'a> {
             None => weights,
         };
 
-        // Both readers below need the raw loadings, so the moments precede whitening.
-        let moments = TermMoments::build(&design, weights.as_deref());
-        let mut warnings = moments
-            .as_ref()
-            .map(|m| detect_collinear_slopes(&design, weights.as_deref(), m))
-            .unwrap_or_default();
-
         // Whiten the slope columns (if any) before the preconditioner reads them.
-        let prepared = PreparedDesign::new(design, moments.as_ref());
+        let prepared = PreparedDesign::new(design, weights.as_deref());
+        let mut warnings = detect_collinear_slopes(&prepared, weights.as_deref());
         let n_dofs = prepared.design.n_dofs;
 
         let (preconditioner, build_warnings) = match preconditioner.into() {

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -34,7 +34,7 @@ fn positive_slope_only_pair_grounds_beyond_dense_threshold() {
     ];
     let prepared = PreparedDesign::unweighted_for_test(Design::new(effects).expect("design"));
     let (domains, warnings) =
-        build_local_domains(&prepared, &LocalSolverConfig::default()).expect("domains");
+        build_local_domains(&prepared, None, &LocalSolverConfig::default()).expect("domains");
     assert!(
         domains.iter().any(|ld| {
             let ct = &ld.component.matrix.cross_tab;

--- a/crates/within/tests/api_pinning.rs
+++ b/crates/within/tests/api_pinning.rs
@@ -85,9 +85,13 @@ fn solver_new_weights_call_shapes_compile() {
     let categories = cats();
     let w_vec: Vec<f64> = vec![1.0; 4];
 
-    // Bare `None` infers, because `weights` is the concrete `Option<&[f64]>`.
+    // Bare `None` — infers, because `weights` is the concrete `Option<Vec<f64>>`
+    // (no turbofish needed). The persistent solver owns its weights; borrow-based
+    // one-shot weighting lives on the free `solve` function instead.
     let _ = Solver::new(categories.view(), None, None).expect("None weights");
-    let _ = Solver::new(categories.view(), Some(&w_vec), None).expect("borrowed weights");
+
+    // Owned `Vec<f64>` weights — moved into the solver.
+    let _ = Solver::new(categories.view(), Some(w_vec), None).expect("Vec<f64> weights");
 }
 
 #[test]

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -46,7 +46,7 @@ fn test_weight_count_mismatch_error() {
     )
     .expect("frame ok");
     let design = Design::from_frame(frame).expect("valid design");
-    let result = Solver::new(design, Some(&[1.0, 2.0]), None);
+    let result = Solver::new(design, Some(vec![1.0, 2.0]), None);
     let err = result.expect_err("expected WeightCountMismatch error, got Ok");
     match err {
         BuildError::WeightCountMismatch { .. } => {}

--- a/crates/within/tests/orchestrate_solve.rs
+++ b/crates/within/tests/orchestrate_solve.rs
@@ -88,7 +88,7 @@ fn test_lsmr_least_squares_weighted_preconditioned() {
         ..Default::default()
     };
     let precond = PreconditionerConfig::default();
-    let solver = Solver::new(design, Some(&weights), &precond).expect("build solver");
+    let solver = Solver::new(design, Some(weights.clone()), &precond).expect("build solver");
     let result = solver.solve(&y, &params).expect("solve");
     common::assert_converged_with_small_residual(&result, 1e-6);
     common::assert_solution_finite(&result);

--- a/crates/within/tests/properties.rs
+++ b/crates/within/tests/properties.rs
@@ -121,7 +121,7 @@ proptest! {
             maxiter: 2000,
             local_size: Some(10),
         };
-        let result = Solver::new(effects, Some(weights), PreconditionerConfig::default())
+        let result = Solver::new(effects, Some(weights.clone()), PreconditionerConfig::default())
             .expect("build solver")
             .solve(y.as_slice(), &params)
             .expect("solve");

--- a/crates/within/tests/slopes.rs
+++ b/crates/within/tests/slopes.rs
@@ -54,7 +54,7 @@ fn solve_with(
     levels: &[u32],
     z: &[f64],
     intercept: bool,
-    weights: Option<&[f64]>,
+    weights: Option<Vec<f64>>,
     y: &[f64],
     config: &PreconditionerConfig,
 ) -> SolveResult {
@@ -72,7 +72,7 @@ fn solve_single(
     levels: &[u32],
     z: &[f64],
     intercept: bool,
-    weights: Option<&[f64]>,
+    weights: Option<Vec<f64>>,
     y: &[f64],
 ) -> SolveResult {
     solve_with(
@@ -201,7 +201,7 @@ fn weighted_solve_matches_closed_form_and_masks_zero_weight_rows() {
     let w: Vec<f64> = vec![1.0, 0.5, 2.0, 1.5, 3.0, 1.0, 1.0, 1.0, 0.0];
     let y = synthetic_y(levels.len());
 
-    let r = solve_single(&levels, &z, true, Some(&w), &y);
+    let r = solve_single(&levels, &z, true, Some(w.clone()), &y);
     assert!(r.converged);
     assert_eq!(drops(&r), [(0, 2, 1)]);
     assert_eq!(r.x[3 + 2], 0.0);
@@ -222,7 +222,8 @@ fn zero_weight_garbage_does_not_poison_identification() {
     let z: Vec<f64> = vec![1.0, 2.0, 3.0, 5.0, 7.0, 1e300];
     let w: Vec<f64> = vec![1.0, 1.0, 1.0, 1.0, 1.0, 0.0];
     let y = synthetic_y(levels.len());
-    let run = |config: &PreconditionerConfig| solve_with(&levels, &z, true, Some(&w), &y, config);
+    let run =
+        |config: &PreconditionerConfig| solve_with(&levels, &z, true, Some(w.clone()), &y, config);
 
     let r = run(&PreconditionerConfig::default());
     assert!(r.unidentified.is_empty());

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -314,11 +314,11 @@ fn test_internal_locality_sort_is_transparent() {
     let params = default_params();
     let precond = additive_precond();
 
-    let make_solver = |weights: Option<&[f64]>| {
+    let make_solver = |weights: Option<Vec<f64>>| {
         let design = common::make_design(vec![col0.clone(), col1.clone()]).expect("design");
         Solver::new(design, weights, &precond).expect("solver")
     };
-    let make_oracle = |weights: Option<&[f64]>| {
+    let make_oracle = |weights: Option<Vec<f64>>| {
         let frame =
             ObservationFrame::new(vec![col0.clone().into(), col1.clone().into()], Vec::new())
                 .expect("frame");
@@ -327,8 +327,10 @@ fn test_internal_locality_sort_is_transparent() {
     };
 
     // The weighted run also exercises the weights-permutation path.
-    for weights in [None, Some(&w[..])] {
-        let oracle = make_oracle(weights).solve(&y, &params).expect("oracle");
+    for weights in [None, Some(w)] {
+        let oracle = make_oracle(weights.clone())
+            .solve(&y, &params)
+            .expect("oracle");
         let sorted = make_solver(weights).solve(&y, &params).expect("sorted");
         common::assert_solutions_close(&sorted.x, &oracle.x, 1e-7);
         common::assert_solutions_close(&sorted.demeaned, &oracle.demeaned, 1e-7);


### PR DESCRIPTION
Stacked on #340. Once the whitened slope columns live beside the raw frame, the collinearity screen no longer needs its own per-level Gram–Schmidt: with `u` orthonormal within each level, `Σw·u·c` is already the coefficient of target `c` on the term's slope span, and `Σw·c / Σw` its constant.

- The screen reads `prepared.loading_column` and keeps a per-level weight sum; `to_coefficients` shrinks to a division.
- `TermMoments` is gone. `SlopeReparam::build` builds `LevelMoments` for the slope-bearing terms in parallel and consumes them directly, so `PreparedDesign::new` takes the weights.
- `LevelMoments` drops the covariate list that `TermMeta` already owns; `TermMeta` gains `covariates()`, `has_slopes()` and `has_intercept()`.

285 Rust tests, 106 Python tests, clippy clean. 8 files, +129/−223.