### PR TITLE
Make PreparedDesign own weights

### DIFF
--- a/crates/within/src/domain.rs
+++ b/crates/within/src/domain.rs
@@ -294,27 +294,6 @@ impl<'a> Design<'a> {
         }
     }
 
-    /// Validate that an optional weight slice matches this design's observation count.
-    pub(crate) fn validate_weights(&self, weights: Option<&[f64]>) -> Result<(), BuildError> {
-        if let Some(w) = weights {
-            if w.len() != self.n_obs {
-                return Err(BuildError::WeightCountMismatch {
-                    expected: self.n_obs,
-                    got: w.len(),
-                });
-            }
-            // `wi >= 0.0` already rejects NaN; `is_finite` additionally rejects `+∞`.
-            if let Some((index, &value)) = w
-                .iter()
-                .enumerate()
-                .find(|&(_, &wi)| !(wi >= 0.0 && wi.is_finite()))
-            {
-                return Err(BuildError::InvalidWeight { index, value });
-            }
-        }
-        Ok(())
-    }
-
     /// Caller order → internal order: `out[k] = v[obs_perm[k]]`; borrows when unpermuted.
     pub(crate) fn permute_obs_in<'v>(&self, v: &'v [f64]) -> Cow<'v, [f64]> {
         debug_assert_eq!(v.len(), self.n_obs);
@@ -435,34 +414,6 @@ mod tests {
         assert!(matches!(
             err,
             BuildError::DofSpaceExceedsU32 { n_dofs } if n_dofs == u32::MAX as usize + 1
-        ));
-    }
-
-    #[test]
-    fn validate_weights_checks_count_and_finiteness() {
-        let design = Design::from_frame(frame(vec![vec![0, 0, 0, 0, 0]], vec![])).unwrap();
-        assert!(design.validate_weights(None).is_ok());
-        assert!(design
-            .validate_weights(Some(&[1.0, 2.0, 3.0, 4.0, 5.0]))
-            .is_ok());
-        // Zero weights are valid (an excluded observation).
-        assert!(design
-            .validate_weights(Some(&[0.0, 1.0, 2.0, 3.0, 4.0]))
-            .is_ok());
-        // Length mismatch.
-        assert!(design.validate_weights(Some(&[1.0, 2.0])).is_err());
-        // Negative / non-finite weights are rejected with the offending index.
-        assert!(matches!(
-            design.validate_weights(Some(&[1.0, -2.0, 3.0, 4.0, 5.0])),
-            Err(BuildError::InvalidWeight { index: 1, .. })
-        ));
-        assert!(matches!(
-            design.validate_weights(Some(&[1.0, 2.0, f64::NAN, 4.0, 5.0])),
-            Err(BuildError::InvalidWeight { index: 2, .. })
-        ));
-        assert!(matches!(
-            design.validate_weights(Some(&[1.0, 2.0, 3.0, f64::INFINITY, 5.0])),
-            Err(BuildError::InvalidWeight { index: 3, .. })
         ));
     }
 

--- a/crates/within/src/domain/collinearity.rs
+++ b/crates/within/src/domain/collinearity.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 
 use rayon::prelude::*;
 
-use super::{row_weight, Design, PreparedDesign, TermMeta};
+use super::{Design, PreparedDesign, TermMeta};
 use crate::channel::Channel;
 use crate::BuildWarning;
 
@@ -18,10 +18,7 @@ const TABLE_BUDGET_BYTES: usize = 64 << 20;
 /// Rows one residual task claims; small enough that work stealing balances the tail.
 const ROWS_PER_TASK: usize = 1 << 16;
 
-pub(crate) fn detect_collinear_slopes(
-    prepared: &PreparedDesign<'_>,
-    sqrt_weights: Option<&[f64]>,
-) -> Vec<BuildWarning> {
+pub(crate) fn detect_collinear_slopes(prepared: &PreparedDesign<'_>) -> Vec<BuildWarning> {
     let design = &prepared.design;
     if design.n_factors() < 2 || !design.terms.iter().any(TermMeta::has_slopes) {
         return Vec::new();
@@ -31,7 +28,7 @@ pub(crate) fn detect_collinear_slopes(
         .into_par_iter()
         .flat_map_iter(move |term| {
             let targets = screened_covariates(design, term);
-            residual_shares(prepared, sqrt_weights, term, &targets, budget)
+            residual_shares(prepared, term, &targets, budget)
                 .into_iter()
                 .zip(targets)
                 .filter(|&(share, _)| share <= COLLINEARITY_TOL)
@@ -58,7 +55,6 @@ fn screened_covariates(design: &Design<'_>, term: usize) -> Vec<(Channel, u32)> 
 /// Two passes, so the share resolves below the `1e-16` a subtraction floors at.
 fn residual_shares(
     prepared: &PreparedDesign<'_>,
-    sqrt_weights: Option<&[f64]>,
     term: usize,
     targets: &[(Channel, u32)],
     budget: usize,
@@ -83,8 +79,8 @@ fn residual_shares(
     let n_levels = meta.n_levels;
     let plan = ScreenPlan::new(budget, n_levels, stride);
     let screen = Screen {
+        prepared,
         levels,
-        sqrt_weights,
         us,
         columns,
         intercept,
@@ -131,8 +127,8 @@ fn residual_shares(
 }
 
 struct Screen<'a> {
+    prepared: &'a PreparedDesign<'a>,
     levels: &'a [u32],
-    sqrt_weights: Option<&'a [f64]>,
     /// The term's slope columns in the solve basis.
     us: Vec<&'a [f64]>,
     columns: Vec<&'a [f64]>,
@@ -151,7 +147,7 @@ impl Screen<'_> {
     ) -> impl Iterator<Item = (usize, f64, usize)> + '_ {
         rows.filter_map(move |i| {
             let obs = self.order.obs(i);
-            let w = row_weight(self.sqrt_weights, obs);
+            let w = self.prepared.row_weight(obs);
             (w > 0.0).then(|| (obs, w, self.levels[obs] as usize - first))
         })
     }

--- a/crates/within/src/domain/collinearity/tests.rs
+++ b/crates/within/src/domain/collinearity/tests.rs
@@ -7,8 +7,8 @@ use crate::Effect;
 const FULL_TABLE: usize = 1 << 24;
 
 fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usize)> {
-    let prepared = PreparedDesign::new(design.clone(), weights);
-    detect_collinear_slopes(&prepared, weights)
+    let prepared = PreparedDesign::new(design.clone(), weights).expect("valid weights");
+    detect_collinear_slopes(&prepared)
         .into_iter()
         .map(|w| match w {
             BuildWarning::CollinearSlopeCovariate { slope, term, .. } => (slope, term),
@@ -21,7 +21,7 @@ fn warn_pairs(design: &Design<'_>, weights: Option<&[f64]>) -> Vec<(Channel, usi
 fn shares(design: &Design<'_>, term: usize, budget: usize) -> Vec<f64> {
     let prepared = PreparedDesign::unweighted_for_test(design.clone());
     let targets = screened_covariates(design, term);
-    residual_shares(&prepared, None, term, &targets, budget)
+    residual_shares(&prepared, term, &targets, budget)
 }
 
 fn two_factor_levels(n: usize) -> (Vec<u32>, Vec<u32>) {
@@ -162,8 +162,7 @@ fn zero_weight_rows_are_excluded_from_the_screen() {
         Effect::new(&b, true, [&spoiled[..]]).unwrap(),
     ])
     .unwrap();
-    // The screen reads frame order, so caller weights go through the locality permutation.
-    let weights = design.permute_obs_in(&weights).into_owned();
+    // PreparedDesign applies the locality permutation to caller-order weights.
     assert!(!warn_pairs(&design, Some(&weights)).is_empty());
     assert_eq!(warn_pairs(&design, None), Vec::new());
 }

--- a/crates/within/src/domain/cross_tab.rs
+++ b/crates/within/src/domain/cross_tab.rs
@@ -203,7 +203,6 @@ impl CrossTab {
     /// Reuses pre-computed active flags instead of rescanning; diagonals come back separately.
     pub(crate) fn build_for_pair_with_active(
         prepared: &PreparedDesign<'_>,
-        sqrt_weights: Option<&[f64]>,
         pair: ChannelPair,
         all_active: &[Vec<bool>],
     ) -> Option<(Self, BlockDiagonals, Vec<u32>)> {
@@ -215,7 +214,7 @@ impl CrossTab {
             design.terms[pair.cols.term].column_base(pair.cols.column),
         )?;
 
-        let (c, row_diag, col_diag) = accumulate_cross_block(prepared, sqrt_weights, pair, &active);
+        let (c, row_diag, col_diag) = accumulate_cross_block(prepared, pair, &active);
         let cross_tab = CrossTab::eager(c);
         let diagonals = BlockDiagonals {
             rows: row_diag,

--- a/crates/within/src/domain/cross_tab/accumulate.rs
+++ b/crates/within/src/domain/cross_tab/accumulate.rs
@@ -85,11 +85,11 @@ impl<Lq: Loading, Lr: Loading> PairColumns<'_, Lq, Lr> {
 /// Accumulate into `C` plus diagonals, dispatching dense or sparse by peak transient memory.
 pub(super) fn accumulate_cross_block(
     prepared: &PreparedDesign<'_>,
-    sqrt_weights: Option<&[f64]>,
     pair: ChannelPair,
     active: &ActiveLevels,
 ) -> (CsrBlock, Vec<f64>, Vec<f64>) {
     let design = &prepared.design;
+    let sqrt_weights = prepared.sqrt_weights();
     // Dispatching on cell count alone would pick sparse where it uses MORE memory.
     let table_size = active.n_rows.saturating_mul(active.n_cols);
     let dense_cost = table_size.saturating_mul(8);

--- a/crates/within/src/domain/cross_tab/tests.rs
+++ b/crates/within/src/domain/cross_tab/tests.rs
@@ -43,7 +43,7 @@ fn test_cross_tab_sparse_accumulation_path() {
     let design_sparse = design_of(vec![fa.clone(), fb.clone()]);
     let active_sparse = find_all_active_levels(&design_sparse.design);
     let (ct_sparse, diag_sparse, _) =
-        CrossTab::build_for_pair_with_active(&design_sparse, None, INTERCEPT_PAIR, &active_sparse)
+        CrossTab::build_for_pair_with_active(&design_sparse, INTERCEPT_PAIR, &active_sparse)
             .expect("sparse cross tab should build");
 
     // Dense reference: collapse levels so n_rows * n_cols <= 5M.
@@ -52,7 +52,7 @@ fn test_cross_tab_sparse_accumulation_path() {
     let design_dense = design_of(vec![fa_small.clone(), fb_small.clone()]);
     let active_dense = find_all_active_levels(&design_dense.design);
     let (_ct_dense, diag_dense, _) =
-        CrossTab::build_for_pair_with_active(&design_dense, None, INTERCEPT_PAIR, &active_dense)
+        CrossTab::build_for_pair_with_active(&design_dense, INTERCEPT_PAIR, &active_dense)
             .expect("dense cross tab should build");
 
     // Each observation appears exactly once in its row/col bucket.
@@ -121,7 +121,7 @@ fn test_extract_component_two_components() {
     let design = design_of(vec![fa, fb]);
     let all_active = find_all_active_levels(&design.design);
     let (ct, parent_diag, _) =
-        CrossTab::build_for_pair_with_active(&design, None, INTERCEPT_PAIR, &all_active)
+        CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
     let components = ct.bipartite_connected_components();
@@ -234,7 +234,7 @@ proptest! {
 
         let design = design_of(vec![fa, fb]);
         let all_active = find_all_active_levels(&design.design);
-        let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, None, INTERCEPT_PAIR, &all_active)
+        let (ct, _, _) = CrossTab::build_for_pair_with_active(&design, INTERCEPT_PAIR, &all_active)
             .expect("cross tab should build");
 
         let components = ct.bipartite_connected_components();

--- a/crates/within/src/domain/factor_pairs.rs
+++ b/crates/within/src/domain/factor_pairs.rs
@@ -35,7 +35,6 @@ pub(crate) struct LocalDomain {
 /// Same-factor channel pairs are exactly orthogonal after whitening, so never enumerated.
 pub(crate) fn build_local_domains(
     prepared: &PreparedDesign<'_>,
-    sqrt_weights: Option<&[f64]>,
     config: &LocalSolverConfig,
 ) -> Result<(Vec<LocalDomain>, Vec<BuildWarning>), BuildError> {
     use rayon::prelude::*;
@@ -67,7 +66,7 @@ pub(crate) fn build_local_domains(
         .par_iter()
         .map(|&pair| {
             let Some((full_ct, full_diag, l2g)) =
-                CrossTab::build_for_pair_with_active(prepared, sqrt_weights, pair, &all_active)
+                CrossTab::build_for_pair_with_active(prepared, pair, &all_active)
             else {
                 return Ok((Vec::new(), Vec::new()));
             };
@@ -221,8 +220,8 @@ mod tests {
     #[test]
     fn test_full_cover_domain_count() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
+        let (domain_pairs, _) =
+            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
         // 3 factor pairs; each pair may produce multiple components
         assert!(domain_pairs.len() >= 3);
     }
@@ -230,8 +229,8 @@ mod tests {
     #[test]
     fn test_partition_of_unity() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
+        let (domain_pairs, _) =
+            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
         let n_dofs = dm.design.n_dofs;
         // Two-sided PoU: squared weights must sum to 1 at every DOF.
         let mut weight_sq_sum = vec![0.0; n_dofs];
@@ -263,7 +262,7 @@ mod tests {
         .expect("valid slope design");
         let design = PreparedDesign::unweighted_for_test(design);
 
-        let (domain_pairs, _) = build_local_domains(&design, None, &LocalSolverConfig::default())
+        let (domain_pairs, _) = build_local_domains(&design, &LocalSolverConfig::default())
             .expect("slope domains build");
 
         for ld in &domain_pairs {
@@ -292,8 +291,8 @@ mod tests {
     #[test]
     fn test_domains_cover_all_dofs() {
         let dm = make_test_design();
-        let (domain_pairs, _) = build_local_domains(&dm, None, &LocalSolverConfig::default())
-            .expect("plain domains build");
+        let (domain_pairs, _) =
+            build_local_domains(&dm, &LocalSolverConfig::default()).expect("plain domains build");
         let mut covered = vec![false; dm.design.n_dofs];
         for ld in &domain_pairs {
             for &idx in ld.core.global_indices() {

--- a/crates/within/src/domain/prepared.rs
+++ b/crates/within/src/domain/prepared.rs
@@ -1,16 +1,38 @@
-use super::{Design, SlopeReparam};
+use super::{row_weight, Design, SlopeReparam};
+use crate::BuildError;
 
-/// A [`Design`] plus the whitened slope basis one weight vector determines.
+/// A [`Design`] plus all state one weight vector determines.
 pub(crate) struct PreparedDesign<'a> {
     pub(crate) design: Design<'a>,
+    /// `W^{1/2}` in the design's internal observation order; `None` is unweighted.
+    sqrt_weights: Option<Vec<f64>>,
     /// `None` for slope-free designs.
     pub(crate) reparam: Option<SlopeReparam>,
 }
 
 impl<'a> PreparedDesign<'a> {
-    pub(crate) fn new(design: Design<'a>, sqrt_weights: Option<&[f64]>) -> Self {
-        let reparam = SlopeReparam::build(&design, sqrt_weights);
-        Self { design, reparam }
+    pub(crate) fn new(design: Design<'a>, weights: Option<&[f64]>) -> Result<Self, BuildError> {
+        let sqrt_weights = weights
+            .map(|weights| prepare_sqrt_weights(&design, weights))
+            .transpose()?;
+        let reparam = SlopeReparam::build(&design, sqrt_weights.as_deref());
+        Ok(Self {
+            design,
+            sqrt_weights,
+            reparam,
+        })
+    }
+
+    /// `W^{1/2}` in internal observation order; `None` is unweighted.
+    #[inline]
+    pub(crate) fn sqrt_weights(&self) -> Option<&[f64]> {
+        self.sqrt_weights.as_deref()
+    }
+
+    /// The Gram weight of row `obs`: the operator applies `s`, so its normal matrix carries `s²`.
+    #[inline]
+    pub(crate) fn row_weight(&self, obs: usize) -> f64 {
+        row_weight(self.sqrt_weights(), obs)
     }
 
     /// Loading column `column` in the solve basis.
@@ -23,6 +45,29 @@ impl<'a> PreparedDesign<'a> {
     }
 }
 
+/// Validate caller-order weights, then return `√w` in the design's internal order.
+fn prepare_sqrt_weights(design: &Design<'_>, weights: &[f64]) -> Result<Vec<f64>, BuildError> {
+    if weights.len() != design.n_obs {
+        return Err(BuildError::WeightCountMismatch {
+            expected: design.n_obs,
+            got: weights.len(),
+        });
+    }
+    // `wi >= 0.0` already rejects NaN; `is_finite` additionally rejects `+∞`.
+    if let Some((index, &value)) = weights
+        .iter()
+        .enumerate()
+        .find(|&(_, &wi)| !(wi >= 0.0 && wi.is_finite()))
+    {
+        return Err(BuildError::InvalidWeight { index, value });
+    }
+    Ok(design
+        .permute_obs_in(weights)
+        .iter()
+        .map(|weight| weight.sqrt())
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -30,7 +75,7 @@ mod tests {
     impl<'a> PreparedDesign<'a> {
         /// Unweighted, whitened like a solver would.
         pub(crate) fn unweighted_for_test(design: Design<'a>) -> Self {
-            Self::new(design, None)
+            Self::new(design, None).expect("unweighted preparation cannot fail")
         }
     }
 
@@ -38,5 +83,49 @@ mod tests {
         pub(crate) fn from_levels_for_test(columns: Vec<Vec<u32>>) -> Self {
             Self::unweighted_for_test(Design::from_levels_for_test(columns))
         }
+    }
+
+    #[test]
+    fn owns_sqrt_weights_in_internal_observation_order() {
+        // Dominant factor [2,0,1,0] argsorts to caller positions [1,3,2,0].
+        let design = Design::from_levels_for_test(vec![vec![2, 0, 1, 0]]);
+        let prepared = PreparedDesign::new(design, Some(&[1.0, 4.0, 9.0, 16.0])).unwrap();
+
+        assert_eq!(prepared.sqrt_weights(), Some(&[2.0, 4.0, 3.0, 1.0][..]));
+        assert_eq!(
+            (0..4)
+                .map(|obs| prepared.row_weight(obs))
+                .collect::<Vec<_>>(),
+            [4.0, 16.0, 9.0, 1.0]
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_weights_before_permuting_them() {
+        let design = Design::from_levels_for_test(vec![vec![2, 0, 1, 0]]);
+
+        assert!(PreparedDesign::new(design.clone(), None).is_ok());
+        assert!(PreparedDesign::new(design.clone(), Some(&[1.0, 2.0, 3.0, 4.0])).is_ok());
+        // Zero weights are valid (an excluded observation).
+        assert!(PreparedDesign::new(design.clone(), Some(&[0.0, 1.0, 2.0, 3.0])).is_ok());
+        assert!(matches!(
+            PreparedDesign::new(design.clone(), Some(&[1.0, 2.0])),
+            Err(BuildError::WeightCountMismatch {
+                expected: 4,
+                got: 2
+            })
+        ));
+        assert!(matches!(
+            PreparedDesign::new(design.clone(), Some(&[1.0, -2.0, 3.0, 4.0])),
+            Err(BuildError::InvalidWeight { index: 1, .. })
+        ));
+        assert!(matches!(
+            PreparedDesign::new(design.clone(), Some(&[1.0, 2.0, f64::NAN, 4.0])),
+            Err(BuildError::InvalidWeight { index: 2, .. })
+        ));
+        assert!(matches!(
+            PreparedDesign::new(design, Some(&[1.0, 2.0, 3.0, f64::INFINITY])),
+            Err(BuildError::InvalidWeight { index: 3, .. })
+        ));
     }
 }

--- a/crates/within/src/operator/design.rs
+++ b/crates/within/src/operator/design.rs
@@ -22,7 +22,6 @@ const PAR_THRESHOLD: usize = 10_000;
 /// Design operator `D` or `W^{1/2} D`, whose normal equations `AᵀA = DᵀWD` recover the Gramian.
 pub(crate) struct DesignOperator<'a> {
     prepared: &'a PreparedDesign<'a>,
-    sqrt_weights: Option<&'a [f64]>,
     /// Sized once to the largest term's block, so it allocates per operator, not per iteration.
     scatter_scratch: Vec<AtomicF64>,
     /// Debug-only reentry sentinel: a concurrent `apply_adjoint` would race the scratch writes.
@@ -31,22 +30,11 @@ pub(crate) struct DesignOperator<'a> {
 }
 
 impl<'a> DesignOperator<'a> {
-    /// `sqrt_weights` must be pre-square-rooted and `design.n_obs` long.
-    pub(crate) fn new(prepared: &'a PreparedDesign<'a>, sqrt_weights: Option<&'a [f64]>) -> Self {
+    pub(crate) fn new(prepared: &'a PreparedDesign<'a>) -> Self {
         let design = &prepared.design;
-        if let Some(sw) = sqrt_weights {
-            assert_eq!(
-                sw.len(),
-                design.n_obs,
-                "sqrt-weights length {} does not match design.n_obs {}",
-                sw.len(),
-                design.n_obs
-            );
-        }
         let max_block = design.terms.iter().map(|t| t.n_dofs()).max().unwrap_or(0);
         Self {
             prepared,
-            sqrt_weights,
             scatter_scratch: (0..max_block).map(|_| AtomicF64::new(0.0)).collect(),
             #[cfg(debug_assertions)]
             adjoint_active: AtomicBool::new(false),
@@ -55,7 +43,7 @@ impl<'a> DesignOperator<'a> {
 
     /// Observation-space RHS `b = W^{1/2} y`; borrows unweighted, owns weighted.
     pub(crate) fn weighted_rhs<'y>(&self, y: &'y [f64]) -> Cow<'y, [f64]> {
-        match self.sqrt_weights {
+        match self.prepared.sqrt_weights() {
             None => Cow::Borrowed(y),
             Some(sw) => Cow::Owned(y.iter().zip(sw).map(|(&yi, &swi)| swi * yi).collect()),
         }
@@ -98,7 +86,7 @@ impl Operator for DesignOperator<'_> {
     fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), schwarz_precond::SolveError> {
         debug_assert_eq!(x.len(), self.prepared.design.n_dofs);
         debug_assert_eq!(y.len(), self.prepared.design.n_obs);
-        gather_apply(self.prepared, x, y, self.sqrt_weights);
+        gather_apply(self.prepared, x, y, self.prepared.sqrt_weights());
         Ok(())
     }
 
@@ -109,7 +97,7 @@ impl Operator for DesignOperator<'_> {
         debug_assert_eq!(y.len(), self.prepared.design.n_dofs);
         y.fill(0.0);
         // No lock needed: `solve_batch` builds one operator per RHS, so calls are sequential.
-        match self.sqrt_weights {
+        match self.prepared.sqrt_weights() {
             Some(sw) => scatter_apply(self.prepared, &self.scatter_scratch, y, &|i| sw[i] * x[i]),
             None => scatter_apply(self.prepared, &self.scatter_scratch, y, &|i| x[i]),
         }
@@ -131,7 +119,7 @@ mod reentry_guard_tests {
     #[should_panic(expected = "concurrently")]
     fn apply_adjoint_detects_in_flight_reentry() {
         let design = PreparedDesign::from_levels_for_test(vec![vec![0, 1, 0]]);
-        let op = DesignOperator::new(&design, None);
+        let op = DesignOperator::new(&design);
         // Simulate a sibling `apply_adjoint` already in flight on this operator.
         op.adjoint_active.store(true, Ordering::Release);
         op.apply_adjoint(

--- a/crates/within/src/operator/design/tests.rs
+++ b/crates/within/src/operator/design/tests.rs
@@ -13,7 +13,7 @@ mod design_tests {
     #[test]
     fn test_design_operator_dimensions() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
         assert_eq!(op.nrows(), 5);
         assert_eq!(op.ncols(), 7);
     }
@@ -21,7 +21,7 @@ mod design_tests {
     #[test]
     fn test_design_operator_adjoint() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
 
         let x = vec![1.0, -0.5, 2.0, 0.3, -1.0, 0.7, 1.5];
         let r = vec![0.1, 0.2, -0.3, 0.4, -0.5];
@@ -40,7 +40,7 @@ mod design_tests {
     #[test]
     fn test_apply_unweighted_values() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
         let x = vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 40.0];
         let mut y = vec![0.0; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
@@ -50,7 +50,7 @@ mod design_tests {
     #[test]
     fn test_apply_adjoint_unweighted_values() {
         let schema = make_test_design();
-        let op = DesignOperator::new(&schema, None);
+        let op = DesignOperator::new(&schema);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0; 7];
         op.apply_adjoint(&r, &mut x)
@@ -79,7 +79,7 @@ mod design_tests {
         let dm = make_large_design();
         let n_dofs = dm.design.n_dofs;
         let n_rows = dm.design.n_obs;
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
         let x: Vec<f64> = (0..n_dofs).map(|i| (i as f64 * 0.17 + 1.0).sin()).collect();
         let r: Vec<f64> = (0..n_rows).map(|i| (i as f64 * 0.23 + 2.0).cos()).collect();
@@ -117,7 +117,7 @@ mod design_tests {
             "dominant factor is sorted; no perm"
         );
 
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
         let x: Vec<f64> = (0..dm.design.n_dofs)
             .map(|i| (i as f64 * 0.17 + 1.0).sin())
             .collect();
@@ -144,7 +144,7 @@ mod design_tests {
     #[test]
     fn test_large_design_matvec_correctness() {
         let dm = make_large_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
         let mut ej = vec![0.0f64; dm.design.n_dofs];
         ej[0] = 1.0;
@@ -163,7 +163,7 @@ mod design_tests {
     #[test]
     fn test_large_design_apply_adjoint_correctness() {
         let dm = make_large_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
         let ones = vec![1.0f64; dm.design.n_obs];
         let mut x = vec![0.0f64; dm.design.n_dofs];
@@ -182,7 +182,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_design_adjoint_property() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
 
         let x: Vec<f64> = vec![1.0, 2.0, 3.0];
         let r: Vec<f64> = vec![0.5, 1.5, -0.5, 2.0, -1.0];
@@ -206,7 +206,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_values() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
         let x = vec![10.0, 20.0, 30.0];
         let mut y = vec![0.0f64; 5];
         op.apply(&x, &mut y).expect("apply succeeds");
@@ -216,7 +216,7 @@ mod design_tests {
     #[test]
     fn test_single_factor_apply_adjoint_values() {
         let dm = make_single_factor_design();
-        let op = DesignOperator::new(&dm, None);
+        let op = DesignOperator::new(&dm);
         let r = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let mut x = vec![0.0f64; 3];
         op.apply_adjoint(&r, &mut x)
@@ -280,14 +280,14 @@ mod design_tests {
             .collect();
 
         // Baseline: a fresh operator that has never applied before.
-        let fresh = DesignOperator::new(dm, None);
+        let fresh = DesignOperator::new(dm);
         let mut baseline = vec![0.0f64; dm.design.n_dofs];
         fresh
             .apply_adjoint(&r, &mut baseline)
             .expect("apply_adjoint succeeds");
 
         // The second apply on a dirtied operator must equal the fresh baseline.
-        let op = DesignOperator::new(dm, None);
+        let op = DesignOperator::new(dm);
         let mut warmup = vec![0.0f64; dm.design.n_dofs];
         op.apply_adjoint(&r, &mut warmup)
             .expect("apply_adjoint succeeds");
@@ -368,7 +368,7 @@ mod slope_design_tests {
             (0..design.design.n_dofs).all(|j| dense.iter().any(|row| row[j] != 0.0)),
             "whitening zeroed a column; the arm's addressing would go untested"
         );
-        let op = DesignOperator::new(&design, None);
+        let op = DesignOperator::new(&design);
 
         let x: Vec<f64> = (0..design.design.n_dofs)
             .map(|j| noise(7_000 + j))
@@ -413,9 +413,9 @@ mod slope_design_tests {
             Effect::new(&unsorted, true, [&z[1][..]]).unwrap(),
             Effect::new(&small, true, [&z[2][..], &z[3][..]]).unwrap(),
         ];
-        let design = PreparedDesign::unweighted_for_test(Design::new(effects).unwrap());
-        let sqrt_weights: Vec<f64> = (0..n).map(|i| (0.5 + noise(i).abs()).sqrt()).collect();
-        let op = DesignOperator::new(&design, Some(&sqrt_weights));
+        let weights: Vec<f64> = (0..n).map(|i| 0.5 + noise(i).abs()).collect();
+        let design = PreparedDesign::new(Design::new(effects).unwrap(), Some(&weights)).unwrap();
+        let op = DesignOperator::new(&design);
 
         let x: Vec<f64> = (0..design.design.n_dofs)
             .map(|j| noise(13 * j + 1))
@@ -445,9 +445,8 @@ mod weighted_adjoint_proptests {
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(10))]
 
-        /// The adjoint property must hold for random weighted designs:
-        /// <D·x, W·r> == <x, D^T·W·r>, with D^T·W·r computed via
-        /// DesignOperator::apply_adjoint(W^{1/2} r) = D^T W^{1/2} (W^{1/2} r) = D^T W r.
+        /// The weighted normal-equation identity must hold for random designs:
+        /// <W^{1/2}D·x, W^{1/2}r> == <x, D^T W·r>.
         #[test]
         fn prop_weighted_adjoint_property(
             n_obs in 20usize..=200,
@@ -466,7 +465,8 @@ mod weighted_adjoint_proptests {
                 .map(|i| 0.5 + (i as f64 * 0.13 + seed as f64 * 0.41).sin().abs())
                 .collect();
 
-            let dm = PreparedDesign::from_levels_for_test(vec![fa, fb]);
+            let design = crate::domain::Design::from_levels_for_test(vec![fa, fb]);
+            let dm = PreparedDesign::new(design, Some(&weights)).unwrap();
 
             let n_dofs = dm.design.n_dofs;
             let n_rows = dm.design.n_obs;
@@ -478,26 +478,19 @@ mod weighted_adjoint_proptests {
                 .map(|i| (i as f64 * 0.29 + seed as f64 * 0.07).cos())
                 .collect();
 
-            let op_unweighted = DesignOperator::new(&dm, None);
+            let op = DesignOperator::new(&dm);
             let mut dx = vec![0.0f64; n_rows];
-            op_unweighted.apply(&x, &mut dx).unwrap();
-            let lhs: f64 = dx
-                .iter()
-                .zip(r.iter())
-                .enumerate()
-                .map(|(i, (dxi, ri))| weights[i] * dxi * ri)
-                .sum();
+            op.apply(&x, &mut dx).unwrap();
+            let weighted_r = op.weighted_rhs(&r);
+            let lhs: f64 = dx.iter().zip(&*weighted_r).map(|(dxi, ri)| dxi * ri).sum();
 
-            let sqrt_weights: Vec<f64> = weights.iter().map(|w| w.sqrt()).collect();
-            let op_weighted = DesignOperator::new(&dm, Some(&sqrt_weights));
-            let wr = op_weighted.weighted_rhs(&r);
             let mut wdtr = vec![0.0f64; n_dofs];
-            op_weighted.apply_adjoint(&wr, &mut wdtr).unwrap();
+            op.apply_adjoint(&weighted_r, &mut wdtr).unwrap();
             let rhs: f64 = x.iter().zip(wdtr.iter()).map(|(xi, wi)| xi * wi).sum();
 
             prop_assert!(
                 (lhs - rhs).abs() < 1e-8,
-                "<D·x, W·r>={lhs} != <x, D^T·W·r>={rhs}"
+                "<W^1/2 D·x, W^1/2 r>={lhs} != <x, D^T W·r>={rhs}"
             );
         }
     }

--- a/crates/within/src/operator/schwarz.rs
+++ b/crates/within/src/operator/schwarz.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use crate::block_elim::BlockElimSolver;
 use crate::config::{LocalSolverConfig, PreconditionerConfig};
 use crate::domain::Loading;
-use crate::domain::{row_weight, LocalDomain, PreparedDesign};
+use crate::domain::{LocalDomain, PreparedDesign};
 use crate::{BuildError, BuildWarning};
 
 #[cfg(test)]
@@ -210,16 +210,13 @@ impl Operator for Preconditioner {
     }
 }
 
-fn build_diagonal(
-    prepared: &PreparedDesign<'_>,
-    sqrt_weights: Option<&[f64]>,
-) -> Result<DiagonalPreconditioner, BuildError> {
+fn build_diagonal(prepared: &PreparedDesign<'_>) -> Result<DiagonalPreconditioner, BuildError> {
     let design = &prepared.design;
     let mut diag = vec![0.0; design.n_dofs];
 
     for (factor_idx, term) in design.terms.iter().enumerate() {
         let levels = design.frame.level_column(factor_idx);
-        let w = |uid: usize| row_weight(sqrt_weights, uid);
+        let w = |uid: usize| prepared.row_weight(uid);
         for (column, loading) in term.columns.iter().enumerate() {
             let base = term.column_base(column);
             let slice = &mut diag[base..base + term.n_levels];
@@ -257,10 +254,9 @@ fn build_diagonal(
     })
 }
 
-/// Build a [`Preconditioner`] for a prepared design and optional `√w`, plus any warnings.
+/// Build a [`Preconditioner`] for a prepared design, plus any warnings.
 pub(crate) fn build_preconditioner(
     prepared: &PreparedDesign<'_>,
-    sqrt_weights: Option<&[f64]>,
     config: Option<&PreconditionerConfig>,
 ) -> Result<(Option<Preconditioner>, Vec<BuildWarning>), BuildError> {
     use crate::domain::build_local_domains;
@@ -279,7 +275,7 @@ pub(crate) fn build_preconditioner(
             local_solver,
             reduction,
         } => {
-            let (domains, warnings) = build_local_domains(prepared, sqrt_weights, local_solver)?;
+            let (domains, warnings) = build_local_domains(prepared, local_solver)?;
             if domains.is_empty() {
                 // No factor-pair subdomains means no useful Schwarz; fall back to plain LSMR.
                 return Ok((None, warnings));
@@ -289,7 +285,7 @@ pub(crate) fn build_preconditioner(
             (Variant::Additive(preconditioner), warnings)
         }
         PreconditionerConfig::Diagonal => {
-            let preconditioner = build_diagonal(prepared, sqrt_weights)?;
+            let preconditioner = build_diagonal(prepared)?;
             (Variant::Diagonal(preconditioner), Vec::new())
         }
     };

--- a/crates/within/src/operator/schwarz/tests.rs
+++ b/crates/within/src/operator/schwarz/tests.rs
@@ -20,8 +20,8 @@ const BLOCK_ELIM_NESTED_RAYON_CHILD_ENV: &str = "WITHIN_TEST_BLOCK_ELIM_NESTED_R
 fn make_test_data() -> (PreparedDesign<'static>, Vec<LocalDomain>) {
     let design =
         PreparedDesign::from_levels_for_test(vec![vec![0, 1, 0, 1, 2], vec![0, 0, 1, 1, 0]]);
-    let (domain_pairs, _) = build_local_domains(&design, None, &LocalSolverConfig::default())
-        .expect("plain domains build");
+    let (domain_pairs, _) =
+        build_local_domains(&design, &LocalSolverConfig::default()).expect("plain domains build");
     (design, domain_pairs)
 }
 

--- a/crates/within/src/solver.rs
+++ b/crates/within/src/solver.rs
@@ -298,8 +298,6 @@ impl BatchSolveResult {
 /// Python boundary — uses owned columns.
 pub struct Solver<'a> {
     prepared: PreparedDesign<'a>,
-    /// `W^{1/2}` in the design's internal observation order; the only form of the weights kept.
-    sqrt_weights: Option<Vec<f64>>,
     preconditioner: Option<Preconditioner>,
     warnings: Vec<BuildWarning>,
 }
@@ -309,7 +307,7 @@ impl std::fmt::Debug for Solver<'_> {
         f.debug_struct("Solver")
             .field("n_obs", &self.prepared.design.n_obs)
             .field("n_dofs", &self.prepared.design.n_dofs)
-            .field("has_weights", &self.sqrt_weights.is_some())
+            .field("has_weights", &self.prepared.sqrt_weights().is_some())
             .field("has_preconditioner", &self.preconditioner.is_some())
             .finish()
     }
@@ -342,7 +340,9 @@ impl<'a> Solver<'a> {
     /// - `PreconditionerConfig::Diagonal` — use diagonal/Jacobi preconditioning
     /// - [`Preconditioner`] or `&Preconditioner` — reuse a previously built one
     ///
-    /// `weights` is `None` for unweighted; the solver keeps only `√w` in its own order.
+    /// `weights` is `None` for an unweighted solve. Supplied weights are validated
+    /// in caller observation order, then retained internally only as `√w` in the
+    /// design's internal observation order.
     ///
     /// LSMR tuning ([`LsmrOptions`]) is supplied per call to [`Solver::solve`] /
     /// [`Solver::solve_batch`], not at construction; preconditioner factorization
@@ -352,22 +352,14 @@ impl<'a> Solver<'a> {
         weights: Option<&[f64]>,
         preconditioner: impl Into<PreconditionerInput>,
     ) -> Result<Self, BuildError> {
-        let design = design.into_design()?;
-        design.validate_weights(weights)?;
-        let sqrt_weights: Option<Vec<f64>> = weights.map(|w| {
-            let w = design.permute_obs_in(w);
-            w.iter().map(|wi| wi.sqrt()).collect()
-        });
-        let sw = sqrt_weights.as_deref();
-
         // Whiten the slope columns (if any) before the preconditioner reads them.
-        let prepared = PreparedDesign::new(design, sw);
-        let mut warnings = detect_collinear_slopes(&prepared, sw);
+        let prepared = PreparedDesign::new(design.into_design()?, weights)?;
+        let mut warnings = detect_collinear_slopes(&prepared);
         let n_dofs = prepared.design.n_dofs;
 
         let (preconditioner, build_warnings) = match preconditioner.into() {
-            PreconditionerInput::Default => build_preconditioner(&prepared, sw, None)?,
-            PreconditionerInput::Config(c) => build_preconditioner(&prepared, sw, Some(&c))?,
+            PreconditionerInput::Default => build_preconditioner(&prepared, None)?,
+            PreconditionerInput::Config(c) => build_preconditioner(&prepared, Some(&c))?,
             PreconditionerInput::Prebuilt(p) => {
                 if p.nrows() != n_dofs || p.ncols() != n_dofs {
                     return Err(BuildError::PreconditionerDimensionMismatch {
@@ -384,7 +376,6 @@ impl<'a> Solver<'a> {
 
         Ok(Self {
             prepared,
-            sqrt_weights,
             preconditioner,
             warnings,
         })
@@ -425,7 +416,7 @@ impl<'a> Solver<'a> {
         let y_internal = self.prepared.design.permute_obs_in(y);
         let y: &[f64] = &y_internal;
 
-        let rect_op = DesignOperator::new(&self.prepared, self.sqrt_weights.as_deref());
+        let rect_op = DesignOperator::new(&self.prepared);
         let b = rect_op.weighted_rhs(y);
         let b: &[f64] = &b;
 

--- a/crates/within/src/solver/tests.rs
+++ b/crates/within/src/solver/tests.rs
@@ -35,7 +35,7 @@ fn positive_slope_only_pair_grounds_beyond_dense_threshold() {
     ];
     let prepared = PreparedDesign::unweighted_for_test(Design::new(effects).expect("design"));
     let (domains, warnings) =
-        build_local_domains(&prepared, None, &LocalSolverConfig::default()).expect("domains");
+        build_local_domains(&prepared, &LocalSolverConfig::default()).expect("domains");
     assert!(
         domains.iter().any(|ld| {
             let ct = &ld.component.matrix.cross_tab;


### PR DESCRIPTION
PreparedDesign now validates, permutes, and owns sqrt weights alongside the weight-derived slope reparameterization. Operators, screening, and preconditioner construction consume that single source so mismatched weight state is not representable.