### PR TITLE
Audit warm-started LSMR stops against the original b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - **BREAKING:** `schwarz_precond::mlsmr` takes an `MlsmrOptions` in place of its trailing `local_size`.
 - **BREAKING:** `LsmrStopReason` gains `Escalated` and `WarmStartExact`, breaking exhaustive `match`es.
 - A warm start that already solves the system reports `WarmStartExact` instead of `ZeroRhs`.
-- The LSMR true-residual audit of a warm-started stop measures the total solution against the original `b` and anchors its normal-equation leg to `‖Aᵀb‖` rather than the restart's own initial residual.
+- The LSMR true-residual audit of a warm-started stop measures the total solution against the original `b` and anchors its normal-equation leg to `‖Aᵀb‖` rather than the restart's own initial residual. A warm start with `b = 0` measures its tolerances against `‖b − A x₀‖`.
 - **BREAKING:** `ScalingConfig::max_sweeps` is now `max_iterations`, and `BuildWarning::UnscalableComponent` reports `iterations` in place of `sweeps`; the dominance certificate runs reduced CG, not relaxation sweeps.
 - **BREAKING:** The serialized `Preconditioner` wire format changed with the `approx-chol` 0.4 → 0.5 bump (v12 → v13), retention of the complete construction config (v13 → v14), retention of its original build duration (v14 → v15), and the new `LocalSolverConfig::ridge` field (v15 → v16); 0.3.0 bytes no longer decode.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - **BREAKING:** `schwarz_precond::mlsmr` takes an `MlsmrOptions` in place of its trailing `local_size`.
 - **BREAKING:** `LsmrStopReason` gains `Escalated` and `WarmStartExact`, breaking exhaustive `match`es.
 - A warm start that already solves the system reports `WarmStartExact` instead of `ZeroRhs`.
+- The LSMR true-residual audit of a warm-started stop measures the total solution against the original `b` and anchors its normal-equation leg to `‖Aᵀb‖` rather than the restart's own initial residual.
 - **BREAKING:** `ScalingConfig::max_sweeps` is now `max_iterations`, and `BuildWarning::UnscalableComponent` reports `iterations` in place of `sweeps`; the dominance certificate runs reduced CG, not relaxation sweeps.
 - **BREAKING:** The serialized `Preconditioner` wire format changed with the `approx-chol` 0.4 → 0.5 bump (v12 → v13), retention of the complete construction config (v13 → v14), retention of its original build duration (v14 → v15), and the new `LocalSolverConfig::ridge` field (v15 → v16); 0.3.0 bytes no longer decode.
 

--- a/crates/schwarz-precond/src/lsmr.rs
+++ b/crates/schwarz-precond/src/lsmr.rs
@@ -201,7 +201,7 @@ pub fn lsmr<A: Operator + ?Sized>(
     let local_size = local_size.unwrap_or(0);
     let (bidiag, step1) = GolubKahan::init(operator, b, local_size)?;
     let criteria = ConvergenceCriteria::new(b_norm, tol);
-    lsmr_from_bidiag(bidiag, step1, b, b_norm, criteria, maxiter, None)
+    lsmr_from_bidiag(bidiag, step1, b, None, criteria, maxiter, None)
 }
 
 /// Preconditioned LSMR with `M ≈ AᵀA` and one `M⁻¹` application per iteration.
@@ -280,40 +280,44 @@ pub fn mlsmr<A: Operator + ?Sized, M: Operator + ?Sized>(
 
     let (bidiag, step1) = ModifiedGolubKahan::init(operator, preconditioner, &rhs, local_size)?;
     let criteria = ConvergenceCriteria::new(b_norm, tol);
-    let mut result = lsmr_from_bidiag(
+    lsmr_from_bidiag(
         bidiag,
         step1,
-        &rhs,
-        rhs_norm,
+        b,
+        warm_start,
         criteria,
         maxiter,
         escalation.map(|policy| policy.handler()),
-    )?;
-    if let Some(x0) = warm_start {
-        for (xi, &x0i) in result.x.iter_mut().zip(x0) {
-            *xi += x0i;
-        }
-    }
-    Ok(result)
+    )
 }
 
 /// Runs the LSMR recurrences over a preconditioner-specific bidiagonalization stream.
+///
+/// The stream solves for the correction to `x0`; results and the audit are in terms of `b`.
 fn lsmr_from_bidiag<B: Bidiagonalization>(
     mut bidiag: B,
     step1: BidiagStep,
-    rhs: &[f64],
-    rhs_norm: f64,
+    b: &[f64],
+    x0: Option<&[f64]>,
     criteria: ConvergenceCriteria,
     maxiter: usize,
     mut escalation: Option<Box<dyn EscalationHandler>>,
 ) -> Result<LsmrResult, SolveError> {
     let n = bidiag.v().len();
+    let total = |mut x: Vec<f64>| {
+        if let Some(x0) = x0 {
+            for (xi, &x0i) in x.iter_mut().zip(x0) {
+                *xi += x0i;
+            }
+        }
+        x
+    };
     if step1.alpha == 0.0 {
         return Ok(LsmrResult {
-            x: vec![0.0; n],
+            x: total(vec![0.0; n]),
             converged: true,
             iterations: 0,
-            residual_norm: rhs_norm,
+            residual_norm: step1.beta,
             normal_eq_residual: 0.0,
             stop_reason: LsmrStopReason::InitialNormalEquationResidualZero,
         });
@@ -336,15 +340,25 @@ fn lsmr_from_bidiag<B: Bidiagonalization>(
             Stop::ResidualTolerance => Some(LsmrStopReason::ResidualTolerance),
             Stop::NormalEquationTolerance => Some(LsmrStopReason::NormalEquationTolerance),
         } {
-            let x = solution.into_x();
-            let cert = bidiag.certify(&x, rhs)?;
-            let converged = convergence.certified(&cert, recurrence.zeta0);
+            // A warm start re-bases `ζ̄₀`; auditing `x = 0` against `b` recovers the cold `‖Âᵀb‖`.
+            let ne_reference = match x0 {
+                Some(_) => bidiag.certify(&vec![0.0; n], b)?.normar,
+                None => 0.0,
+            };
+            let ne_reference = if ne_reference > 0.0 {
+                ne_reference
+            } else {
+                recurrence.zeta0
+            };
+            let x = total(solution.into_x());
+            let cert = bidiag.certify(&x, b)?;
+            let converged = convergence.certified(&cert, ne_reference);
             return Ok(LsmrResult {
                 x,
                 converged,
                 iterations: itn,
                 residual_norm: cert.normr,
-                normal_eq_residual: cert.normar / recurrence.zeta0,
+                normal_eq_residual: cert.normar / ne_reference,
                 stop_reason: if converged {
                     stop_reason
                 } else {
@@ -359,7 +373,7 @@ fn lsmr_from_bidiag<B: Bidiagonalization>(
             };
             if rule.should_escalate(progress) {
                 return Ok(LsmrResult {
-                    x: solution.into_x(),
+                    x: total(solution.into_x()),
                     converged: false,
                     iterations: itn,
                     residual_norm: recurrence.residual_estimate(),
@@ -372,7 +386,7 @@ fn lsmr_from_bidiag<B: Bidiagonalization>(
     }
 
     Ok(LsmrResult {
-        x: solution.into_x(),
+        x: total(solution.into_x()),
         converged: false,
         iterations: maxiter,
         residual_norm: recurrence.residual_estimate(),

--- a/crates/schwarz-precond/src/lsmr.rs
+++ b/crates/schwarz-precond/src/lsmr.rs
@@ -164,7 +164,7 @@ impl EscalationHandler for StalenessRun {
 /// Optional behaviors for [`mlsmr`].
 #[derive(Clone, Copy, Default)]
 pub struct MlsmrOptions<'a> {
-    /// Initial iterate for a residual correction; tolerances remain relative to the original `‖b‖`.
+    /// Residual-correction start; tolerances stay relative to `‖b‖` (`‖b − A x₀‖` if `b = 0`).
     pub warm_start: Option<&'a [f64]>,
     /// Hands off to a stronger preconditioner mid-run; see [`EscalationPolicy`].
     pub escalation: Option<&'a dyn EscalationPolicy>,
@@ -279,7 +279,8 @@ pub fn mlsmr<A: Operator + ?Sized, M: Operator + ?Sized>(
     }
 
     let (bidiag, step1) = ModifiedGolubKahan::init(operator, preconditioner, &rhs, local_size)?;
-    let criteria = ConvergenceCriteria::new(b_norm, tol);
+    let reference_norm = if b_norm > 0.0 { b_norm } else { rhs_norm };
+    let criteria = ConvergenceCriteria::new(reference_norm, tol);
     lsmr_from_bidiag(
         bidiag,
         step1,

--- a/crates/schwarz-precond/src/lsmr/tests/audit.rs
+++ b/crates/schwarz-precond/src/lsmr/tests/audit.rs
@@ -42,7 +42,7 @@ fn scripted_run(normr: f64, normar: f64) -> super::super::LsmrResult {
         beta: 1.0,
     };
     let criteria = ConvergenceCriteria::new(1.0, 1e-10);
-    lsmr_from_bidiag(stream, step1, &[1.0, 1.0], 1.0, criteria, 5, None).expect("scripted run")
+    lsmr_from_bidiag(stream, step1, &[1.0, 1.0], None, criteria, 5, None).expect("scripted run")
 }
 
 #[test]

--- a/crates/schwarz-precond/src/lsmr/tests/ladder.rs
+++ b/crates/schwarz-precond/src/lsmr/tests/ladder.rs
@@ -93,6 +93,8 @@ fn test_mlsmr_zero_rhs_corrects_non_exact_warm_start() {
     let result = mlsmr(&op, &[0.0, 0.0, 0.0], &op, 1e-10, 10, options).expect("warm correction");
 
     assert!(result.converged);
+    // `b = 0` leaves `‖b − A x₀‖` as the only scale, so the residual leg is satisfiable.
+    assert_eq!(result.stop_reason, LsmrStopReason::ResidualTolerance);
     assert!(vec_norm(&result.x) < 1e-12);
     assert!(result.iterations > 0);
 }


### PR DESCRIPTION
Closes #292.

The true-residual audit of a warm-started stop measured the correction against the re-based `rhs = b − A x₀` and certified its normal-equation leg against the restart's own `ζ̄₀`. A restart from a refused iterate could therefore fake through.

- The audit measures the total solution `x₀ + δ` against the original `b`.
- Its normal-equation leg is anchored to the cold `‖Âᵀb‖`, recovered by auditing `x = 0`; one extra operator pass per warm-started stop.
- A warm start with `b = 0` measures its tolerances against `‖b − A x₀‖`.

Cold runs are unchanged. The stopping rules stay Fong & Saunders S1 and S2: an `ε‖A‖‖b‖` floor stop, a `σ_min` optimality-gap stop, and a condition-number rule were each measured against `main` and made no case better (first two commits here, reverted by the third). Chang, Paige & Titley-Peloquin (SIMAX 2009) name the near-consistent S2 stall and the recurrence collapse; within's tolerances sit far above the floor they describe.
