### PR TITLE
Build a cross-tab's transpose lazily and drop the Gremban cover before its factor

### DIFF
--- a/crates/within/src/block_elim/schur.rs
+++ b/crates/within/src/block_elim/schur.rs
@@ -109,7 +109,7 @@ fn compute_schur_row_dense(
     touched.push(i);
 
     let elim_to_keep = &matrix.cross_tab.c;
-    for (k, w) in matrix.cross_tab.ct.row(i) {
+    for (k, w) in matrix.cross_tab.ct().row(i) {
         let inv = inv_diagonal_eliminated[k];
         let start = elim_to_keep.indptr[k] as usize;
         let end = elim_to_keep.indptr[k + 1] as usize;
@@ -239,7 +239,7 @@ fn reduced_surplus(matrix: &SddmMatrix, inv_diagonal_eliminated: &[f64]) -> Vec<
     let mut surplus = vec![0.0; matrix.n_kept()];
     matrix
         .cross_tab
-        .ct
+        .ct()
         .spmv_assign_add(&scaled, matrix.surplus_kept(), &mut surplus, false);
     surplus
 }

--- a/crates/within/src/block_elim/solver.rs
+++ b/crates/within/src/block_elim/solver.rs
@@ -111,7 +111,7 @@ impl<'de> serde::Deserialize<'de> for BlockElimSolver {
         let h = Helper::deserialize(deserializer)?;
 
         // `ct`'s row count is the only witness bounding `c.ncols`.
-        let CrossTab { c, ct } = h.cross_tab;
+        let (c, ct) = h.cross_tab.into_parts();
         if !c.is_structurally_valid() {
             return Err(D::Error::custom(
                 "cross_tab.c is not a structurally valid CSR block",
@@ -144,9 +144,8 @@ impl<'de> serde::Deserialize<'de> for BlockElimSolver {
         }
 
         // Rebuild from the validated `c` so the transpose cannot disagree.
-        let ct = c.transpose();
         Ok(BlockElimSolver::new(
-            CrossTab { c, ct },
+            CrossTab::eager(c),
             h.inv_diag_elim,
             h.reduced_factor,
             h.coordinates,
@@ -258,12 +257,8 @@ fn assemble_bipartite_cover(matrix: &SddmMatrix) -> SddmMatrix {
         nrows: 2 * n_rows,
         ncols: 2 * n_cols,
     };
-    let cover_ct = cover_c.transpose();
     SddmMatrix {
-        cross_tab: CrossTab {
-            c: cover_c,
-            ct: cover_ct,
-        },
+        cross_tab: CrossTab::new(cover_c),
         diagonal: double_for_cover(&matrix.diagonal, n_rows),
         ground_edges: double_for_cover(&matrix.ground_edges, n_rows),
         grounding: matrix.grounding,
@@ -294,6 +289,8 @@ impl BlockElimSolver {
         coordinates: CoordinateMap,
     ) -> Self {
         let cross_tab = cross_tab.into();
+        // Every solve reads the transpose, so it is built here rather than inside the first.
+        cross_tab.ct();
         debug_assert!(reduced_factor.spans_kept_block(cross_tab.n_cols()));
         let n_internal = cross_tab.n_local();
         let n_reduced = reduced_factor.solve_dimension();
@@ -362,7 +359,7 @@ impl BlockElimSolver {
         {
             let (main, scratch) = rhs.split_at_mut(n);
             scratch[n_keep..self.n_reduced].fill(0.0);
-            self.cross_tab.ct.spmv_assign_add(
+            self.cross_tab.ct().spmv_assign_add(
                 &main[..n_elim],
                 &main[n_elim..],
                 &mut scratch[..n_keep],

--- a/crates/within/src/block_elim/solver.rs
+++ b/crates/within/src/block_elim/solver.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::sync::Arc;
 
 use approx_chol::{ExactFailure, Factor};
@@ -182,38 +183,48 @@ impl Eliminated {
         })
     }
 
-    /// Fold of the signed matrix's Gremban cover; transient, dropped once its factor is built.
+    /// Fold of the signed matrix's Gremban cover; transient, dropped once its complement is built.
     fn cover(&self) -> Result<Self, BuildError> {
         Self::new(assemble_bipartite_cover(&self.matrix))
     }
 
     /// A dense Cholesky spends nothing on sparsity, so it entails the exact complement.
-    fn factor_reduced(&self, config: &LocalSolverConfig) -> Result<Factor, BuildError> {
+    fn factor_reduced(
+        fold: impl Borrow<Self>,
+        config: &LocalSolverConfig,
+    ) -> Result<Factor, BuildError> {
+        let this = fold.borrow();
         let exact_below = config.dense_threshold;
-        let factor = |complement: &CsrMatrix, on_failure| {
-            factor_sparse(
-                complement,
-                config.approx_chol.to_approx_chol(exact_below, on_failure),
-            )
-        };
-
-        let exact = (exact_below > 0 && self.matrix.n_kept() <= exact_below)
-            .then(|| schur::exact_for_factor(&self.matrix, &self.inv_diagonal));
+        let exact = (exact_below > 0 && this.matrix.n_kept() <= exact_below)
+            .then(|| schur::exact_for_factor(&this.matrix, &this.inv_diagonal));
         if let Some(exact) = &exact {
-            match factor(exact, ExactFailure::Error) {
+            match factor_complement(exact, config, ExactFailure::Error) {
                 Err(approx_chol::Error::DenseFactorizationFailed { .. }) => {}
                 result => return result.map_err(local_solver_build),
             }
         }
-
         let complement = match &config.schur {
-            SchurMode::Approximate(cfg) => schur::sampled(&self.matrix, cfg),
+            SchurMode::Approximate(cfg) => schur::sampled(&this.matrix, cfg),
             SchurMode::Exact => {
-                exact.unwrap_or_else(|| schur::exact_for_factor(&self.matrix, &self.inv_diagonal))
+                exact.unwrap_or_else(|| schur::exact_for_factor(&this.matrix, &this.inv_diagonal))
             }
         };
-        factor(&complement, ExactFailure::FallBackToApproximate).map_err(local_solver_build)
+        // An owned fold is the transient cover; it is freed before the factor's fill is allocated.
+        drop(fold);
+        factor_complement(&complement, config, ExactFailure::FallBackToApproximate)
+            .map_err(local_solver_build)
     }
+}
+
+fn factor_complement(
+    complement: &CsrMatrix,
+    config: &LocalSolverConfig,
+    on_failure: ExactFailure,
+) -> Result<Factor, approx_chol::Error> {
+    let approx_chol = config
+        .approx_chol
+        .to_approx_chol(config.dense_threshold, on_failure);
+    factor_sparse(complement, approx_chol)
 }
 
 /// Gremban cover: SDDM, and acts on the antisymmetric `[z, -z]` subspace as the original.
@@ -319,20 +330,17 @@ impl BlockElimSolver {
         let factor = match form {
             MatrixForm::Laplacian => {
                 let factor = ReducedFactor::Direct {
-                    factor: eliminated.factor_reduced(config)?,
+                    factor: Eliminated::factor_reduced(&eliminated, config)?,
                     grounding: eliminated.matrix.grounding,
                 };
                 debug_assert!(factor.solve_dimension() >= factor.input_dimension());
                 factor
             }
             // Surplus survives the cover, so it grounds as the signed matrix did.
-            MatrixForm::SignedPendingCover => {
-                let cover = eliminated.cover()?;
-                ReducedFactor::Cover {
-                    inner: cover.factor_reduced(config)?,
-                    m: eliminated.matrix.n_kept(),
-                }
-            }
+            MatrixForm::SignedPendingCover => ReducedFactor::Cover {
+                inner: Eliminated::factor_reduced(eliminated.cover()?, config)?,
+                m: eliminated.matrix.n_kept(),
+            },
         };
 
         Ok(BlockElimSolver::new(

--- a/crates/within/src/block_elim/solver/tests.rs
+++ b/crates/within/src/block_elim/solver/tests.rs
@@ -477,8 +477,7 @@ fn kept_block_wider_than_the_reduced_factor_is_rejected() {
     // Earlier cross-field witnesses stay intact, so the factor's span is the check under test.
     let mut c = bad.cross_tab.c.clone();
     c.ncols += 2;
-    let ct = c.transpose();
-    bad.cross_tab = Arc::new(CrossTab { c, ct });
+    bad.cross_tab = Arc::new(CrossTab::eager(c));
     let bytes = postcard::to_stdvec(&bad).expect("serialize");
     assert!(postcard::from_bytes::<BlockElimSolver>(&bytes).is_err());
 }

--- a/crates/within/src/block_elim/solver/tests.rs
+++ b/crates/within/src/block_elim/solver/tests.rs
@@ -96,7 +96,7 @@ fn an_unusable_dense_pivot_is_retried_rather_than_fatal() {
         };
 
         assert!(
-            eliminated.factor_reduced(&config).is_ok(),
+            Eliminated::factor_reduced(&eliminated, &config).is_ok(),
             "{:?}: an unusable pivot must not be fatal",
             config.schur
         );

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -1,9 +1,13 @@
 //! Cross-tabulation of a channel pair: the bipartite local Gramian.
 //!
-//! [`CrossTab`] holds `C` as a [`CsrBlock`] plus its precomputed transpose and
-//! the two diagonals (rather than assembling the symmetric block matrix), and
+//! [`CrossTab`] holds `C` as a [`CsrBlock`] plus its transpose, built on first use,
+//! and the two diagonals (rather than assembling the symmetric block matrix), and
 //! supports bipartite connected-components splitting and per-component extraction.
 //! Levels are stored compactly with a `local_to_global` map for active levels only.
+
+use std::sync::OnceLock;
+
+use serde::ser::SerializeStruct;
 
 use crate::channel::ChannelPair;
 use crate::csr_block::{to_u32, CsrBlock};
@@ -92,12 +96,72 @@ pub(crate) struct BipartiteComponent {
 }
 
 /// Stores `C` and `Cᵀ` only; the solve path never reads the diagonals of `G`.
-#[derive(Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Clone)]
 pub(crate) struct CrossTab {
     /// CSR(C): row-block rows (n_rows) x col-block cols (n_cols).
     pub(crate) c: CsrBlock,
-    /// CSR(Cᵀ): `n_cols` x `n_rows`, precomputed via `c.transpose()`.
-    pub(crate) ct: CsrBlock,
+    /// CSR(Cᵀ), built on first use so a cover that only reads rows of `C` never pays for it.
+    ct: OnceLock<CsrBlock>,
+}
+
+impl CrossTab {
+    pub(crate) fn new(c: CsrBlock) -> Self {
+        Self {
+            c,
+            ct: OnceLock::new(),
+        }
+    }
+
+    pub(crate) fn with_transpose(c: CsrBlock, ct: CsrBlock) -> Self {
+        debug_assert!(ct.nrows == c.ncols && ct.ncols == c.nrows);
+        Self {
+            c,
+            ct: OnceLock::from(ct),
+        }
+    }
+
+    /// Both blocks up front, for a cross-tab the solve will read on every iteration.
+    pub(crate) fn eager(c: CsrBlock) -> Self {
+        let ct = c.transpose();
+        Self::with_transpose(c, ct)
+    }
+
+    pub(crate) fn ct(&self) -> &CsrBlock {
+        self.ct.get_or_init(|| self.c.transpose())
+    }
+
+    pub(crate) fn into_parts(self) -> (CsrBlock, CsrBlock) {
+        self.ct();
+        let ct = self.ct.into_inner().expect("transpose was just built");
+        (self.c, ct)
+    }
+}
+
+// The wire carries both blocks, as the derive did, so the format is unchanged.
+impl serde::Serialize for CrossTab {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut state = serializer.serialize_struct("CrossTab", 2)?;
+        state.serialize_field("c", &self.c)?;
+        state.serialize_field("ct", self.ct())?;
+        state.end()
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for CrossTab {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(serde::Deserialize)]
+        #[serde(rename = "CrossTab")]
+        struct Wire {
+            c: CsrBlock,
+            ct: CsrBlock,
+        }
+        // Shapes are the owning solver's decoder's to reject; corrupt bytes must not panic here.
+        let Wire { c, ct } = Wire::deserialize(deserializer)?;
+        Ok(Self {
+            c,
+            ct: OnceLock::from(ct),
+        })
+    }
 }
 
 /// Folded into the reduced factor during assembly and never read again, so not serialized.
@@ -151,8 +215,7 @@ impl CrossTab {
         )?;
 
         let (c, row_diag, col_diag) = accumulate_cross_block(design, weights, pair, &active);
-        let ct = c.transpose();
-        let cross_tab = CrossTab { c, ct };
+        let cross_tab = CrossTab::eager(c);
         let diagonals = BlockDiagonals {
             rows: row_diag,
             cols: col_diag,
@@ -166,7 +229,7 @@ impl CrossTab {
         let (block, row, off) = if i < n_rows {
             (&self.c, i, n_rows)
         } else {
-            (&self.ct, i - n_rows, 0)
+            (self.ct(), i - n_rows, 0)
         };
         block.row(row).map(move |(j, v)| (off + j, v))
     }
@@ -252,8 +315,6 @@ impl CrossTab {
             nrows: n_rows,
             ncols: n_cols,
         };
-        let ct = c.transpose();
-
         for &old_idx in &comp.rows {
             row_remap[old_idx] = u32::MAX;
         }
@@ -261,7 +322,7 @@ impl CrossTab {
             col_remap[old_idx] = u32::MAX;
         }
 
-        CrossTab { c, ct }
+        CrossTab::eager(c)
     }
 }
 

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -13,8 +13,7 @@ use crate::observation::ObservationFrame;
 impl CrossTab {
     pub(crate) fn from_dense_for_test(table: &[f64], n_rows: usize, n_cols: usize) -> Self {
         let c = CsrBlock::from_dense_table(table, n_rows, n_cols);
-        let ct = c.transpose();
-        Self { c, ct }
+        Self::eager(c)
     }
 }
 
@@ -100,14 +99,16 @@ fn test_cross_tab_sparse_accumulation_path() {
     // C^T must equal the transpose of C for both paths.
     let ct_t = ct_sparse.c.transpose();
     assert_eq!(
-        ct_t.indptr, ct_sparse.ct.indptr,
+        ct_t.indptr,
+        ct_sparse.ct().indptr,
         "sparse: C^T indptr should equal transpose(C)"
     );
     assert_eq!(
-        ct_t.indices, ct_sparse.ct.indices,
+        ct_t.indices,
+        ct_sparse.ct().indices,
         "sparse: C^T indices should equal transpose(C)"
     );
-    for (a, b) in ct_t.data.iter().zip(&ct_sparse.ct.data) {
+    for (a, b) in ct_t.data.iter().zip(&ct_sparse.ct().data) {
         assert!(
             (a - b).abs() < 1e-12,
             "sparse: C^T data should equal transpose(C)"
@@ -176,14 +177,16 @@ fn test_extract_component_two_components() {
     // C^T of sub_a should equal the exact transpose of sub_a.c.
     let ct_t = sub_a.c.transpose();
     assert_eq!(
-        ct_t.indptr, sub_a.ct.indptr,
+        ct_t.indptr,
+        sub_a.ct().indptr,
         "sub_a: ct.indptr should equal transpose(c).indptr"
     );
     assert_eq!(
-        ct_t.indices, sub_a.ct.indices,
+        ct_t.indices,
+        sub_a.ct().indices,
         "sub_a: ct.indices should equal transpose(c).indices"
     );
-    for (a, b) in ct_t.data.iter().zip(&sub_a.ct.data) {
+    for (a, b) in ct_t.data.iter().zip(&sub_a.ct().data) {
         assert!(
             (a - b).abs() < 1e-12,
             "sub_a: ct.data should equal transpose(c).data"

--- a/crates/within/src/domain/factor_pairs/sddm.rs
+++ b/crates/within/src/domain/factor_pairs/sddm.rs
@@ -98,14 +98,8 @@ pub(crate) fn orient_for_elimination(
     }
     diagonal.rotate_left(cross_tab.n_rows());
     globals.rotate_left(cross_tab.n_rows());
-    (
-        CrossTab {
-            c: cross_tab.ct,
-            ct: cross_tab.c,
-        },
-        diagonal,
-        globals,
-    )
+    let (c, ct) = cross_tab.into_parts();
+    (CrossTab::with_transpose(ct, c), diagonal, globals)
 }
 
 /// Bipartite SDDM in eliminated-major form; arrays are flat, split at `n_eliminated`.
@@ -256,7 +250,7 @@ fn convert_general(
 
 /// A [`MatrixForm::Laplacian`] must fold to a Z-matrix, so a positive off-diagonal is an error.
 fn assemble(
-    mut cross_tab: CrossTab,
+    cross_tab: CrossTab,
     diagonal: Vec<f64>,
     factors: Vec<f64>,
     form: MatrixForm,
@@ -264,11 +258,13 @@ fn assemble(
 ) -> Result<(LocalComponent, f64), NotScalable> {
     let n_rows = cross_tab.n_rows();
     let enforce_z = form == MatrixForm::Laplacian;
+    // The transpose is stale once `c` is folded; `_` drops it here, `..` would keep it to the end.
+    let (mut c, _) = cross_tab.into_parts();
     for i in 0..n_rows {
-        let start = cross_tab.c.indptr[i] as usize;
-        let end = cross_tab.c.indptr[i + 1] as usize;
-        let columns = &cross_tab.c.indices[start..end];
-        for (&j, value) in columns.iter().zip(&mut cross_tab.c.data[start..end]) {
+        let start = c.indptr[i] as usize;
+        let end = c.indptr[i + 1] as usize;
+        let columns = &c.indices[start..end];
+        for (&j, value) in columns.iter().zip(&mut c.data[start..end]) {
             let folded = -factors[i] * factors[n_rows + j as usize] * *value;
             if !folded.is_finite() || (enforce_z && folded < 0.0) {
                 return Err(NotScalable);
@@ -276,7 +272,7 @@ fn assemble(
             *value = folded;
         }
     }
-    cross_tab.ct = cross_tab.c.transpose();
+    let cross_tab = CrossTab::eager(c);
 
     let scaled_diagonal: Vec<f64> = diagonal
         .iter()

--- a/crates/within/src/domain/factor_pairs/sddm/scaling.rs
+++ b/crates/within/src/domain/factor_pairs/sddm/scaling.rs
@@ -37,7 +37,7 @@ impl<'a> NormalizedCrossOperator<'a> {
         let (small_to_large, large_to_small, small_inv_sqrt, large_inv_sqrt, small_side) =
             if cross_tab.n_rows() <= cross_tab.n_cols() {
                 (
-                    &cross_tab.ct,
+                    cross_tab.ct(),
                     &cross_tab.c,
                     row_inv_sqrt,
                     col_inv_sqrt,
@@ -46,7 +46,7 @@ impl<'a> NormalizedCrossOperator<'a> {
             } else {
                 (
                     &cross_tab.c,
-                    &cross_tab.ct,
+                    cross_tab.ct(),
                     col_inv_sqrt,
                     row_inv_sqrt,
                     BipartiteSide::Columns,

--- a/crates/within/src/domain/factor_pairs/sddm/tests.rs
+++ b/crates/within/src/domain/factor_pairs/sddm/tests.rs
@@ -84,10 +84,9 @@ fn chain_with_mid_deficit(m: usize) -> (CrossTab, Vec<f64>) {
         nrows: m,
         ncols: m + 1,
     };
-    let ct = c.transpose();
     let mut diagonal = vec![2.0; 2 * m + 1];
     diagonal[m + m / 2] = 2.0 * (1.0 - 1e-3);
-    (CrossTab { c, ct }, diagonal)
+    (CrossTab::eager(c), diagonal)
 }
 
 #[test]
@@ -277,10 +276,7 @@ fn large_rescaled_singular_boundary_remains_floating() {
         nrows: 1,
         ncols: n_cols,
     };
-    let cross_tab = CrossTab {
-        ct: c.transpose(),
-        c,
-    };
+    let cross_tab = CrossTab::eager(c);
     let diagonal: Vec<f64> = std::iter::once(weights.iter().sum::<f64>() / row_factor.powi(2))
         .chain(
             weights

--- a/crates/within/src/operator/schwarz/tests.rs
+++ b/crates/within/src/operator/schwarz/tests.rs
@@ -70,9 +70,8 @@ fn synthetic_sparse_cross_tab(n_keep: usize, elim_ratio: usize) -> (CrossTab, Ve
         nrows: n_rows,
         ncols: n_cols,
     };
-    let ct = c.transpose();
     (
-        CrossTab { c, ct },
+        CrossTab::eager(c),
         row_diag.into_iter().chain(col_diag).collect(),
     )
 }


### PR DESCRIPTION
Slices 5+6 of `feat/adaptive-cluster-rung`, independent of the #309/#340 stack.

Two commits. `CrossTab` holds `Cᵀ` in a `OnceLock` read through `ct()`; the pair build, the wire decoder, and the solver still supply or force it up front, so only the transient Gremban cover, which the sampled Schur reads row-wise, skips it. Wire format unchanged. Second, reducing a domain's Schur complement is split from factoring it, so a cover is dropped before the sparse factor grows; the dense attempt still runs first and the fallback is only sampled when it fails, as on main.

Peak RSS building the Additive preconditioner on the 3-slope difficult fixest panel: 1M rows 1053 → 975 MB, 2M 2016 → 1885 MB, 4M 3955 → 3721 MB. Build time unchanged. Output identical (all tests, including the wire fixtures, pass).