### PR TITLE
Run parameterized tests as rstest cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,6 +1479,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.119",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1572,7 @@ dependencies = [
  "faer",
  "postcard",
  "rayon",
+ "rstest",
  "serde",
  "thiserror 2.0.20",
  "thread_local",
@@ -2056,6 +2095,7 @@ dependencies = [
  "proptest",
  "rand 0.10.2",
  "rayon",
+ "rstest",
  "schwarz-precond",
  "serde",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rayon = "1.12"
 serde = { version = "1", features = ["derive"] }
 postcard = { version = "1", features = ["use-std"] }
 thiserror = "2"
+rstest = { version = "0.26.1", default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/schwarz-precond/Cargo.toml
+++ b/crates/schwarz-precond/Cargo.toml
@@ -22,6 +22,7 @@ thread_local = "1.1"
 [dev-dependencies]
 faer.workspace = true
 postcard.workspace = true
+rstest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/schwarz-precond/src/lsmr/bidiag/tests.rs
+++ b/crates/schwarz-precond/src/lsmr/bidiag/tests.rs
@@ -1,45 +1,41 @@
 //! White-box checks on the bidiagonalization itself.
 
+use rstest::rstest;
+
 use super::{alpha_from_vp, dot, Bidiagonalization, GolubKahan};
 use crate::lsmr::fixtures::{DenseOp, DiagOp};
 use crate::{Operator, SolveError};
 
 /// A NaN `vp` clamped to α = 0 via `f64::max`; a product bound overflowed to ∞ or underflowed to 0.
-#[test]
-fn alpha_from_vp_rejects_non_finite_and_indefinite_pairs() {
-    let rejected = [
-        (vec![1.0, f64::NAN], vec![1.0, 1.0]),
-        (vec![1.0, f64::INFINITY], vec![1.0, 1.0]),
-        (vec![-1e100], vec![1e100]),
-        (vec![-1e302, f64::MAX, f64::MAX], vec![1.0, 0.0, 0.0]),
-        (vec![-2e300, 1e308], vec![1e-316, 0.0]),
-    ];
-    for (v, p) in &rejected {
-        assert!(
-            matches!(alpha_from_vp(v, p), Err(SolveError::InvalidInput { .. })),
-            "{v:?}·{p:?} accepted"
-        );
-    }
-    let clamped = [
-        (vec![1.0, 1.0], vec![1.0, -1.0 - 1e-12]),
-        (vec![1e-100, 1e-100], vec![1e-100, -1.000000000001e-100]),
-        (vec![1e-316, 1e-316], vec![1e308, -1.000000000001e308]),
-    ];
-    for (v, p) in &clamped {
-        assert_eq!(alpha_from_vp(v, p).expect("within √ε"), 0.0, "{v:?}·{p:?}");
-    }
+#[rstest]
+#[case::nan(&[1.0, f64::NAN], &[1.0, 1.0])]
+#[case::infinity(&[1.0, f64::INFINITY], &[1.0, 1.0])]
+#[case::indefinite(&[-1e100], &[1e100])]
+#[case::overflowing_bound(&[-1e302, f64::MAX, f64::MAX], &[1.0, 0.0, 0.0])]
+#[case::underflowing_bound(&[-2e300, 1e308], &[1e-316, 0.0])]
+fn alpha_from_vp_rejects_non_finite_and_indefinite_pairs(#[case] v: &[f64], #[case] p: &[f64]) {
+    assert!(
+        matches!(alpha_from_vp(v, p), Err(SolveError::InvalidInput { .. })),
+        "{v:?}·{p:?} accepted"
+    );
+}
+
+#[rstest]
+#[case::unit_scale(&[1.0, 1.0], &[1.0, -1.0 - 1e-12])]
+#[case::tiny_scale(&[1e-100, 1e-100], &[1e-100, -1.000000000001e-100])]
+#[case::extreme_scales(&[1e-316, 1e-316], &[1e308, -1.000000000001e308])]
+fn alpha_from_vp_clamps_a_pair_within_root_epsilon(#[case] v: &[f64], #[case] p: &[f64]) {
+    assert_eq!(alpha_from_vp(v, p).expect("within √ε"), 0.0, "{v:?}·{p:?}");
 }
 
 /// `beta == 0.0` and `alpha > 0.0` are both false for NaN; unguarded, an overflow poisons the run.
-#[test]
-fn a_non_finite_operator_norm_is_an_error() {
-    for bad in [f64::NAN, f64::MAX] {
-        let result = crate::lsmr::lsmr(&DiagOp(vec![bad, 1.0]), &[1.0, 1.0], 1e-10, 50, None);
-        assert!(
-            matches!(result, Err(SolveError::InvalidInput { .. })),
-            "{bad:e} accepted"
-        );
-    }
+#[rstest]
+fn a_non_finite_operator_norm_is_an_error(#[values(f64::NAN, f64::MAX)] bad: f64) {
+    let result = crate::lsmr::lsmr(&DiagOp(vec![bad, 1.0]), &[1.0, 1.0], 1e-10, 50, None);
+    assert!(
+        matches!(result, Err(SolveError::InvalidInput { .. })),
+        "{bad:e} accepted"
+    );
 }
 
 /// A finite adjoint keeps `init` clean, so the overflow reaches the `step` guard on β.

--- a/crates/schwarz-precond/src/lsmr/tests/breakdown.rs
+++ b/crates/schwarz-precond/src/lsmr/tests/breakdown.rs
@@ -1,36 +1,41 @@
 //! Breakdown, early-exit and input-validation paths.
 
+use rstest::rstest;
+
 use super::super::*;
 use crate::lsmr::fixtures::*;
 use crate::{Operator, SolveError};
 
-#[test]
-fn test_mlsmr_mid_stream_beta_zero_breakdown() {
-    // Consistent rank-1 system: b lies in A's range, so A v_1 - alpha_1 u_1
-    // collapses and beta_2 == 0, driving the mid-stream beta == 0 branch in
-    // both bidiagonalizations (ModifiedGolubKahan also zeroes the paired p̃).
-    // The residual estimate is then exactly zero — reported as a converged
-    // ResidualTolerance solve, not a distinct breakdown reason.
-    let b = vec![5.0, 0.0];
-    let identity = IdentityOp { n: 2 };
-    for result in [
-        lsmr(&ZeroSecondRow, &b, 1e-12, 100, None).expect("Golub-Kahan beta=0"),
+/// `ZeroSecondRow` under either bidiagonalization; the modified one also zeroes the paired p̃.
+fn zero_second_row_solve(b: &[f64], modified: bool) -> LsmrResult {
+    if modified {
+        let identity = IdentityOp { n: 2 };
         mlsmr(
             &ZeroSecondRow,
-            &b,
+            b,
             &identity,
             1e-12,
             100,
             MlsmrOptions::default(),
         )
-        .expect("modified Golub-Kahan beta=0"),
-    ] {
-        assert!(result.converged);
-        assert_eq!(result.iterations, 1);
-        assert_eq!(result.stop_reason, LsmrStopReason::ResidualTolerance);
-        assert!((result.x[0] - 5.0).abs() < 1e-12);
-        assert!(result.x[1].abs() < 1e-12);
+        .expect("modified Golub-Kahan")
+    } else {
+        lsmr(&ZeroSecondRow, b, 1e-12, 100, None).expect("Golub-Kahan")
     }
+}
+
+/// b lies in A's range, so `A v₁ − α₁ u₁` collapses and β₂ = 0; the residual estimate is then
+/// exactly zero — a converged ResidualTolerance solve, not a distinct breakdown reason.
+#[rstest]
+#[case::golub_kahan(false)]
+#[case::modified_golub_kahan(true)]
+fn test_mlsmr_mid_stream_beta_zero_breakdown(#[case] modified: bool) {
+    let result = zero_second_row_solve(&[5.0, 0.0], modified);
+    assert!(result.converged);
+    assert_eq!(result.iterations, 1);
+    assert_eq!(result.stop_reason, LsmrStopReason::ResidualTolerance);
+    assert!((result.x[0] - 5.0).abs() < 1e-12);
+    assert!(result.x[1].abs() < 1e-12);
 }
 
 /// `Aᵀb = 0` with `b ≠ 0` triggers the `step1.alpha == 0` early-exit:
@@ -79,28 +84,16 @@ fn test_mlsmr_step1_alpha_zero_early_exit() {
 ///
 /// `ZeroSecondRow` with `b = [5, 3]` reaches `alpha_2 = 0` while leaving a
 /// residual of 3, exercising exactly this path on both bidiagonalizations.
-#[test]
-fn test_mid_stream_breakdown_reports_convergence() {
-    let b = vec![5.0, 3.0];
-    let identity = IdentityOp { n: 2 };
-    for result in [
-        lsmr(&ZeroSecondRow, &b, 1e-12, 100, None).expect("Golub-Kahan breakdown"),
-        mlsmr(
-            &ZeroSecondRow,
-            &b,
-            &identity,
-            1e-12,
-            100,
-            MlsmrOptions::default(),
-        )
-        .expect("modified Golub-Kahan breakdown"),
-    ] {
-        assert!(result.converged);
-        assert_eq!(result.stop_reason, LsmrStopReason::NormalEquationTolerance);
-        // x_0 = 5 fits row 0; row 1 is unmatchable, leaving residual 3.
-        assert!((result.x[0] - 5.0).abs() < 1e-10);
-        assert!((result.residual_norm - 3.0).abs() < 1e-10);
-    }
+#[rstest]
+#[case::golub_kahan(false)]
+#[case::modified_golub_kahan(true)]
+fn test_mid_stream_breakdown_reports_convergence(#[case] modified: bool) {
+    let result = zero_second_row_solve(&[5.0, 3.0], modified);
+    assert!(result.converged);
+    assert_eq!(result.stop_reason, LsmrStopReason::NormalEquationTolerance);
+    // x_0 = 5 fits row 0; row 1 is unmatchable, leaving residual 3.
+    assert!((result.x[0] - 5.0).abs() < 1e-10);
+    assert!((result.residual_norm - 3.0).abs() < 1e-10);
 }
 
 #[test]

--- a/crates/schwarz-precond/src/lsmr/tests/ladder.rs
+++ b/crates/schwarz-precond/src/lsmr/tests/ladder.rs
@@ -1,5 +1,7 @@
 //! Warm starts and escalation: the preconditioner ladder.
 
+use rstest::rstest;
+
 use super::super::*;
 use crate::lsmr::fixtures::*;
 use crate::{Operator, SolveError};
@@ -48,21 +50,21 @@ fn test_mlsmr_warm_tolerance_is_relative_to_original_rhs() {
 
 /// A zero RHS must not shadow warm-start validation: the same bad `x0` has to be
 /// rejected whether or not `b` short-circuits the solve.
-#[test]
-fn test_mlsmr_rejects_bad_warm_start_for_any_rhs() {
+#[rstest]
+#[case::short_x0(&[1.0, 2.0, 3.0], &[0.0, 0.0])]
+#[case::nan_x0(&[1.0, 2.0, 3.0], &[0.0, f64::NAN, 0.0])]
+#[case::short_x0_zero_rhs(&[0.0, 0.0, 0.0], &[0.0, 0.0])]
+#[case::nan_x0_zero_rhs(&[0.0, 0.0, 0.0], &[0.0, f64::NAN, 0.0])]
+fn test_mlsmr_rejects_bad_warm_start_for_any_rhs(#[case] b: &[f64], #[case] x0: &[f64]) {
     let op = IdentityOp { n: 3 };
-    for b in [[1.0, 2.0, 3.0], [0.0, 0.0, 0.0]] {
-        for x0 in [&[0.0, 0.0][..], &[0.0, f64::NAN, 0.0]] {
-            let options = MlsmrOptions {
-                warm_start: Some(x0),
-                ..Default::default()
-            };
-            assert!(matches!(
-                mlsmr(&op, &b, &op, 1e-8, 10, options),
-                Err(SolveError::InvalidInput { .. })
-            ));
-        }
-    }
+    let options = MlsmrOptions {
+        warm_start: Some(x0),
+        ..Default::default()
+    };
+    assert!(matches!(
+        mlsmr(&op, b, &op, 1e-8, 10, options),
+        Err(SolveError::InvalidInput { .. })
+    ));
 }
 
 /// Regression: `A·x₀` overflowing made `b - A·x₀` norm to NaN, which `init` read
@@ -118,24 +120,24 @@ fn test_mlsmr_zero_rhs_corrects_non_exact_warm_start() {
     assert!(result.iterations > 0);
 }
 
-#[test]
-fn test_mlsmr_exact_warm_start_is_returned_untouched() {
-    let cases: [(&dyn Operator, &[f64], &[f64]); 2] = [
-        (&IdentityOp { n: 3 }, &[1.0, 2.0, 3.0], &[1.0, 2.0, 3.0]),
-        (&ZeroSecondRow, &[0.0, 0.0], &[0.0, 7.0]),
-    ];
-    for (op, b, x0) in cases {
-        let options = MlsmrOptions {
-            warm_start: Some(x0),
-            ..Default::default()
-        };
-        let m = IdentityOp { n: op.ncols() };
-        let result = mlsmr(op, b, &m, 1e-10, 50, options).expect("exact warm start");
-        assert_eq!(result.stop_reason, LsmrStopReason::WarmStartExact);
-        assert!(result.converged);
-        assert_eq!(result.x, x0);
-        assert_eq!(result.iterations, 0);
-    }
+#[rstest]
+#[case::identity(&IdentityOp { n: 3 }, &[1.0, 2.0, 3.0], &[1.0, 2.0, 3.0])]
+#[case::null_direction(&ZeroSecondRow, &[0.0, 0.0], &[0.0, 7.0])]
+fn test_mlsmr_exact_warm_start_is_returned_untouched(
+    #[case] op: &dyn Operator,
+    #[case] b: &[f64],
+    #[case] x0: &[f64],
+) {
+    let options = MlsmrOptions {
+        warm_start: Some(x0),
+        ..Default::default()
+    };
+    let m = IdentityOp { n: op.ncols() };
+    let result = mlsmr(op, b, &m, 1e-10, 50, options).expect("exact warm start");
+    assert_eq!(result.stop_reason, LsmrStopReason::WarmStartExact);
+    assert!(result.converged);
+    assert_eq!(result.x, x0);
+    assert_eq!(result.iterations, 0);
 }
 
 #[test]
@@ -243,32 +245,38 @@ fn test_staleness_default_exposes_its_fields() {
 
 #[cfg(feature = "serde")]
 #[test]
-fn test_staleness_serde_round_trips_and_validates() {
+fn test_staleness_serde_round_trips() {
     let default = Staleness::default();
     let bytes = postcard::to_stdvec(&default).expect("serialize");
     assert_eq!(
         postcard::from_bytes::<Staleness>(&bytes).expect("deserialize"),
         default
     );
-    for invalid in [(0usize, 0.7f64), (4, 1.0)] {
-        let bytes = postcard::to_stdvec(&invalid).expect("serialize");
-        assert!(
-            postcard::from_bytes::<Staleness>(&bytes).is_err(),
-            "{invalid:?}"
-        );
-    }
+}
+
+#[cfg(feature = "serde")]
+#[rstest]
+#[case::zero_window(0, 0.7)]
+#[case::threshold_one(4, 1.0)]
+fn test_staleness_serde_validates(#[case] window: usize, #[case] threshold: f64) {
+    let bytes = postcard::to_stdvec(&(window, threshold)).expect("serialize");
+    assert!(postcard::from_bytes::<Staleness>(&bytes).is_err());
 }
 
 #[test]
-fn test_staleness_rejects_invalid_configuration() {
+fn test_staleness_rejects_a_zero_window() {
     assert!(matches!(
         Staleness::try_new(0, 0.7),
         Err(StalenessError::ZeroWindow)
     ));
-    for threshold in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, -0.1, 1.0, 1.5] {
-        assert!(matches!(
-            Staleness::try_new(4, threshold),
-            Err(StalenessError::InvalidThreshold { .. })
-        ));
-    }
+}
+
+#[rstest]
+fn test_staleness_rejects_an_invalid_threshold(
+    #[values(f64::NAN, f64::INFINITY, f64::NEG_INFINITY, -0.1, 1.0, 1.5)] threshold: f64,
+) {
+    assert!(matches!(
+        Staleness::try_new(4, threshold),
+        Err(StalenessError::InvalidThreshold { .. })
+    ));
 }

--- a/crates/schwarz-precond/src/lsmr/tests/solve.rs
+++ b/crates/schwarz-precond/src/lsmr/tests/solve.rs
@@ -1,5 +1,7 @@
 //! Solve behaviors: preconditioning, rank, and local reorthogonalization.
 
+use rstest::rstest;
+
 use super::super::*;
 use crate::lsmr::fixtures::*;
 use crate::{Operator, SolveError};
@@ -402,11 +404,13 @@ fn test_mlsmr_local_reorth_preconditioned() {
     );
 }
 
-/// Window sizes at the boundaries of useful values: `Some(1)` (degenerate
-/// ring of one), `Some(12)` (= number of columns), `Some(13)` (= cols + 1).
-/// All three must converge and produce a small normal-equation residual.
-#[test]
-fn test_mlsmr_local_reorth_window_boundary_sizes() {
+/// Window sizes at the boundaries of useful values; each must converge to a small
+/// normal-equation residual.
+#[rstest]
+#[case::ring_of_one(1)]
+#[case::cols(12)]
+#[case::cols_plus_one(13)]
+fn test_mlsmr_local_reorth_window_boundary_sizes(#[case] window_size: usize) {
     let op = DenseOp::vandermonde(30, 12);
     let b: Vec<f64> = (0..op.rows)
         .map(|i| {
@@ -415,18 +419,11 @@ fn test_mlsmr_local_reorth_window_boundary_sizes() {
         })
         .collect();
 
-    // Budget of 200 iterations gives `Some(1)` (which degenerates to no real
-    // reorthogonalization) enough room to converge on this cond ≈ 1e10 system,
-    // while still being a small bounded budget for the larger window sizes.
-    for window_size in [Some(1usize), Some(12), Some(13)] {
-        let result = lsmr(&op, &b, 1e-9, 200, window_size).expect("lsmr boundary-window solve");
-        assert!(
-            result.converged,
-            "did not converge with window {window_size:?}"
-        );
-        assert!(
-            normal_equation_residual(&op, &result.x, &b) < 1e-6,
-            "normal-eq residual too large with window {window_size:?}",
-        );
-    }
+    // 200 iterations lets a ring of one (no real reorthogonalization) converge at cond ≈ 1e10.
+    let result = lsmr(&op, &b, 1e-9, 200, Some(window_size)).expect("lsmr boundary-window solve");
+    assert!(result.converged);
+    assert!(
+        normal_equation_residual(&op, &result.x, &b) < 1e-6,
+        "normal-eq residual too large with window {window_size}",
+    );
 }

--- a/crates/schwarz-precond/tests/schwarz.rs
+++ b/crates/schwarz-precond/tests/schwarz.rs
@@ -6,6 +6,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use rayon::prelude::*;
+use rstest::rstest;
 use schwarz_precond::{
     lsmr, mlsmr, LocalSolveError, LocalSolver, MlsmrOptions, Operator, PartitionWeights,
     ReductionStrategy, SchwarzPreconditioner, SubdomainCore, SubdomainEntry,
@@ -366,37 +367,34 @@ fn test_additive_backends_match_on_overlapping_subdomains() {
     });
 }
 
-#[test]
-fn test_additive_auto_matches_resolved_backend() {
+#[rstest]
+fn test_additive_auto_matches_resolved_backend(#[values(1, 4)] n_threads: usize) {
     let n = 66;
     let rhs: Vec<f64> = (0..n).map(|i| ((3 * i) % 17) as f64 - 8.0).collect();
 
-    for &n_threads in &[1usize, 4usize] {
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(n_threads)
-            .build()
-            .expect("test rayon pool");
-        pool.install(|| {
-            let auto =
-                SchwarzPreconditioner::new(make_overlapping_entries(n), ReductionStrategy::Auto);
-            let resolved = auto.reduction_strategy();
-            assert_ne!(
-                resolved,
-                ReductionStrategy::Auto,
-                "auto must resolve to a concrete backend"
-            );
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(n_threads)
+        .build()
+        .expect("test rayon pool");
+    pool.install(|| {
+        let auto = SchwarzPreconditioner::new(make_overlapping_entries(n), ReductionStrategy::Auto);
+        let resolved = auto.reduction_strategy();
+        assert_ne!(
+            resolved,
+            ReductionStrategy::Auto,
+            "auto must resolve to a concrete backend"
+        );
 
-            let explicit = SchwarzPreconditioner::new(make_overlapping_entries(n), resolved);
+        let explicit = SchwarzPreconditioner::new(make_overlapping_entries(n), resolved);
 
-            let mut z_auto = vec![0.0; n];
-            let mut z_explicit = vec![0.0; n];
-            auto.apply(&rhs, &mut z_auto).expect("auto apply succeeds");
-            explicit
-                .apply(&rhs, &mut z_explicit)
-                .expect("explicit apply succeeds");
-            assert_vec_close(&z_auto, &z_explicit, 1e-12);
-        });
-    }
+        let mut z_auto = vec![0.0; n];
+        let mut z_explicit = vec![0.0; n];
+        auto.apply(&rhs, &mut z_auto).expect("auto apply succeeds");
+        explicit
+            .apply(&rhs, &mut z_explicit)
+            .expect("explicit apply succeeds");
+        assert_vec_close(&z_auto, &z_explicit, 1e-12);
+    });
 }
 
 use schwarz_precond::{BuildError, SolveError};

--- a/crates/within/Cargo.toml
+++ b/crates/within/Cargo.toml
@@ -24,6 +24,7 @@ thiserror.workspace = true
 criterion = { version = "0.7", features = ["html_reports"] }
 rand = "0.10"
 proptest = "1"
+rstest.workspace = true
 
 [[bench]]
 name = "fixest"

--- a/crates/within/src/block_elim/schur/tests.rs
+++ b/crates/within/src/block_elim/schur/tests.rs
@@ -1,3 +1,5 @@
+use rstest::rstest;
+
 use super::*;
 
 fn sparse_to_dense(matrix: &CsrMatrix) -> Vec<Vec<f64>> {
@@ -96,30 +98,22 @@ fn exact_schur_matches_dense_reference_when_eliminating_rows() {
 
 /// The sequential arm reuses one scatter workspace across rows, so a row that failed to
 /// reset it would read the previous row's entries.
-#[test]
-fn both_row_splits_produce_the_same_complement() {
+#[rstest]
+fn both_row_splits_produce_the_same_complement(
+    #[values(Grounding::Grounded, Grounding::Floating)] grounding: Grounding,
+) {
     let c_dense = vec![1.0, 2.0, 3.0, 0.0, 0.0, 4.0];
     let diagonal = vec![5.0, 6.0, 8.0, 7.0, 9.0];
     let (row_diag, _) = diagonal.split_at(3);
     let inv_diagonal: Vec<f64> = row_diag.iter().map(|d| 1.0 / d).collect();
 
-    for grounding in [Grounding::Grounded, Grounding::Floating] {
-        let operator = SddmMatrix::from_dense_for_test(&c_dense, 3, 2, diagonal.clone(), grounding);
-        let parallel = exact(&operator, &inv_diagonal, RowSplit::Parallel);
-        let sequential = exact(&operator, &inv_diagonal, RowSplit::Sequential);
+    let operator = SddmMatrix::from_dense_for_test(&c_dense, 3, 2, diagonal, grounding);
+    let parallel = exact(&operator, &inv_diagonal, RowSplit::Parallel);
+    let sequential = exact(&operator, &inv_diagonal, RowSplit::Sequential);
 
-        assert_eq!(
-            sequential.indptr(),
-            parallel.indptr(),
-            "{grounding:?} indptr"
-        );
-        assert_eq!(
-            sequential.indices(),
-            parallel.indices(),
-            "{grounding:?} indices"
-        );
-        assert_eq!(sequential.data(), parallel.data(), "{grounding:?} data");
-    }
+    assert_eq!(sequential.indptr(), parallel.indptr());
+    assert_eq!(sequential.indices(), parallel.indices());
+    assert_eq!(sequential.data(), parallel.data());
 }
 
 #[test]

--- a/crates/within/src/block_elim/solver/tests.rs
+++ b/crates/within/src/block_elim/solver/tests.rs
@@ -1,3 +1,5 @@
+use rstest::rstest;
+
 use super::*;
 
 use crate::block_elim::csr_matrix::CsrMatrix;
@@ -70,8 +72,10 @@ fn fold_rejects_a_zero_eliminated_diagonal() {
     }
 }
 
-#[test]
-fn an_unusable_dense_pivot_is_retried_rather_than_fatal() {
+#[rstest]
+fn an_unusable_dense_pivot_is_retried_rather_than_fatal(
+    #[values(SchurMode::Exact, SchurMode::Approximate(Default::default()))] schur: SchurMode,
+) {
     // The exact attempt only fails when weight spread costs the complement its definiteness.
     let matrix =
         SddmMatrix::laplacian_for_test(&[0.0, 1e-16, 1e2, 1e0, 1e5, 0.0, 0.0, 1e14, 0.0], 3, 3);
@@ -87,20 +91,16 @@ fn an_unusable_dense_pivot_is_retried_rather_than_fatal() {
         "the fixture no longer reaches the fall-through"
     );
 
-    for schur in [SchurMode::Exact, SchurMode::Approximate(Default::default())] {
-        let config = LocalSolverConfig {
-            approx_chol: ApproxCholConfig::default(),
-            schur,
-            dense_threshold: DEFAULT_DENSE_SCHUR_THRESHOLD,
-            ..Default::default()
-        };
-
-        assert!(
-            Eliminated::factor_reduced(&eliminated, &config).is_ok(),
-            "{:?}: an unusable pivot must not be fatal",
-            config.schur
-        );
-    }
+    let config = LocalSolverConfig {
+        approx_chol: ApproxCholConfig::default(),
+        schur,
+        dense_threshold: DEFAULT_DENSE_SCHUR_THRESHOLD,
+        ..Default::default()
+    };
+    assert!(
+        Eliminated::factor_reduced(&eliminated, &config).is_ok(),
+        "an unusable pivot must not be fatal"
+    );
 }
 
 /// Build an eliminated-major CrossTab (`n_rows > n_cols`, as orientation
@@ -205,33 +205,30 @@ fn grounded_two_block_solve_is_leak_free() {
     }
 }
 
-#[test]
-fn trivial_singleton_component_solves_r_over_d() {
-    // Live 1×1 components keep n_keep = 0, so the solve degenerates to x = r/d exactly.
+/// Live 1×1 components keep n_keep = 0, so the solve degenerates to x = r/d exactly.
+#[rstest]
+#[case::row_singleton(1, 0)]
+#[case::column_singleton(0, 1)]
+fn trivial_singleton_component_solves_r_over_d(#[case] n_rows: usize, #[case] n_cols: usize) {
     let config = LocalSolverConfig {
         approx_chol: ApproxCholConfig::default(),
         schur: SchurMode::Exact,
         dense_threshold: 0,
         ..Default::default()
     };
-    for (n_rows, n_cols) in [(1usize, 0usize), (0, 1)] {
-        let cross_tab = CrossTab::from_dense_for_test(&[], n_rows, n_cols);
-        let diagonal = vec![4.0; n_rows + n_cols];
-        let component = LocalComponent::general_for_test(cross_tab, diagonal);
-        let solver = BlockElimSolver::build(component, &config).expect("trivial 1×1 build");
-        assert_eq!(solver.n_local(), 1);
+    let cross_tab = CrossTab::from_dense_for_test(&[], n_rows, n_cols);
+    let diagonal = vec![4.0; n_rows + n_cols];
+    let component = LocalComponent::general_for_test(cross_tab, diagonal);
+    let solver = BlockElimSolver::build(component, &config).expect("trivial 1×1 build");
+    assert_eq!(solver.n_local(), 1);
 
-        let mut rhs = vec![0.0; solver.scratch_size()];
-        rhs[0] = 2.0;
-        let mut sol = vec![0.0; solver.scratch_size()];
-        solver
-            .solve_local(&mut rhs, &mut sol, false)
-            .expect("trivial solve");
-        assert_eq!(
-            sol[0], 0.5,
-            "n_rows={n_rows}, n_cols={n_cols}: expected r/d"
-        );
-    }
+    let mut rhs = vec![0.0; solver.scratch_size()];
+    rhs[0] = 2.0;
+    let mut sol = vec![0.0; solver.scratch_size()];
+    solver
+        .solve_local(&mut rhs, &mut sol, false)
+        .expect("trivial solve");
+    assert_eq!(sol[0], 0.5, "expected r/d");
 }
 
 #[test]
@@ -301,9 +298,15 @@ fn grounded_backend_auxiliary_is_initialized_on_every_solve() {
     assert_eq!(first[..solver.n_local()], second[..solver.n_local()]);
 }
 
-#[test]
-fn signed_component_realizes_congruence_transformed_solve() {
-    // Stars of ≤2 entries sample deterministically-exact, so all three arms share one oracle.
+/// Stars of ≤2 entries sample deterministically-exact, so all three arms share one oracle.
+#[rstest]
+#[case::dense_full_minor(8, SchurMode::Exact)]
+#[case::exact_sparse(0, SchurMode::Exact)]
+#[case::sampled_sparse(0, SchurMode::Approximate(crate::config::ApproxSchurConfig::default()))]
+fn signed_component_realizes_congruence_transformed_solve(
+    #[case] dense_threshold: usize,
+    #[case] schur: SchurMode,
+) {
     let (n_rows, n_cols) = (3usize, 2usize);
     let d: Vec<f64> = vec![-1.0, 4.0, 0.25, 2.0, -0.5];
     let c_hat = [[1.0, 3.0], [2.0, 0.0], [0.5, 1.5]];
@@ -316,64 +319,54 @@ fn signed_component_realizes_congruence_transformed_solve() {
         }
     }
 
-    for (label, dense_threshold, schur) in [
-        ("dense full minor", 8, SchurMode::Exact),
-        ("exact sparse", 0, SchurMode::Exact),
-        (
-            "sampled sparse",
-            0,
-            SchurMode::Approximate(crate::config::ApproxSchurConfig::default()),
-        ),
-    ] {
-        let cross_tab = CrossTab::from_dense_for_test(&c_raw, n_rows, n_cols);
-        let diagonals: Vec<f64> = (0..n_rows + n_cols)
-            .map(|k| diag_hat[k] / (d[k] * d[k]))
-            .collect();
-        let config = LocalSolverConfig {
-            approx_chol: ApproxCholConfig::default(),
-            schur,
-            dense_threshold,
-            ..Default::default()
-        };
-        // SDDM factors fold the bipartite negation in: f = d on q, -d on r.
-        let factors: Vec<f64> = d
-            .iter()
-            .enumerate()
-            .map(|(i, &v)| if i < n_rows { v } else { -v })
-            .collect();
-        let component = LocalComponent::with_factors_for_test(cross_tab, diagonals, &factors);
-        let solver =
-            BlockElimSolver::build(component, &config).expect("signed block-elim build failed");
+    let cross_tab = CrossTab::from_dense_for_test(&c_raw, n_rows, n_cols);
+    let diagonals: Vec<f64> = (0..n_rows + n_cols)
+        .map(|k| diag_hat[k] / (d[k] * d[k]))
+        .collect();
+    let config = LocalSolverConfig {
+        approx_chol: ApproxCholConfig::default(),
+        schur,
+        dense_threshold,
+        ..Default::default()
+    };
+    // SDDM factors fold the bipartite negation in: f = d on q, -d on r.
+    let factors: Vec<f64> = d
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| if i < n_rows { v } else { -v })
+        .collect();
+    let component = LocalComponent::with_factors_for_test(cross_tab, diagonals, &factors);
+    let solver =
+        BlockElimSolver::build(component, &config).expect("signed block-elim build failed");
 
-        let n = n_rows + n_cols;
-        let r = [0.5, 3.0, -1.25, 1.0, -2.0];
-        let mut rhs = vec![0.0; solver.scratch_size()];
-        rhs[..n].copy_from_slice(&r);
-        let mut sol = vec![0.0; solver.scratch_size()];
-        solver
-            .solve_local(&mut rhs, &mut sol, false)
-            .expect("solve_local failed");
+    let n = n_rows + n_cols;
+    let r = [0.5, 3.0, -1.25, 1.0, -2.0];
+    let mut rhs = vec![0.0; solver.scratch_size()];
+    rhs[..n].copy_from_slice(&r);
+    let mut sol = vec![0.0; solver.scratch_size()];
+    solver
+        .solve_local(&mut rhs, &mut sol, false)
+        .expect("solve_local failed");
 
-        for i in 0..n {
-            let mut ax = 0.0;
-            for j in 0..n {
-                let a_ij = if i == j {
-                    diag_hat[i] / (d[i] * d[i])
-                } else if i < n_rows && j >= n_rows {
-                    c_raw[i * n_cols + (j - n_rows)]
-                } else if j < n_rows && i >= n_rows {
-                    c_raw[j * n_cols + (i - n_rows)]
-                } else {
-                    0.0
-                };
-                ax += a_ij * sol[j];
-            }
-            assert!(
-                (ax - r[i]).abs() < 1e-9,
-                "{label}: row {i}: A·x = {ax}, expected {}",
-                r[i]
-            );
+    for i in 0..n {
+        let mut ax = 0.0;
+        for j in 0..n {
+            let a_ij = if i == j {
+                diag_hat[i] / (d[i] * d[i])
+            } else if i < n_rows && j >= n_rows {
+                c_raw[i * n_cols + (j - n_rows)]
+            } else if j < n_rows && i >= n_rows {
+                c_raw[j * n_cols + (i - n_rows)]
+            } else {
+                0.0
+            };
+            ax += a_ij * sol[j];
         }
+        assert!(
+            (ax - r[i]).abs() < 1e-9,
+            "row {i}: A·x = {ax}, expected {}",
+            r[i]
+        );
     }
 }
 

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -1,3 +1,5 @@
+use rstest::rstest;
+
 use super::*;
 use crate::Effect;
 
@@ -63,20 +65,17 @@ fn shared_covariate_across_two_terms_warns_both_ways() {
 
 /// The disease is scale-invariant, so the screen must be too: the raw Gram's
 /// intercept diagonal dwarfs a small covariate's.
-#[test]
-fn a_rescaled_shared_covariate_still_warns_both_ways() {
+#[rstest]
+fn a_rescaled_shared_covariate_still_warns_both_ways(#[values(1.0, 1e-6, 1e-9)] scale: f64) {
     let n = 4000;
     let (a, b) = two_factor_levels(n);
-    let z = pseudo_noise(n, 3);
-    for scale in [1.0, 1e-6, 1e-9] {
-        let scaled: Vec<f64> = z.iter().map(|v| v * scale).collect();
-        let design = Design::new(vec![
-            Effect::new(&a, true, [&scaled[..]]).unwrap(),
-            Effect::new(&b, true, [&scaled[..]]).unwrap(),
-        ])
-        .unwrap();
-        assert_eq!(warn_pairs(&design, None).len(), 2, "scale {scale:e}");
-    }
+    let scaled: Vec<f64> = pseudo_noise(n, 3).iter().map(|v| v * scale).collect();
+    let design = Design::new(vec![
+        Effect::new(&a, true, [&scaled[..]]).unwrap(),
+        Effect::new(&b, true, [&scaled[..]]).unwrap(),
+    ])
+    .unwrap();
+    assert_eq!(warn_pairs(&design, None).len(), 2);
 }
 
 #[test]
@@ -117,20 +116,19 @@ fn factor_measurable_covariate_warns_against_the_intercept_term() {
 
 /// The span holds every level's constant, so a covariate's offset must not
 /// enter the share: measured against `Σw·c²`, `mean=2005, sd=6` reads 7.6e-7.
-#[test]
-fn an_independent_covariate_stays_silent_at_any_offset() {
+#[rstest]
+fn an_independent_covariate_stays_silent_at_any_offset(
+    #[values(0.0, 1.0, 100.0, 2005.0, 1e6)] mean: f64,
+) {
     let n = 4000;
     let (a, b) = two_factor_levels(n);
-    let z = pseudo_noise(n, 5);
-    for mean in [0.0, 1.0, 100.0, 2005.0, 1e6] {
-        let shifted: Vec<f64> = z.iter().map(|v| mean + 6.0 * v).collect();
-        let design = Design::new(vec![
-            Effect::new(&a, true, [&shifted[..]]).unwrap(),
-            Effect::new(&b, true, []).unwrap(),
-        ])
-        .unwrap();
-        assert_eq!(warn_pairs(&design, None), Vec::new(), "mean {mean:e}");
-    }
+    let shifted: Vec<f64> = pseudo_noise(n, 5).iter().map(|v| mean + 6.0 * v).collect();
+    let design = Design::new(vec![
+        Effect::new(&a, true, [&shifted[..]]).unwrap(),
+        Effect::new(&b, true, []).unwrap(),
+    ])
+    .unwrap();
+    assert_eq!(warn_pairs(&design, None), Vec::new());
 }
 
 #[test]
@@ -170,31 +168,36 @@ fn zero_weight_rows_are_excluded_from_the_screen() {
     assert_eq!(warn_pairs(&design, None), Vec::new());
 }
 
-/// Severity peaks where a covariate is *nearly* shared: `eps²` down to 1e-24.
-#[test]
-fn the_share_resolves_a_perturbation_of_a_shared_covariate() {
+/// Term 1's share when its covariate is term 0's plus `eps` times independent noise.
+fn perturbed_share(eps: f64) -> f64 {
     let n = 4000;
     let (a, b) = two_factor_levels(n);
     let z = pseudo_noise(n, 3);
     let noise = pseudo_noise(n, 17);
-    let share_at = |eps: f64| {
-        let perturbed: Vec<f64> = z.iter().zip(&noise).map(|(&v, &e)| v + eps * e).collect();
-        let design = Design::new(vec![
-            Effect::new(&a, true, [&z[..]]).unwrap(),
-            Effect::new(&b, true, [&perturbed[..]]).unwrap(),
-        ])
-        .unwrap();
-        shares(&design, 1, FULL_TABLE)[0]
-    };
+    let perturbed: Vec<f64> = z.iter().zip(&noise).map(|(&v, &e)| v + eps * e).collect();
+    let design = Design::new(vec![
+        Effect::new(&a, true, [&z[..]]).unwrap(),
+        Effect::new(&b, true, [&perturbed[..]]).unwrap(),
+    ])
+    .unwrap();
+    shares(&design, 1, FULL_TABLE)[0]
+}
 
-    // An exactly shared covariate is reproduced to the last bit of the fit itself.
-    let exact = share_at(0.0);
+/// An exactly shared covariate is reproduced to the last bit of the fit itself.
+#[test]
+fn the_share_of_an_exactly_shared_covariate_is_at_the_fit_s_bits() {
+    let exact = perturbed_share(0.0);
     assert!(exact < 1e-28, "{exact:e}");
-    for eps in [1e-12, 1e-9, 1e-6, 1e-3] {
-        let share = share_at(eps);
-        let ratio = share / (eps * eps);
-        assert!((0.2..5.0).contains(&ratio), "eps {eps:e}: share {share:e}");
-    }
+}
+
+/// Severity peaks where a covariate is *nearly* shared: `eps²` down to 1e-24.
+#[rstest]
+fn the_share_resolves_a_perturbation_of_a_shared_covariate(
+    #[values(1e-12, 1e-9, 1e-6, 1e-3)] eps: f64,
+) {
+    let share = perturbed_share(eps);
+    let ratio = share / (eps * eps);
+    assert!((0.2..5.0).contains(&ratio), "share {share:e}");
 }
 
 /// Without an intercept both the fit and the denominator must read the covariate raw.
@@ -290,15 +293,19 @@ fn the_plan_keeps_the_table_inside_the_budget() {
     let table = |plan: ScreenPlan| plan.per_block * 32;
     let fits = ScreenPlan::new(4000, 125, 32);
     assert_eq!((fits.per_block, table(fits)), (125, 4000));
-    // A level count the budget cannot hold whole is cut, however large it is.
-    for n_levels in [1_000, 1_000_000, 100_000_000] {
-        let plan = ScreenPlan::new(4000, n_levels, 32);
-        assert_eq!(plan.per_block, 125, "{n_levels}");
-        assert!(table(plan) <= 4000, "{n_levels}");
-    }
     // One level's row is the floor: the stride, however many levels the term has.
     let starved = ScreenPlan::new(0, 100_000_000, 32);
     assert_eq!((starved.per_block, table(starved)), (1, 32));
+}
+
+/// A level count the budget cannot hold whole is cut, however large it is.
+#[rstest]
+fn the_plan_cuts_a_level_count_over_budget(
+    #[values(1_000, 1_000_000, 100_000_000)] n_levels: usize,
+) {
+    let plan = ScreenPlan::new(4000, n_levels, 32);
+    assert_eq!(plan.per_block, 125);
+    assert!(plan.per_block * 32 <= 4000);
 }
 
 /// Every row is walked in exactly one block, under either row order.

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -2,6 +2,7 @@ mod design_tests {
     use crate::domain::Design;
     use crate::linalg::dot;
     use crate::operator::DesignOperator;
+    use rstest::rstest;
     use schwarz_precond::Operator;
 
     fn make_test_design() -> Design<'static> {
@@ -240,15 +241,21 @@ mod design_tests {
         }
     }
 
-    #[test]
-    fn test_scatter_scratch_reuse_matches_fresh_operator() {
-        // The three pairs route Sequential, Fold and SortedCoalesced respectively.
-        for (n_obs, n_levels) in [(200usize, 16usize), (15_000, 64), (150_000, 100_000)] {
-            let dm = make_strategy_design(n_obs, n_levels);
-            assert_scratch_reuse_matches_fresh(&dm, &format!("n_obs={n_obs}, n_levels={n_levels}"));
-        }
+    #[rstest]
+    #[case::sequential(200, 16)]
+    #[case::fold(15_000, 64)]
+    #[case::sorted_coalesced(150_000, 100_000)]
+    fn test_scatter_scratch_reuse_matches_fresh_operator(
+        #[case] n_obs: usize,
+        #[case] n_levels: usize,
+    ) {
+        let dm = make_strategy_design(n_obs, n_levels);
+        assert_scratch_reuse_matches_fresh(&dm, &format!("n_obs={n_obs}, n_levels={n_levels}"));
+    }
 
-        // A large unsorted non-dominant factor cannot coalesce.
+    /// A large unsorted non-dominant factor cannot coalesce.
+    #[test]
+    fn test_atomic_scatter_scratch_reuse_matches_fresh_operator() {
         let n_obs = 150_000usize;
         let fa: Vec<u32> = (0..n_obs as u32).collect();
         let fb: Vec<u32> = (0..n_obs).map(|i| ((i * 7919) % 100_000) as u32).collect();

--- a/crates/within/tests/error_paths.rs
+++ b/crates/within/tests/error_paths.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 
 use ndarray::Array2;
+use rstest::rstest;
 use schwarz_precond::SolveError;
 use within::observation::ObservationFrame;
 use within::{
@@ -204,25 +205,23 @@ fn test_within_error_source_chains_through_transparent_wrapper() {
     assert!(e.source().is_some());
 }
 
-#[test]
-fn test_invalid_ridge_rejected() {
+#[rstest]
+fn test_invalid_ridge_rejected(#[values(-1e-9, f64::NAN, f64::INFINITY)] ridge: f64) {
     let f = [0u32, 0, 1, 1];
     let g = [0u32, 1, 0, 1];
-    for ridge in [-1e-9, f64::NAN, f64::INFINITY] {
-        let precond = PreconditionerConfig::Additive {
-            local_solver: LocalSolverConfig {
-                ridge,
-                ..Default::default()
-            },
-            reduction: Default::default(),
-        };
-        let effects = vec![
-            Effect::new(&f, true, []).expect("f"),
-            Effect::new(&g, true, []).expect("g"),
-        ];
-        match Solver::new(effects, None, &precond) {
-            Err(BuildError::InvalidRidge { value }) => assert_eq!(value.to_bits(), ridge.to_bits()),
-            other => panic!("expected InvalidRidge for {ridge}, got {other:?}"),
-        }
+    let precond = PreconditionerConfig::Additive {
+        local_solver: LocalSolverConfig {
+            ridge,
+            ..Default::default()
+        },
+        reduction: Default::default(),
+    };
+    let effects = vec![
+        Effect::new(&f, true, []).expect("f"),
+        Effect::new(&g, true, []).expect("g"),
+    ];
+    match Solver::new(effects, None, &precond) {
+        Err(BuildError::InvalidRidge { value }) => assert_eq!(value.to_bits(), ridge.to_bits()),
+        other => panic!("expected InvalidRidge, got {other:?}"),
     }
 }

--- a/crates/within/tests/precond_deser_robustness.rs
+++ b/crates/within/tests/precond_deser_robustness.rs
@@ -4,6 +4,7 @@
 //! in the `preconditioner_from_bytes` fuzz target (see `fuzz/`); this pins the
 //! specific inputs a stable-toolchain CI job can guard without a fuzzer.
 
+use rstest::rstest;
 use within::Preconditioner;
 
 // The fuzzer's first find: a serialized Schwarz preconditioner whose `n_dofs`
@@ -18,33 +19,16 @@ const CRASH_NDOFS_SPAN: &[u8] = include_bytes!("fixtures/precond_deser_crash_ndo
 // nested discriminant fails to decode instead.
 const CRASH_NESTED_COVER: &[u8] = include_bytes!("fixtures/precond_deser_crash_nested_cover.bin");
 
-#[test]
-fn deserializing_untrusted_bytes_returns_error_not_panic() {
-    assert!(
-        postcard::from_bytes::<Preconditioner>(CRASH_NDOFS_SPAN).is_err(),
-        "n_dofs-below-span input must deserialize to a typed error"
-    );
-    assert!(
-        postcard::from_bytes::<Preconditioner>(CRASH_NESTED_COVER).is_err(),
-        "nested-Cover input must deserialize to a typed error"
-    );
-
-    // Malformed inputs — empty, truncated, and saturated byte strings — must
-    // deserialize to an error without panicking (a panic here fails the test).
-    let half = &CRASH_NDOFS_SPAN[..CRASH_NDOFS_SPAN.len() / 2];
-    let cases: [&[u8]; 6] = [
-        &[],
-        &[0x00],
-        &[0xFF; 8],
-        &[0xFF; 64],
-        half,
-        &CRASH_NDOFS_SPAN[..1],
-    ];
-    for bytes in cases {
-        assert!(
-            postcard::from_bytes::<Preconditioner>(bytes).is_err(),
-            "malformed input of {} bytes must deserialize to an error",
-            bytes.len()
-        );
-    }
+/// Crash fixtures and malformed byte strings alike must decode to a typed error, never panic.
+#[rstest]
+#[case::n_dofs_below_span(CRASH_NDOFS_SPAN)]
+#[case::nested_cover(CRASH_NESTED_COVER)]
+#[case::empty(&[])]
+#[case::one_zero_byte(&[0x00])]
+#[case::saturated_8(&[0xFF; 8])]
+#[case::saturated_64(&[0xFF; 64])]
+#[case::truncated_half(&CRASH_NDOFS_SPAN[..CRASH_NDOFS_SPAN.len() / 2])]
+#[case::truncated_to_one_byte(&CRASH_NDOFS_SPAN[..1])]
+fn deserializing_untrusted_bytes_returns_error_not_panic(#[case] bytes: &[u8]) {
+    assert!(postcard::from_bytes::<Preconditioner>(bytes).is_err());
 }

--- a/crates/within/tests/slopes_routing.rs
+++ b/crates/within/tests/slopes_routing.rs
@@ -2,6 +2,7 @@
 //! factors through balanced/scaled signed subdomains, with frustrated
 //! components solving through their Gremban double cover (#62).
 
+use rstest::rstest;
 use within::{Effect, LsmrOptions, Preconditioner, PreconditionerConfig, SchurMode, Solver};
 
 fn lcg(seed: &mut u64) -> u64 {
@@ -325,16 +326,17 @@ fn singleton_level_in_non_first_slope_term_solves_under_default() {
     }
 }
 
-/// One slope column per sloped factor, as a function of the year code.
-struct Loadings {
-    what: &'static str,
-    worker_loading: fn(f64) -> f64,
-    firm_loading: fn(f64) -> f64,
-}
-
 /// Dual-factor slopes reduce through the exact dense Schur; the trigger is the loading values.
-#[test]
-fn dual_factor_slopes_build_across_loading_shapes() {
+/// Each case is one slope column per sloped factor, as a function of the year code.
+#[rstest]
+#[case::t_and_t_squared(|t: f64| t, |t: f64| t * t)]
+#[case::t_squared_and_t(|t: f64| t * t, |t: f64| t)]
+#[case::exp_and_t_squared(|t: f64| (0.3 * t).exp(), |t: f64| t * t)]
+#[case::t_and_log(|t: f64| t, |t: f64| (1.0 + t).ln())]
+fn dual_factor_slopes_build_across_loading_shapes(
+    #[case] worker_loading: fn(f64) -> f64,
+    #[case] firm_loading: fn(f64) -> f64,
+) {
     const N_YEARS: usize = 10;
     let n_obs = 50_000;
     let n_indiv = n_obs / N_YEARS;
@@ -345,49 +347,22 @@ fn dual_factor_slopes_build_across_loading_shapes() {
     let firm: Vec<u32> = (0..n_obs).map(|i| (i % n_firm) as u32).collect();
     let t: Vec<f64> = year.iter().map(|&y| y as f64).collect();
 
-    for Loadings {
-        what,
-        worker_loading,
-        firm_loading,
-    } in [
-        Loadings {
-            what: "t / t^2",
-            worker_loading: |t| t,
-            firm_loading: |t| t * t,
-        },
-        Loadings {
-            what: "t^2 / t",
-            worker_loading: |t| t * t,
-            firm_loading: |t| t,
-        },
-        Loadings {
-            what: "exp / t^2",
-            worker_loading: |t| (0.3 * t).exp(),
-            firm_loading: |t| t * t,
-        },
-        Loadings {
-            what: "t / log",
-            worker_loading: |t| t,
-            firm_loading: |t| (1.0 + t).ln(),
-        },
-    ] {
-        let z_worker: Vec<f64> = t.iter().map(|&t| worker_loading(t)).collect();
-        let z_firm: Vec<f64> = t.iter().map(|&t| firm_loading(t)).collect();
-        let y: Vec<f64> = (0..n_obs)
-            .map(|i| {
-                (worker[i] as f64 * 0.017).sin() + 0.4 * z_worker[i] - 0.2 * z_firm[i]
-                    + (i as f64 * 0.31).cos() * 0.1
-            })
-            .collect();
-        let effects = vec![
-            Effect::new(&worker, true, [&z_worker[..]]).expect("worker slope"),
-            Effect::new(&year, true, []).expect("year effect"),
-            Effect::new(&firm, true, [&z_firm[..]]).expect("firm slope"),
-        ];
-        let r = Solver::new(effects, None, PreconditionerConfig::default())
-            .unwrap_or_else(|e| panic!("{what}: build failed: {e}"))
-            .solve(&y, &LsmrOptions::default())
-            .unwrap_or_else(|e| panic!("{what}: solve failed: {e}"));
-        assert!(r.converged, "{what}: did not converge");
-    }
+    let z_worker: Vec<f64> = t.iter().map(|&t| worker_loading(t)).collect();
+    let z_firm: Vec<f64> = t.iter().map(|&t| firm_loading(t)).collect();
+    let y: Vec<f64> = (0..n_obs)
+        .map(|i| {
+            (worker[i] as f64 * 0.017).sin() + 0.4 * z_worker[i] - 0.2 * z_firm[i]
+                + (i as f64 * 0.31).cos() * 0.1
+        })
+        .collect();
+    let effects = vec![
+        Effect::new(&worker, true, [&z_worker[..]]).expect("worker slope"),
+        Effect::new(&year, true, []).expect("year effect"),
+        Effect::new(&firm, true, [&z_firm[..]]).expect("firm slope"),
+    ];
+    let r = Solver::new(effects, None, PreconditionerConfig::default())
+        .expect("build")
+        .solve(&y, &LsmrOptions::default())
+        .expect("solve");
+    assert!(r.converged);
 }

--- a/crates/within/tests/solver.rs
+++ b/crates/within/tests/solver.rs
@@ -1,4 +1,5 @@
 use ndarray::array;
+use rstest::rstest;
 use within::{
     solve, ApproxCholConfig, ApproxSchurConfig, Effect, LocalSolverConfig, LsmrOptions,
     Preconditioner, PreconditionerConfig, ReductionStrategy, ScalingConfig, ScalingFailure,
@@ -297,9 +298,11 @@ fn test_solver_accepts_prebuilt_design() {
 /// is applied to every frame by `Design::from_frame`, so the oracle is built
 /// via `from_frame_unsorted`, the explicit caller-order escape hatch. Results
 /// agree within solver tolerance, not bitwise: the paths sum in different
-/// row orders.
-#[test]
-fn test_internal_locality_sort_is_transparent() {
+/// row orders. The weighted run also exercises the weights-permutation path.
+#[rstest]
+#[case::unweighted(false)]
+#[case::weighted(true)]
+fn test_internal_locality_sort_is_transparent(#[case] weighted: bool) {
     use within::observation::ObservationFrame;
     use within::Design;
 
@@ -310,7 +313,11 @@ fn test_internal_locality_sort_is_transparent() {
     let y: Vec<f64> = (0..n_obs)
         .map(|i| (i as f64 * 1.3 - 2.0).sin() + 0.5)
         .collect();
-    let w: Vec<f64> = (0..n_obs).map(|i| 0.5 + 0.1 * i as f64).collect();
+    let weights = weighted.then(|| {
+        (0..n_obs)
+            .map(|i| 0.5 + 0.1 * i as f64)
+            .collect::<Vec<f64>>()
+    });
     let params = default_params();
     let precond = additive_precond();
 
@@ -326,13 +333,10 @@ fn test_internal_locality_sort_is_transparent() {
         Solver::new(design, weights, &precond).expect("oracle solver")
     };
 
-    // The weighted run also exercises the weights-permutation path.
-    for weights in [None, Some(w)] {
-        let oracle = make_oracle(weights.clone())
-            .solve(&y, &params)
-            .expect("oracle");
-        let sorted = make_solver(weights).solve(&y, &params).expect("sorted");
-        common::assert_solutions_close(&sorted.x, &oracle.x, 1e-7);
-        common::assert_solutions_close(&sorted.demeaned, &oracle.demeaned, 1e-7);
-    }
+    let oracle = make_oracle(weights.clone())
+        .solve(&y, &params)
+        .expect("oracle");
+    let sorted = make_solver(weights).solve(&y, &params).expect("sorted");
+    common::assert_solutions_close(&sorted.x, &oracle.x, 1e-7);
+    common::assert_solutions_close(&sorted.demeaned, &oracle.demeaned, 1e-7);
 }


### PR DESCRIPTION
Closes #313.

24 case-array loops across 13 test files become `rstest` cases, each a named, filterable test. Loops that walk expected values inside one scenario stay loops (staleness sequences, matrix assembly, per-slot checks in `slopes.rs`, `slopes_routing.rs`, `tests/solver.rs` batch columns, `metamorphic.rs`).

`rstest` 0.26.1 enters as a workspace dev-dependency (`default-features = false`), the same declaration #312 carries. No behaviour change; assertions are unchanged.