### PR TITLE
Fail an LSMR solve on a non-finite operator or preconditioner output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 - A design carrying varying slopes on two distinct factors could fail preconditioner construction with `matrix is not symmetric`, when rounding left the two triangles of the exact Schur complement unequal (#229).
 - A `design` that is neither a 2-D `uint32` array nor a list of `Effect` raised `ValueError` where the documented type is `TypeError`, and `AdditiveSchwarz` accepted a wrong-type `local_solver` at construction, deferring the `TypeError` to solve time (#248).
 - A slope covariate collinear with another term could make LSMR report convergence on a solve that had not demeaned the response; tolerance stops are now audited against the true residual and a failed check reports `LsmrStopReason::FalseConvergence` with `converged = false` (#290).
+- A non-finite `α`, `β`, `⟨v, Mv⟩`, or `‖b‖` in LSMR fails the solve with `SolveError::InvalidInput`; a NaN previously read as `α = 0` and reported a converged `x = 0`, and an overflowing `‖b‖` certified any result. The preconditioner-indefiniteness test no longer over- or underflows at extreme magnitudes (#303).
 
 ### Removed
 

--- a/crates/schwarz-precond/src/lsmr.rs
+++ b/crates/schwarz-precond/src/lsmr.rs
@@ -186,7 +186,7 @@ pub fn lsmr<A: Operator + ?Sized>(
     validate_lsmr_inputs(operator, b, tol)?;
     let n = operator.ncols();
 
-    let b_norm = vec_norm(b);
+    let b_norm = finite(vec_norm(b), "rhs norm")?;
     if b_norm == 0.0 {
         return Ok(LsmrResult {
             x: vec![0.0; n],
@@ -242,7 +242,8 @@ pub fn mlsmr<A: Operator + ?Sized, M: Operator + ?Sized>(
         }
     }
 
-    let b_norm = vec_norm(b);
+    // `b` is finite entrywise, but its norm sets the tolerance and an ∞ there certifies anything.
+    let b_norm = finite(vec_norm(b), "rhs norm")?;
     let local_size = local_size.unwrap_or(0);
 
     let rhs: Cow<'_, [f64]> = match warm_start {
@@ -256,13 +257,8 @@ pub fn mlsmr<A: Operator + ?Sized, M: Operator + ?Sized>(
             Cow::Owned(residual)
         }
     };
-    let rhs_norm = vec_norm(&rhs);
     // Unlike `b`, `rhs` is computed: an ∞ entry norms to NaN, which reads as β₁ = 0 downstream.
-    if !rhs_norm.is_finite() {
-        return Err(invalid_input(format!(
-            "warm-start residual b - A·x0 has non-finite norm {rhs_norm}"
-        )));
-    }
+    let rhs_norm = finite(vec_norm(&rhs), "warm-start residual norm")?;
     if rhs_norm == 0.0 {
         let (x, stop_reason) = match warm_start {
             Some(x0) => (x0.to_vec(), LsmrStopReason::WarmStartExact),
@@ -419,6 +415,14 @@ fn validate_lsmr_inputs<A: Operator + ?Sized>(
         )));
     }
     Ok(())
+}
+
+/// Every comparison against a non-finite value is false, so it reads as a breakdown downstream.
+fn finite(value: f64, what: &str) -> Result<f64, SolveError> {
+    if !value.is_finite() {
+        return Err(invalid_input(format!("non-finite {what} ({value})")));
+    }
+    Ok(value)
 }
 
 fn invalid_input(message: String) -> SolveError {

--- a/crates/schwarz-precond/src/lsmr/bidiag.rs
+++ b/crates/schwarz-precond/src/lsmr/bidiag.rs
@@ -10,6 +10,7 @@
 #[cfg(test)]
 mod tests;
 
+use super::finite;
 use crate::{Operator, SolveError};
 use rayon::iter::{IndexedParallelIterator, ParallelIterator};
 use rayon::prelude::{ParallelSlice, ParallelSliceMut};
@@ -97,7 +98,8 @@ fn par_dot(a: &[f64], b: &[f64]) -> f64 {
 
 /// `α = √⟨v, p̃⟩`; a `vp` negative within `√ε·‖v‖‖p̃‖` clamps to 0, an indefinite `M` raises.
 fn alpha_from_vp(v: &[f64], p_tilde: &[f64]) -> Result<f64, SolveError> {
-    let vp = par_dot(v, p_tilde);
+    // `vp.max(0.0)` returns 0 for NaN, which α = 0 reports as an exact solve at x = 0.
+    let vp = finite(par_dot(v, p_tilde), "⟨v, Mv⟩")?;
     if vp < 0.0 {
         let bound = f64::EPSILON.sqrt() * (par_dot(v, v) * par_dot(p_tilde, p_tilde)).sqrt();
         if vp < -bound {
@@ -262,7 +264,7 @@ impl<A: Operator + ?Sized> Bidiagonalization for GolubKahan<'_, A> {
     fn step(&mut self) -> Result<BidiagStep, SolveError> {
         self.operator.apply(&self.bufs.v, &mut self.bufs.av)?;
         let beta_sq = axpy_with_sq_norm(&mut self.bufs.u, &self.bufs.av, -self.alpha);
-        let beta = beta_sq.sqrt();
+        let beta = finite(beta_sq.sqrt(), "β")?;
         if beta == 0.0 {
             // Lucky breakdown: zero `v` so `solution.update` contributes nothing.
             self.bufs.v.fill(0.0);
@@ -281,7 +283,7 @@ impl<A: Operator + ?Sized> Bidiagonalization for GolubKahan<'_, A> {
             reorth.reorthogonalize(&mut self.bufs.v);
             alpha_sq = par_dot(&self.bufs.v, &self.bufs.v);
         }
-        let alpha = alpha_sq.sqrt();
+        let alpha = finite(alpha_sq.sqrt(), "α")?;
         if alpha > 0.0 {
             scale_in_place(&mut self.bufs.v, 1.0 / alpha);
         }
@@ -314,7 +316,7 @@ impl<A: Operator + ?Sized, M: Operator + ?Sized> Bidiagonalization
         let scale = -(self.alpha * self.beta_prev_inv);
         self.operator.apply(&self.bufs.v, &mut self.bufs.av)?;
         let beta_sq = axpy_with_sq_norm(&mut self.bufs.u, &self.bufs.av, scale);
-        let beta = beta_sq.sqrt();
+        let beta = finite(beta_sq.sqrt(), "β")?;
         if beta == 0.0 {
             // Lucky breakdown: zero `v` and its paired `p̃` so the update contributes nothing.
             self.bufs.v.fill(0.0);
@@ -408,7 +410,7 @@ impl<'a, A: Operator + ?Sized> GolubKahan<'a, A> {
         }
 
         operator.apply_adjoint(&bufs.u, &mut bufs.v)?;
-        let alpha = par_dot(&bufs.v, &bufs.v).sqrt();
+        let alpha = finite(par_dot(&bufs.v, &bufs.v).sqrt(), "α")?;
         if alpha > 0.0 {
             scale_in_place(&mut bufs.v, 1.0 / alpha);
         }

--- a/crates/schwarz-precond/src/lsmr/bidiag.rs
+++ b/crates/schwarz-precond/src/lsmr/bidiag.rs
@@ -101,8 +101,11 @@ fn alpha_from_vp(v: &[f64], p_tilde: &[f64]) -> Result<f64, SolveError> {
     // `vp.max(0.0)` returns 0 for NaN, which α = 0 reports as an exact solve at x = 0.
     let vp = finite(par_dot(v, p_tilde), "⟨v, Mv⟩")?;
     if vp < 0.0 {
-        let bound = f64::EPSILON.sqrt() * (par_dot(v, v) * par_dot(p_tilde, p_tilde)).sqrt();
-        if vp < -bound {
+        let norm_v = finite(super::vec_norm(v), "‖v‖")?;
+        let norm_p = finite(super::vec_norm(p_tilde), "‖p̃‖")?;
+        // Dividing by the smaller norm first keeps the sign decision exact where a product fails.
+        let (small, large) = (norm_v.min(norm_p), norm_v.max(norm_p));
+        if vp / small / large < -f64::EPSILON.sqrt() {
             return Err(SolveError::InvalidInput {
                 context: "mlsmr",
                 message: "preconditioner not positive definite (⟨v, Mv⟩ < 0)".to_string(),

--- a/crates/schwarz-precond/src/lsmr/bidiag/tests.rs
+++ b/crates/schwarz-precond/src/lsmr/bidiag/tests.rs
@@ -1,7 +1,69 @@
 //! White-box checks on the bidiagonalization itself.
 
-use super::{dot, Bidiagonalization, GolubKahan};
-use crate::lsmr::fixtures::DenseOp;
+use super::{alpha_from_vp, dot, Bidiagonalization, GolubKahan};
+use crate::lsmr::fixtures::{DenseOp, DiagOp};
+use crate::{Operator, SolveError};
+
+/// A NaN `vp` clamped to α = 0 via `f64::max`, which the driver reports as an exact solve at x = 0.
+#[test]
+fn alpha_from_vp_rejects_non_finite_and_indefinite_pairs() {
+    let rejected = [
+        (vec![1.0, f64::NAN], vec![1.0, 1.0]),
+        (vec![1.0, f64::INFINITY], vec![1.0, 1.0]),
+    ];
+    for (v, p) in &rejected {
+        assert!(
+            matches!(alpha_from_vp(v, p), Err(SolveError::InvalidInput { .. })),
+            "{v:?}·{p:?} accepted"
+        );
+    }
+    let clamped = [(vec![1.0, 1.0], vec![1.0, -1.0 - 1e-12])];
+    for (v, p) in &clamped {
+        assert_eq!(alpha_from_vp(v, p).expect("within √ε"), 0.0, "{v:?}·{p:?}");
+    }
+}
+
+/// `beta == 0.0` and `alpha > 0.0` are both false for NaN; unguarded, an overflow poisons the run.
+#[test]
+fn a_non_finite_operator_norm_is_an_error() {
+    for bad in [f64::NAN, f64::MAX] {
+        let result = crate::lsmr::lsmr(&DiagOp(vec![bad, 1.0]), &[1.0, 1.0], 1e-10, 50, None);
+        assert!(
+            matches!(result, Err(SolveError::InvalidInput { .. })),
+            "{bad:e} accepted"
+        );
+    }
+}
+
+/// A finite adjoint keeps `init` clean, so the overflow reaches the `step` guard on β.
+#[test]
+fn an_overflow_after_initialization_is_an_error() {
+    struct OverflowingForward;
+    impl Operator for OverflowingForward {
+        fn nrows(&self) -> usize {
+            2
+        }
+        fn ncols(&self) -> usize {
+            2
+        }
+        fn apply(&self, _x: &[f64], y: &mut [f64]) -> Result<(), SolveError> {
+            y.fill(f64::MAX);
+            Ok(())
+        }
+        fn apply_adjoint(&self, x: &[f64], y: &mut [f64]) -> Result<(), SolveError> {
+            y.copy_from_slice(x);
+            Ok(())
+        }
+    }
+    let (mut bidiag, first) =
+        GolubKahan::init(&OverflowingForward, &[1.0, 1.0], 0).expect("finite init");
+    assert!(first.alpha > 0.0);
+    let err = bidiag.step().err().expect("an overflowing β was accepted");
+    assert!(
+        matches!(&err, SolveError::InvalidInput { message, .. } if message.contains("β")),
+        "{err}"
+    );
+}
 
 /// Window smaller than the iteration count: the ring must wrap correctly.
 /// We re-run the bidiagonalization manually with the same window and

--- a/crates/schwarz-precond/src/lsmr/bidiag/tests.rs
+++ b/crates/schwarz-precond/src/lsmr/bidiag/tests.rs
@@ -4,12 +4,15 @@ use super::{alpha_from_vp, dot, Bidiagonalization, GolubKahan};
 use crate::lsmr::fixtures::{DenseOp, DiagOp};
 use crate::{Operator, SolveError};
 
-/// A NaN `vp` clamped to α = 0 via `f64::max`, which the driver reports as an exact solve at x = 0.
+/// A NaN `vp` clamped to α = 0 via `f64::max`; a product bound overflowed to ∞ or underflowed to 0.
 #[test]
 fn alpha_from_vp_rejects_non_finite_and_indefinite_pairs() {
     let rejected = [
         (vec![1.0, f64::NAN], vec![1.0, 1.0]),
         (vec![1.0, f64::INFINITY], vec![1.0, 1.0]),
+        (vec![-1e100], vec![1e100]),
+        (vec![-1e302, f64::MAX, f64::MAX], vec![1.0, 0.0, 0.0]),
+        (vec![-2e300, 1e308], vec![1e-316, 0.0]),
     ];
     for (v, p) in &rejected {
         assert!(
@@ -17,7 +20,11 @@ fn alpha_from_vp_rejects_non_finite_and_indefinite_pairs() {
             "{v:?}·{p:?} accepted"
         );
     }
-    let clamped = [(vec![1.0, 1.0], vec![1.0, -1.0 - 1e-12])];
+    let clamped = [
+        (vec![1.0, 1.0], vec![1.0, -1.0 - 1e-12]),
+        (vec![1e-100, 1e-100], vec![1e-100, -1.000000000001e-100]),
+        (vec![1e-316, 1e-316], vec![1e308, -1.000000000001e308]),
+    ];
     for (v, p) in &clamped {
         assert_eq!(alpha_from_vp(v, p).expect("within √ε"), 0.0, "{v:?}·{p:?}");
     }

--- a/crates/schwarz-precond/src/lsmr/tests/breakdown.rs
+++ b/crates/schwarz-precond/src/lsmr/tests/breakdown.rs
@@ -179,6 +179,13 @@ fn test_mlsmr_rejects_invalid_inputs() {
         None,
     );
     assert!(matches!(bad_rhs, Err(SolveError::InvalidInput { .. })));
+
+    // Finite entrywise, but `‖b‖` overflows and would scale u₁ to zero, reading as α₁ = 0.
+    let overflowing_rhs = lsmr(&OverdeterminedOp, &[f64::MAX; 4], 1e-10, 100, None);
+    assert!(matches!(
+        overflowing_rhs,
+        Err(SolveError::InvalidInput { .. })
+    ));
 }
 
 #[test]

--- a/crates/schwarz-precond/src/lsmr/tests/ladder.rs
+++ b/crates/schwarz-precond/src/lsmr/tests/ladder.rs
@@ -82,6 +82,25 @@ fn test_mlsmr_warm_rejects_overflowing_warm_start_residual() {
     ));
 }
 
+/// `‖b‖` sets the tolerance even when the warm-start residual it is measured against is finite.
+#[test]
+fn test_mlsmr_warm_rejects_overflowing_rhs_norm() {
+    let op = DiagOp(vec![1.0, 1.1]);
+    let m = DiagOp(vec![1e-310; 2]);
+    let x0 = [1.2e308, 1.1e308];
+    let options = MlsmrOptions {
+        warm_start: Some(&x0),
+        ..Default::default()
+    };
+    let err = mlsmr(&op, &[1.3e308; 2], &m, 1e-10, 10, options)
+        .err()
+        .expect("an infinite ‖b‖ certified the warm start");
+    assert!(
+        matches!(&err, SolveError::InvalidInput { message, .. } if message.contains("rhs norm")),
+        "{err}"
+    );
+}
+
 #[test]
 fn test_mlsmr_zero_rhs_corrects_non_exact_warm_start() {
     let op = IdentityOp { n: 3 };


### PR DESCRIPTION
A NaN `⟨v, Mv⟩` from the operator or preconditioner passed through `vp.max(0.0)` as 0, so LSMR reported `InitialNormalEquationResidualZero`, a least-squares solution at `x = 0`, on a system it had not solved. A NaN `α` or `β` likewise failed both the `== 0.0` and `> 0.0` branches, leaving the vector unscaled and the recurrence silently poisoned.

Two overflow paths of the same class, found in review, are closed too: `‖b‖` overflowing to `∞` scaled `u₁` to zero and read as α₁ = 0, and the indefiniteness bound `√(‖v‖²‖p̃‖²)` overflowed where the norms did not, so an indefinite `M` clamped to α = 0 instead of raising.

All now fail the solve with `SolveError::InvalidInput` naming the offending quantity. Root cause of the silent `x = 0` seen in #303; split out of the adaptive-ladder branch so it lands independently of #309/#340.