### PR TITLE
Give Staleness a Default, field accessors, and validated serde

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `schwarz_precond::Staleness` gains `Default` (window 4, threshold 0.7), `window()`/`threshold()` accessors, and serde support validated through `try_new` (#260).
 - Python `Preconditioner.build_duration_seconds` and Rust `Preconditioner::build_duration()` expose the original preconditioner build duration, preserved across serialization and reuse.
 - `BuildWarning::CollinearSlopeCovariate` reports a slope covariate that is (nearly) a per-level combination of another term's columns — a cross-term near-null direction that per-term whitening cannot see and that can inflate iteration counts by orders of magnitude (#281).
 - `schwarz_precond::EscalationPolicy` builds a per-run `EscalationHandler` that ends a solve with `LsmrStopReason::Escalated` and an iterate that warm-starts the next preconditioner; `Staleness` implements it from the trailing contraction window.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,6 +1532,7 @@ name = "schwarz-precond"
 version = "0.4.0"
 dependencies = [
  "faer",
+ "postcard",
  "rayon",
  "serde",
  "thiserror 2.0.20",

--- a/crates/schwarz-precond/Cargo.toml
+++ b/crates/schwarz-precond/Cargo.toml
@@ -21,6 +21,7 @@ thread_local = "1.1"
 
 [dev-dependencies]
 faer.workspace = true
+postcard.workspace = true
 
 [lints]
 workspace = true

--- a/crates/schwarz-precond/src/lsmr.rs
+++ b/crates/schwarz-precond/src/lsmr.rs
@@ -96,6 +96,7 @@ pub trait EscalationHandler {
 
 /// Escalates after `window` consecutive contraction ratios exceed `threshold`.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Staleness {
     window: usize,
     threshold: f64,
@@ -127,6 +128,43 @@ impl Staleness {
             return Err(StalenessError::InvalidThreshold { threshold });
         }
         Ok(Self { window, threshold })
+    }
+
+    /// Consecutive stalled iterations required before escalating.
+    pub fn window(&self) -> usize {
+        self.window
+    }
+
+    /// Contraction ratio above which an iteration counts as stalled.
+    pub fn threshold(&self) -> f64 {
+        self.threshold
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Staleness {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        struct Helper {
+            window: usize,
+            threshold: f64,
+        }
+
+        let helper = Helper::deserialize(deserializer)?;
+        Self::try_new(helper.window, helper.threshold).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Default for Staleness {
+    /// Escalates after four consecutive residual reductions below 30% (ratio above 0.7).
+    fn default() -> Self {
+        Self {
+            window: 4,
+            threshold: 0.7,
+        }
     }
 }
 

--- a/crates/schwarz-precond/src/lsmr/tests/ladder.rs
+++ b/crates/schwarz-precond/src/lsmr/tests/ladder.rs
@@ -235,6 +235,31 @@ fn test_staleness_escalates_only_the_stalling_preconditioner() {
 }
 
 #[test]
+fn test_staleness_default_exposes_its_fields() {
+    let default = Staleness::default();
+    assert_eq!(default.window(), 4);
+    assert_eq!(default.threshold(), 0.7);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_staleness_serde_round_trips_and_validates() {
+    let default = Staleness::default();
+    let bytes = postcard::to_stdvec(&default).expect("serialize");
+    assert_eq!(
+        postcard::from_bytes::<Staleness>(&bytes).expect("deserialize"),
+        default
+    );
+    for invalid in [(0usize, 0.7f64), (4, 1.0)] {
+        let bytes = postcard::to_stdvec(&invalid).expect("serialize");
+        assert!(
+            postcard::from_bytes::<Staleness>(&bytes).is_err(),
+            "{invalid:?}"
+        );
+    }
+}
+
+#[test]
 fn test_staleness_rejects_invalid_configuration() {
     assert!(matches!(
         Staleness::try_new(0, 0.7),


### PR DESCRIPTION
Slice 2 of `feat/adaptive-cluster-rung`, independent of the #309/#340 stack.

`schwarz_precond::Staleness` gains `Default` (window 4, threshold 0.7), `window()`/`threshold()` accessors, and serde support behind the `serde` feature. Deserialization runs through `try_new`, so a serialized config cannot carry a zero window or an out-of-range threshold; a postcard round-trip test covers both directions.

On main nothing outside the module consumes these yet. Their consumers arrive with the later adaptive slices: the `PreconditionerConfig::Adaptive` default, the Python `Staleness` getters, and the serialized preconditioner config.